### PR TITLE
fix: typo in entitlement page

### DIFF
--- a/docs/content/modeling/advanced/patterns/entitlements.mdx
+++ b/docs/content/modeling/advanced/patterns/entitlements.mdx
@@ -674,7 +674,7 @@ a subsequent check for `is anne related to feature:issues as access?` would retu
 
 - `{ "user": "anne", "relation": "member", "object": "organization:z" }`
 - `{ "user": "organization:z", "relation": "subscriber", "object": "plan:y" }`
-- `{ "user": "play:y", "relation": "associated_plan", "object": "feature:issues" }`
+- `{ "user": "plan:y", "relation": "associated_plan", "object": "feature:issues" }`
 
 #### Verification
 


### PR DESCRIPTION
## Description
Fix typo in entitlement page.  Should read `plan:y` instead of `play:y`.


## References
Close https://github.com/openfga/openfga.dev/issues/19


## Review Checklist
- [X] The correct base branch is being used, if not `main`
