### PR TITLE
chore: swap to point to new swagger document

### DIFF
--- a/docs/content/integration/advanced/search-with-permissions.mdx
+++ b/docs/content/integration/advanced/search-with-permissions.mdx
@@ -44,7 +44,7 @@ Pre-filter, then call <ProductName format={ProductNameFormat.ShortForm}/> Check 
 
 Consume the `GET /changes` endpoint to create a local index you can use to do an intersection on the two sets of results.
 
-1. Call the <UpdateProductNameInLinks link="/api/service#/Tuples/ReadChanges" name="{ProductName} changes API" />.
+1. Call the <UpdateProductNameInLinks link="/api/service#/Relationship%20Tuples/ReadChanges" name="{ProductName} changes API" />.
 1. For the particular authorization model version(s) you are using in production, flatten/expand the changes (e.g. `user:anne, writer, doc:planning` becomes two tuples: `user:anne, writer, doc:planning` and `user:anne, reader, doc:planning`).
 1. Build the intersection between the objects in your database and the flattened/expanded state you created.
 1. You can then call `/check` on each resource in the resulting set before returning the response to filter out any resource with permissions revoked but whose authorization data has not made it into your index yet.

--- a/docs/content/integration/perform-check.mdx
+++ b/docs/content/integration/perform-check.mdx
@@ -108,7 +108,7 @@ The result's `allowed` field will return `true` if the relationship exists and `
     {
       title: '{ProductName} Check API',
       description: 'Read the Check API documentation and see how it works.',
-      link: '/api/service#/Tuples/Check',
+      link: '/api/service#/Relationship%20Queries/Check',
     },
   ]}
 />

--- a/docs/content/intro/openfga-concepts.mdx
+++ b/docs/content/intro/openfga-concepts.mdx
@@ -428,7 +428,7 @@ A **check request** is a call to the <ProductName format={ProductNameFormat.Long
 
 <!-- markdown-link-check-disable -->
 
-This can be done using the `check` methods in the <ProductName format={ProductNameFormat.ShortForm}/> SDKs ([JavaScript SDK](https://www.npmjs.com/package/@openfga/sdk)/[Go SDK](https://github.com/openfga/go-sdk)/[.NET SDK](https://www.nuget.org/packages/OpenFGA.Sdk)), by manually calling the [check endpoint](/api/service#/Tuples/Check) using curl, or in your code.
+This can be done using the `check` methods in the <ProductName format={ProductNameFormat.ShortForm}/> SDKs ([JavaScript SDK](https://www.npmjs.com/package/@openfga/sdk)/[Go SDK](https://github.com/openfga/go-sdk)/[.NET SDK](https://www.nuget.org/packages/OpenFGA.Sdk)), by manually calling the [check endpoint](/api/service#/Relationship%20Queries/Check) using curl, or in your code.
 
 <!-- markdown-link-check-enable -->
 
@@ -440,7 +440,7 @@ For example, the following will check whether `anne` has a `viewer` relation to 
 
 <!-- markdown-link-check-disable -->
 
-For more information, please see [Comparison between check, read and expand](../writing-data/advanced/check-read-expand.mdx) and [Check API Request Documentation](/api/service#/Tuples/Check).
+For more information, please see [Comparison between check, read and expand](../writing-data/advanced/check-read-expand.mdx) and [Check API Request Documentation](/api/service#/Relationship%20Queries/Check).
 
 <!-- markdown-link-check-enable -->
 
@@ -461,7 +461,7 @@ Unlike relationship tuples, they are not written to the system state. However, i
 
 <!-- markdown-link-check-disable -->
 
-For more information, please see [Contextual and Time-Based Authorization](../modeling/basics/contextual-time-based-authorization.mdx), [Authorization Through Organization Context](../modeling/basics/organization-context-authorization.mdx) and [Check API Request Documentation](/api/service#/Tuples/Check).
+For more information, please see [Contextual and Time-Based Authorization](../modeling/basics/contextual-time-based-authorization.mdx), [Authorization Through Organization Context](../modeling/basics/organization-context-authorization.mdx) and [Check API Request Documentation](/api/service#/Relationship%20Queries/Check).
 
 <!-- markdown-link-check-enable -->
 

--- a/docs/content/modeling/basics/contextual-time-based-authorization.mdx
+++ b/docs/content/modeling/basics/contextual-time-based-authorization.mdx
@@ -763,8 +763,8 @@ When Anne is connecting from a denied ip address range or timeslot, <ProductName
 Contextual tuples:
 
 - Are not persisted in the store.
-- Are only supported on the [Check API endpoint](/api/service#/Tuples/Check). They are not supported on read, expand and other endpoints.
-- If you are using the [ReadChanges API endpoint](/api/service#/Tuples/ReadChanges) to build a permission aware search index, note that it will not be trivial to take contextual tuples into account.
+- Are only supported on the [Check API endpoint](/api/service#/Relationship%20Queries/Check). They are not supported on read, expand and other endpoints.
+- If you are using the [ReadChanges API endpoint](/api/service#/Relationship%20Tuples/ReadChanges) to build a permission aware search index, note that it will not be trivial to take contextual tuples into account.
 :::
 
 ### Taking it a step further: Banks as a Service Authorization
@@ -963,7 +963,7 @@ In that case, we can extend the model like so:
     {
       title: '{ProductName} API',
       description: 'Details on the Check API in the {ProductName} reference guide.',
-      link: '/api/service#/Tuples/Check',
+      link: '/api/service#/Relationship%20Queries/Check',
     },
   ]}
 />

--- a/docs/content/modeling/basics/organization-context-authorization.mdx
+++ b/docs/content/modeling/basics/organization-context-authorization.mdx
@@ -626,8 +626,8 @@ Using this, you can check that the following requirements are satisfied:
 Contextual tuples:
 
 - Are not persisted in the store.
-- Are only supported on the <UpdateProductNameInLinks link="/api/service#/Tuples/Check" name="Check API endpoint" />. They are not supported on read, expand and other endpoints.
-- If you are using the <UpdateProductNameInLinks link="/api/service#/Tuples/ReadChanges" name="Read Changes API endpoint" /> to build a permission aware search index, note that it will not be trivial to take contextual tuples into account.
+- Are only supported on the <UpdateProductNameInLinks link="/api/service#/Relationship%20Queries/Check" name="Check API endpoint" />. They are not supported on read, expand and other endpoints.
+- If you are using the <UpdateProductNameInLinks link="/api/service#/Relationship%20Tuples/ReadChanges" name="Read Changes API endpoint" /> to build a permission aware search index, note that it will not be trivial to take contextual tuples into account.
 :::
 
 ## Related Sections
@@ -651,7 +651,7 @@ Contextual tuples:
     {
       title: '{ProductName} Check API',
       description: 'Details on the Check API in the {ProductName} reference guide.',
-      link: '/api/service#/Tuples/Check',
+      link: '/api/service#/Relationship%20Queries/Check',
     },
   ]}
 />

--- a/docs/content/modeling/concepts/usersets.mdx
+++ b/docs/content/modeling/concepts/usersets.mdx
@@ -114,7 +114,7 @@ Imagine the following authorization model:
   }}
 />
 
-If we wanted to see which users and usersets have a `reader` relationship with `document:budget`, we can call the [Expand API](/api/service#/Debugging/Expand). The response will contain a userset tree where the leaf nodes are specific user IDs and usersets. For example:
+If we wanted to see which users and usersets have a `reader` relationship with `document:budget`, we can call the [Expand API](/api/service#/Relationship%20Queries/Expand). The response will contain a userset tree where the leaf nodes are specific user IDs and usersets. For example:
 
 ```json
 {

--- a/docs/content/writing-data/advanced/check-read-expand.mdx
+++ b/docs/content/writing-data/advanced/check-read-expand.mdx
@@ -103,7 +103,7 @@ You need to know how to create an authorization model and create a relationship 
 
 <!-- markdown-link-check-disable -->
 
-The [Check API](/api/service#/Tuples/Check) is a call to the <ProductName format={ProductNameFormat.LongForm}/> API endpoint that returns whether the user has a certain relationship with an object. <ProductName format={ProductNameFormat.ShortForm}/> will resolve all prerequisite relationships to establish whether a relationship exists.
+The [Check API](/api/service#/Relationship%20Queries/Check) is a call to the <ProductName format={ProductNameFormat.LongForm}/> API endpoint that returns whether the user has a certain relationship with an object. <ProductName format={ProductNameFormat.ShortForm}/> will resolve all prerequisite relationships to establish whether a relationship exists.
 
 <!-- markdown-link-check-enable -->
 
@@ -134,7 +134,7 @@ Check is designed to answer the question "Does user:X have relationship Y with o
 
 <!-- markdown-link-check-disable -->
 
-The [Read API](/api/service#/Tuples/Read) is a call to the <ProductName format={ProductNameFormat.LongForm}/> API endpoint that returns the relationship tuples that are stored in the system that satisfy a query.
+The [Read API](/api/service#/Relationship%20Tuples/Read) is a call to the <ProductName format={ProductNameFormat.LongForm}/> API endpoint that returns the relationship tuples that are stored in the system that satisfy a query.
 
 <!-- markdown-link-check-enable -->
 
@@ -292,17 +292,17 @@ The Expand call is expensive and has high latency. As such, it is designed to be
     {
       title: '{ProductName} API - Check',
       description: 'Details on the check API in the {ProductName} reference guide.',
-      link: '/api/service#/Tuples/Check',
+      link: '/api/service#/Relationship%20Queries/Check',
     },
     {
       title: '{ProductName} API - Read',
       description: 'Details on the read API in the {ProductName} reference guide.',
-      link: '/api/service#/Tuples/Read',
+      link: '/api/service#/Relationship%20Tuples/Read',
     },
     {
       title: '{ProductName} - Expand',
       description: 'Details on the expand API in the {ProductName} reference guide.',
-      link: '/api/service#/Debugging/Expand',
+      link: '/api/service#/Relationship%20Queries/Expand',
     },
   ]}
 />

--- a/docs/content/writing-data/transactional-writes.mdx
+++ b/docs/content/writing-data/transactional-writes.mdx
@@ -180,7 +180,7 @@ The <ProductName format={ProductNameFormat.LongForm}/> service will attempt to p
     {
       title: '{ProductName} API',
       description: 'Details on the write API in the {ProductName} reference guide.',
-      link: '/api/service#/Tuples/Write',
+      link: '/api/service#/Relationship%20Tuples/Write',
     },
   ]}
 />

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -61,7 +61,7 @@ const config = {
       defaultLink: 'https://discord.gg/8naAwJfWN6',
     },
     // location of the swagger file
-    apiDocsBasePath: process.env.API_DOCS_PATH ? process.env.API_DOCS_PATH : 'https://s3.amazonaws.com/assets.sandcastle.cloud/us1/docs/service.swagger.json',
+    apiDocsBasePath: process.env.API_DOCS_PATH ? process.env.API_DOCS_PATH : 'https://raw.githubusercontent.com/openfga/api/main/docs/openapiv2/apidocs.swagger.json',
 
     // Customization for product information
     /* eslint-disable max-len */

--- a/src/components/SwaggerUI/swagger-ui.tsx
+++ b/src/components/SwaggerUI/swagger-ui.tsx
@@ -29,9 +29,10 @@ const SwaggerUI: React.FC<SwaggerUIProps> = ({ apiDocsBasePath }) => {
       responseInterceptor={(response) => {
         if (response.body.tags && response.body.tags.length > 0) {
           response.body.tags = [
-            { name: 'Store Models' },
-            { name: 'Tuples' },
-            { name: 'Debugging' },
+            { name: 'Stores' },
+            { name: 'Authorization Models' },
+            { name: 'Relationship Tuples' },
+            { name: 'Relationship Queries' },
             { name: 'Assertions' },
             // All other tags will appear after these tags.
           ];


### PR DESCRIPTION
## Description
Swap docusaurus configuration to point to the actual swagger file. Also need to update links to API service as tags are different.

## References
Close https://github.com/openfga/openfga.dev/issues/7


## Review Checklist
- [x] The correct base branch is being used, if not `main`
