### PR TITLE
fix: add CNAME as part of github action deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,6 +31,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # Build output to publish to the `gh-pages` branch:
           publish_dir: ./build
+          cname: openfga.dev
           # The following lines assign commit authorship to the official
           # GH-Actions bot for deploys to `gh-pages` branch:
           # https://github.com/actions/checkout/issues/13#issuecomment-724415212


### PR DESCRIPTION
## Description
According to https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-add-cname-file-cname, we can specify the CNAME used.

## References
Close https://github.com/openfga/openfga.dev/issues/21

## Review Checklist
- [ ] The correct base branch is being used, if not `main`
