### PR TITLE
style: remove red outlines, align chevrons on API page

### DIFF
--- a/src/components/SwaggerUI/swagger-ui-override.css
+++ b/src/components/SwaggerUI/swagger-ui-override.css
@@ -7135,7 +7135,7 @@
   border-bottom: 1px solid rgba(59, 65, 81, 0.3);
   cursor: pointer;
   display: flex;
-  padding: 0 26px 16px 0;
+  padding: 0 0 16px 0;
   transition: all 0.2s;
   color: var(--ifm-color-primary-contrast-foreground);
   font-size: 24px;
@@ -7370,8 +7370,9 @@
   background: #fca130;
 }
 .swagger-ui .opblock.opblock-delete {
-  background: rgba(249, 62, 62, 0.1);
-  border-color: #f93e3e;
+  background: unset;
+  border-color: unset;
+  border: unset;
 }
 .swagger-ui .opblock.opblock-delete .opblock-summary-method {
   background: #f93e3e;
@@ -7940,6 +7941,7 @@
 .swagger-ui .expand-operation {
   background: none;
   border: none;
+  padding: 0px;
 }
 .swagger-ui .expand-methods svg,
 .swagger-ui .expand-operation svg {


### PR DESCRIPTION
Style cleanup on API page

## Description
The API page had some styling inconsistencies to resolve:
* Border and background style on Delete endpoints
* Chevrons for API sections weren't aligned

Before:
![image](https://user-images.githubusercontent.com/6372810/173412405-648d7e56-7fee-4dc7-ae4d-71032da08dad.png)

After:
![Screen Shot 2022-06-13 at 2 43 34 PM](https://user-images.githubusercontent.com/6372810/173412926-8a1d763b-e1bc-47ce-a591-6c194629b343.png)


## References
Closes #54 

## Review Checklist
- [ ] I have added documentation for new/changed functionality in this PR or in [openfga.dev](https://github.com/openfga/openfga.dev)
- [X] The correct base branch is being used, if not `main`
