### PR TITLE
feat: update configuration language page equivalent section for language

### DIFF
--- a/docs/content/modeling/configuration-language.mdx
+++ b/docs/content/modeling/configuration-language.mdx
@@ -12,6 +12,7 @@ import {
   ProductNameFormat,
   RelatedSection,
   RelationshipTuplesViewer,
+  SyntaxFormat,
   UpdateProductNameInLinks,
 } from '@components/Docs';
 
@@ -755,6 +756,63 @@ relation {
 In the <ProductName format={ProductNameFormat.ShortForm}/> DSL, it would become:
 
 <AuthzModelSnippetViewer
+  onlyShow={SyntaxFormat.Friendly2}
+  configuration={{
+    type_definitions: [
+      {
+        type: 'doc',
+        relations: {
+          owner: {
+            this: {},
+          },
+          editor: {
+            union: {
+              child: [
+                {
+                  this: {},
+                },
+                {
+                  computedUserset: {
+                    relation: 'owner',
+                  },
+                },
+              ],
+            },
+          },
+          viewer: {
+            union: {
+              child: [
+                {
+                  this: {},
+                },
+                {
+                  computedUserset: {
+                    relation: 'editor',
+                  },
+                },
+                {
+                  tupleToUserset: {
+                    tupleset: {
+                      relation: 'parent',
+                    },
+                    computedUserset: {
+                      relation: 'viewer',
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        },
+      },
+    ],
+  }}
+/>
+
+And in the <ProductName format={ProductNameFormat.ShortForm}/> JSON, it would become:
+
+<AuthzModelSnippetViewer
+  onlyShow={SyntaxFormat.Api}
   configuration={{
     type_definitions: [
       {


### PR DESCRIPTION
## Description
When discussing Zanzibar equivalent, display authorization model in
DSL and API separately to allow clearer understanding of difference.

https://user-images.githubusercontent.com/10730463/172890324-bc533b8e-b10d-46be-9792-88b014b75845.mov


## References
Close https://github.com/openfga/openfga.dev/issues/5

## Review Checklist
- [x] The correct base branch is being used, if not `main`
