### PR TITLE
feat: clipboard behavior for curl command [WIP]

### DIFF
--- a/src/features/LandingPage/QuickStartSection/index.tsx
+++ b/src/features/LandingPage/QuickStartSection/index.tsx
@@ -5,6 +5,18 @@ import QuickStartImg from '@static/img/Terminal.png';
 
 import styles from './QuickStartSection.module.css';
 
+const copyCurlCommand = () => {
+  const cmd = 'curl -O https://openfga.com/docker-compose.yml && docker-compose up -d';
+
+  navigator.clipboard.writeText(cmd);
+
+  document.getElementsByClassName(styles.copyQuickstart)[0].setAttribute('copied', 'true');
+
+  setTimeout(() => {
+    document.getElementsByClassName(styles.copyQuickstart)[0].setAttribute('copied', 'false');
+  }, 5000);
+};
+
 const QuickStartSection = () => {
   return (
     <Section className={styles.section} id="quick-start">
@@ -25,6 +37,22 @@ const QuickStartSection = () => {
         </div>
         <div className={styles.graphic}>
           <img src={QuickStartImg} alt="Terminal showing how awesome OpenFGA is." />
+          <button className={styles.copyQuickstart} onClick={() => copyCurlCommand()}>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="#fff"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+              <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+            </svg>
+          </button>
         </div>
       </div>
     </Section>

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -5,6 +5,87 @@
   margin-bottom: 1.5rem;
 }
 
+/* Quick Start */
+
+.quickstartSection {
+  background-color: var(--ofga-neutral-black);
+  padding: 9.25rem 0 10.25rem;
+  color: var(--ofga-neutral-base);
+}
+
+.quickstartContainer {
+  display: flex;
+  justify-content: space-between;
+}
+
+.quickstartContent {
+  flex: 0 0 20.5rem;
+}
+
+.quickstartContent p {
+  margin-bottom: 2rem;
+}
+
+.quickstartContent p:last-child {
+  margin-bottom: 0rem;
+}
+
+.quickstartHighlight {
+  font-weight: 500;
+  font-size: 1.75rem;
+  line-height: 1.28;
+}
+
+.quickstartGraphic {
+  flex: 1;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.quickstartGraphic img {
+  height: 100%;
+  object-fit: cover;
+}
+
+.copyQuickstart {
+  background: none;
+  border: 0;
+  cursor: pointer;
+  height: 48px;
+  left: -80px;
+  padding: 4px;
+  position: relative;
+  top: 68px;
+  width: 48px;
+  display: flex;
+}
+
+.copyQuickstart[copied='true'] svg,
+.copyQuickstart[copied='true']:hover svg {
+  stroke: transparent;
+}
+
+.copyQuickstart[copied='true']::after {
+  color: var(--ofga-green-neon);
+  content: 'copied ✓';
+  font-family: courier;
+  font-size: 16px;
+  line-height: 30px;
+  margin-left: -120px;
+  text-align: right;
+  width: 120px;
+}
+
+.copyQuickstart svg {
+  stroke: var(--ofga-green-neon);
+  transition: all 0.2s ease-in-out;
+}
+
+.copyQuickstart:hover svg {
+  stroke: var(--ofga-neutral-white);
+  transition: all 0.2s ease-in-out;
+}
+
 /* Features */
 
 /* Resources */


### PR DESCRIPTION
> As a user, I want a way to try the docker-compose quickstart command without manually reading and typing it out into my terminal.

This PR introduces a simple copy-to-clipboard command.

![copy](https://user-images.githubusercontent.com/6372810/172173642-6073888d-dc16-4fd2-b087-3f81087bc8ce.gif)

The message uses a simple timeout - this is pretty basic. I'm just trying to save @matldupont time on styling up an MVP version.

Acceptance Criteria:
- [ ]  Add an SVG <title> element for screenreaders, if we're sticking with the SVG strategy
- [ ]  Refactor button into component (at @matldupont 's discretion)
- [ ]  Finalize url for docker-compose file and update

-----

