### PR TITLE
chore: update build script to point to correct CNAME

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -38,8 +38,6 @@ jobs:
         run: npx madge --circular . --extensions ts,js,jsx,tsx
 
       - name: Build with npm
-        env:
-          BASE_URL: '/openfga.dev/'
         run: npm run build
 
   fossa:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,8 +21,6 @@ jobs:
       - name: Install dependencies
         run: npm clean-install
       - name: Build website
-        env:
-          BASE_URL: '/openfga.dev/'
         run: npm run build
 
       # Popular action to deploy to GitHub Pages:

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -21,6 +21,4 @@ jobs:
       - name: Install dependencies
         run: npm clean-install
       - name: Test build website
-        env:
-          BASE_URL: '/openfga.dev/'
         run: npm run build

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ If you find a bug or inaccuracy in the documentation content, please report it i
 
 <!-- markdown-link-check-disable -->
 ## Author
-OpenFGA <contact@openfga.dev> (https://docs.openfga.dev)
+OpenFGA <contact@openfga.dev> (https://openfga.dev)
 
 ## License
 Please refer to https://github.com/openfga/rfcs/blob/main/LICENSE for license information.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -14,7 +14,7 @@ const baseUrl = process.env.BASE_URL ?? '/';
 const config = {
   title: 'OpenFGA Docs',
   tagline: 'Relationship-based access control made fast, scalable, and easy to use.',
-  url: 'https://openfga.github.io/',
+  url: 'https://openfga.dev/',
   baseUrl: baseUrl,
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',


### PR DESCRIPTION

## Description
Document is now hosted in root instead of under openfga.github.io page.


## References
Close https://github.com/openfga/openfga.dev/issues/14

## Review Checklist
- [X] The correct base branch is being used, if not `main`
