### PR TITLE
fix: link on hero landing page to github

### DIFF
--- a/src/features/LandingPage/HeroHeader/index.tsx
+++ b/src/features/LandingPage/HeroHeader/index.tsx
@@ -66,7 +66,7 @@ const HeroHeader = () => {
                 </svg>
                 Quick start
               </ButtonLink>
-              <ButtonLink href="https://github.com/openfga/openfga">
+              <ButtonLink href="https://github.com/openfga">
                 <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
                   <path
                     fillRule="evenodd"


### PR DESCRIPTION
## Description
Change link to https://github.com/openfga

https://user-images.githubusercontent.com/10730463/173119811-d06ef1fa-47eb-46d6-a4c1-f5d6693b42d4.mov


## References
Close https://github.com/openfga/openfga.dev/issues/36


## Review Checklist
- [ ] I have added documentation for new/changed functionality in this PR or in [openfga.dev](https://github.com/openfga/openfga.dev)
- [X] The correct base branch is being used, if not `main`
