### PR TITLE
fix: update metadata title to correct page title

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -14,7 +14,7 @@ const baseUrl = process.env.BASE_URL ?? '/';
 const config = {
   title: 'OpenFGA',
   tagline: 'Relationship-based access control made fast, scalable, and easy to use.',
-  url: 'https://openfga.dev/',
+  url: 'https://openfga.dev',
   baseUrl: baseUrl,
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',
@@ -188,6 +188,10 @@ using OpenFga.Sdk.Configuration;`,
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
+      metadata: [
+        { name: 'keywords', content: 'OpenFGA, open source, fine-grained-authorization, fine grained authorization, Zanzibar' },
+        { property: 'og:image', content: 'https://openfga.dev/img/openfga_logo.svg'  }
+      ],
       colorMode: {
         defaultMode: 'dark',
         disableSwitch: true,

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -12,7 +12,7 @@ const baseUrl = process.env.BASE_URL ?? '/';
 // With JSDoc @type annotations, IDEs can provide config autocompletion
 /** @type {import('@docusaurus/types').Config} */
 const config = {
-  title: 'OpenFGA Docs',
+  title: 'OpenFGA',
   tagline: 'Relationship-based access control made fast, scalable, and easy to use.',
   url: 'https://openfga.dev/',
   baseUrl: baseUrl,
@@ -74,6 +74,7 @@ const config = {
     // link to the concept page (relative to baseURL)
     conceptLink: `intro/openfga-concepts`,
     longProductName: `OpenFGA`,
+    landingPageTitle: "Fine Grained Authorization",
 
     // define playgroundName and playgroundURL if you want to show your examples through playground
     //playgroundName: '',

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -6,8 +6,9 @@ import { QuickStartSection, FeaturesSection, ResourcesSection, HeroHeader } from
 
 export default function Home(): JSX.Element {
   const { siteConfig } = useDocusaurusContext();
+  const title = siteConfig.customFields.landingPageTitle;
   return (
-    <Layout title={`${siteConfig.title}`} description="Description will go into a meta tag in <head />">
+    <Layout title={`${title}`} description={`${siteConfig.tagline}`}>
       <HeroHeader />
       <main>
         <QuickStartSection />


### PR DESCRIPTION
## Description
Update so that the correct title is in the document home page
<img width="1905" alt="Screen Shot 2022-06-13 at 4 02 08 PM" src="https://user-images.githubusercontent.com/10730463/173435851-e84fd97d-c51a-49cb-85a3-7b3284144af8.png">
<img width="1905" alt="Screen Shot 2022-06-13 at 4 01 53 PM" src="https://user-images.githubusercontent.com/10730463/173435861-289fe0d5-ae22-435e-9409-69126c558f05.png">


## References
Close https://github.com/openfga/openfga.dev/issues/32
## Review Checklist
- [ ] I have added documentation for new/changed functionality in this PR or in [openfga.dev](https://github.com/openfga/openfga.dev)
- [X] The correct base branch is being used, if not `main`
