### PR TITLE
chore: add link /docs to easy remember address that link directly

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -145,6 +145,10 @@ using OpenFga.Sdk.Configuration;`,
             to: '/api/service',
             from: ['/api'],
           },
+          {
+            to: '/intro/authorization-and-openfga',
+            from: '/docs',
+          }
         ],
       }),
     ],


### PR DESCRIPTION
## Description

Added redirect link in docusaurus config to allow '/docs' to redirect to docs homepage

https://user-images.githubusercontent.com/10730463/173149863-fadae911-3eba-4c91-b548-a8e3dd39fa93.mov


## References
Close https://github.com/openfga/openfga.dev/issues/49


## Review Checklist
- [ ] I have added documentation for new/changed functionality in this PR or in [openfga.dev](https://github.com/openfga/openfga.dev)
- [X] The correct base branch is being used, if not `main`
