### PR TITLE
fix: reveal and hide header logo upon scroll

### DIFF
--- a/src/features/LandingPage/HeroHeader/index.tsx
+++ b/src/features/LandingPage/HeroHeader/index.tsx
@@ -39,7 +39,7 @@ const HeroHeader = () => {
       <div className="container">
         <div className={styles.container}>
           <div className={styles.content}>
-            <h1 className={styles.heading}>
+            <h1 className={styles.heading} ref={headingRef}>
               {<HeroLogo />}
               <span className={styles.headingSubtitle}>{siteConfig.tagline}</span>
             </h1>


### PR DESCRIPTION
Fix to re-enable showing and hiding of header logo when hero logo is visible.

## Description
At some point we lost the `ref={headerRef}` that we use for detecting when the hero logo is in view.

## Review Checklist
- [ ] I have added documentation for new/changed functionality in this PR or in [openfga.dev](https://github.com/openfga/openfga.dev)
- [x] The correct base branch is being used, if not `main`
