### PR TITLE
feat: adjustable scroll targets for docs

### DIFF
--- a/static/css/openfga.css
+++ b/static/css/openfga.css
@@ -43,6 +43,15 @@
 
 html {
   font-family: var(--ofga-font-base);
+  scroll-behavior: smooth;
+}
+  
+/* Link targets for TOC scrolling */
+:target:before {
+  content: "";
+  display: block;
+  height: 60px;           /* adjust these to */
+  margin: -60px 0 0;      /* control offset  */
 }
 
 /* Gradient Color Bar */


### PR DESCRIPTION
Adjustable scroll targets for docs Table of Contents links.

## Description
This uses the :target pseudoelement, with a negative margin and height to make it possible for us to adjust the offset from the top of the viewport when a user clicks on TOC links to scroll to a heading within a docs page. See the following before/after comparing the currently deployed site at openfga.dev vs. the branch used for this PR:

![scrolling](https://user-images.githubusercontent.com/6372810/173067316-62aa82f4-7202-4f87-9eec-fbaffe9c4c84.gif)

## References
This closes #31 