### PR TITLE
style:logo sizing for hero element

### DIFF
--- a/src/features/LandingPage/HeroHeader/HeroHeader.module.css
+++ b/src/features/LandingPage/HeroHeader/HeroHeader.module.css
@@ -27,8 +27,7 @@
 }
 
 .heading svg {
-  width: 16rem;
-  height: 4.5rem;
+  width: 20rem;
 }
 
 .headingSubtitle {
@@ -39,6 +38,10 @@
 }
 
 @media screen and (min-width: 996px) {
+  .heading svg {
+    width: 25.8rem;
+    height: unset;
+  }
   .headingSubtitle {
     font-size: 2.7rem;
   }


### PR DESCRIPTION
Adjusted logo size on hero element across two breakpoints.

## Description
At some point the logo in the hero component was reduced in size until on desktop it more or less matched the subtitle below it. The plan (based on our Figma mockups) was to have the logo larger and more prominent, so that it can be recognized as distinct from the other text.

I've adjusted the size on mobile and desktop breakpoints to match the mockups.

### References

Before:
![Screen Shot 2022-06-10 at 2 48 58 PM](https://user-images.githubusercontent.com/6372810/173123997-e87be9f3-cc9d-4fd8-98d3-50954f7c377f.png)
![Screen Shot 2022-06-10 at 2 49 08 PM](https://user-images.githubusercontent.com/6372810/173124001-b4b78bc8-11e4-4317-a9f6-68cf038b9a79.png)

After:
![Screen Shot 2022-06-10 at 2 48 18 PM](https://user-images.githubusercontent.com/6372810/173124011-a8d2188d-fd6b-4872-acdb-23b85e001ab7.png)
![Screen Shot 2022-06-10 at 2 48 41 PM](https://user-images.githubusercontent.com/6372810/173124014-33a3fabc-019b-444b-933d-f04862fcae40.png)

## Review Checklist
- [ ] I have added documentation for new/changed functionality in this PR or in [openfga.dev](https://github.com/openfga/openfga.dev)
- [x] The correct base branch is being used, if not `main`
