### PR TITLE
chore: update feature roadmap link

### DIFF
--- a/src/features/LandingPage/FeaturesSection/index.tsx
+++ b/src/features/LandingPage/FeaturesSection/index.tsx
@@ -69,7 +69,7 @@ const FeaturesSection = () => (
         <h3>Get involved</h3>
         <p>
           OpenFGA has an active <Link href="https://discord.gg/8naAwJfWN6">Discord community</Link>, a{' '}
-          <Link href="https://github.com/orgs/openfga/projects">public roadmap</Link>, and is ready for contributions.
+          <Link href="https://github.com/orgs/openfga/projects/1">public roadmap</Link>, and is ready for contributions.
           Check out existing <Link href="https://github.com/openfga/rfcs">RFCs</Link> to understand where the project is
           headed, and learn more about how to take part by reading our{' '}
           <Link href="https://github.com/openfga/.github/blob/main/CONTRIBUTING.md">CONTRIBUTING.md</Link>.


### PR DESCRIPTION

## Description
Update to https://github.com/orgs/openfga/projects/1 instead of
https://github.com/orgs/openfga/projects


https://user-images.githubusercontent.com/10730463/173120464-ba758666-5aa4-49ec-9faa-30fb6a4e0730.mov



## References
Close https://github.com/openfga/openfga.dev/issues/37

## Review Checklist
- [ ] I have added documentation for new/changed functionality in this PR or in [openfga.dev](https://github.com/openfga/openfga.dev)
- [X] The correct base branch is being used, if not `main`
