### PR TITLE
fix: styling in details/summary box

### DIFF
--- a/static/css/openfga.css
+++ b/static/css/openfga.css
@@ -493,8 +493,8 @@ a.table-of-contents__link--active {
 }
 
 .markdown details h3 {
-  font-size: 20px;
-  line-height: 26px;
+  font-size: 1.25rem;
+  line-height: 1.625rem;
   letter-spacing: -0.1px;
   margin: unset;
   padding: 1.5rem 0 1rem;

--- a/static/css/openfga.css
+++ b/static/css/openfga.css
@@ -463,6 +463,7 @@ a.table-of-contents__link--active {
 
 .markdown details {
   margin-top: 2rem;
+  border-radius: 24px !important;
   padding: 0;
 }
 
@@ -479,6 +480,7 @@ a.table-of-contents__link--active {
   padding: 2rem;
   margin: unset;
 }
+
 .markdown details summary:before {
   left: auto;
   right: 1rem;
@@ -488,6 +490,14 @@ a.table-of-contents__link--active {
 
 .markdown details[data-collapsed='false'] > summary:before {
   transform: rotate(270deg) !important;
+}
+
+.markdown details h3 {
+  font-size: 20px;
+  line-height: 26px;
+  letter-spacing: -0.1px;
+  margin: unset;
+  padding: 1.5rem 0 1rem;
 }
 
 /* Pre - Code */


### PR DESCRIPTION
## Description
Add styling for details and summary box
<img width="969" alt="Screen Shot 2022-06-13 at 2 33 37 PM" src="https://user-images.githubusercontent.com/10730463/173421464-b0961e92-f99a-4771-9385-2abe9b333b60.png">
<img width="1029" alt="Screen Shot 2022-06-13 at 2 33 12 PM" src="https://user-images.githubusercontent.com/10730463/173421470-c5f542a5-8226-48c5-b48b-fcf554ae8d2a.png">



## References
Close https://github.com/openfga/openfga.dev/issues/56

## Review Checklist
- [ ] I have added documentation for new/changed functionality in this PR or in [openfga.dev](https://github.com/openfga/openfga.dev)
- [X] The correct base branch is being used, if not `main`
