### PR TITLE
fix: adjusting :visited styles for TOC links

### DIFF
--- a/src/features/LandingPage/QuickStartSection/QuickStartSection.module.css
+++ b/src/features/LandingPage/QuickStartSection/QuickStartSection.module.css
@@ -66,6 +66,6 @@
   object-fit: cover;
 }
 
-a:hover {
+.section a:hover {
   background-color: var(--true-black);
 }

--- a/static/css/openfga.css
+++ b/static/css/openfga.css
@@ -35,10 +35,10 @@
     sans-serif, ‘Apple Color Emoji’, ‘Segoe UI Emoji’, ‘Segoe UI Symbol’;
 
   --ofga-font-highlight: 'Space Grotesk', sans-serif;
-  
+
   /* avoid these except for special cases */
   --true-black: #000;
-  --true-white: #FFF;
+  --true-white: #fff;
 }
 
 html {
@@ -281,10 +281,15 @@ a.menu__link:hover {
 
 .table-of-contents__link {
   font-weight: 500;
+}
+
+.table-of-contents__link,
+.table-of-contents__link:visited:not(.table-of-contents__link--active) {
   color: var(--ofga-neutral-base);
 }
 
-.table-of-contents__link--active {
+a.table-of-contents__link:active,
+a.table-of-contents__link--active {
   color: var(--ofga-neutral-white);
 }
 
@@ -429,7 +434,6 @@ a.menu__link:hover {
 
 .markdown > h1:first-child {
   margin: 2rem 0 3rem;
-  
 }
 .markdown > h2 {
   margin-top: 5rem;
@@ -472,7 +476,7 @@ a.menu__link:hover {
   transform: rotate(90deg);
 }
 
-.markdown details[data-collapsed="false"] > summary:before {
+.markdown details[data-collapsed='false'] > summary:before {
   transform: rotate(270deg) !important;
 }
 


### PR DESCRIPTION
## Fixing TOC styling
- Scoped the "true-black" hover for the Quickstart Section
- Fixed the visited styling for the Table of Contents