### PR TITLE
feat: add write authorization model viewer component

### DIFF
--- a/src/components/Docs/AuthorizationModel/AuthzModelSnippetViewer.tsx
+++ b/src/components/Docs/AuthorizationModel/AuthzModelSnippetViewer.tsx
@@ -1,25 +1,30 @@
+import React from 'react';
+
+import { TypeDefinitions } from '@auth0/fga';
+import Link from "@docusaurus/Link";
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import Admonition from '@theme/Admonition';
 
-import React from 'react';
-import { TypeDefinitions } from '@auth0/fga';
-import { SyntaxFormat } from './SyntaxTransformer';
+import { SyntaxFormat, WriteAuthzModelViewer } from "@components/Docs";
 import { AuthzModelCodeBlock } from './AuthzModelCodeBlock';
 
 type AuthzModelSnippetViewerProps = {
-  // Namespace configuration in api syntax
+  // Authorization Model in api syntax
   configuration: TypeDefinitions;
   // optional description
   description?: string;
   onlyShow?: SyntaxFormat;
+  showWrite?: boolean;
 };
 
-const AuthzModelSnippetViewer: React.FC<AuthzModelSnippetViewerProps> = ({ configuration, onlyShow }) => {
+const AuthzModelSnippetViewer: React.FC<AuthzModelSnippetViewerProps> = ({ configuration, onlyShow, showWrite }) => {
   if (onlyShow) {
     return <AuthzModelCodeBlock configuration={configuration} syntaxFormat={onlyShow} />;
   }
 
   return (
+    <>
     <Tabs groupId="dsl">
       <TabItem value="dsl" label="DSL">
         <AuthzModelCodeBlock configuration={configuration} syntaxFormat={SyntaxFormat.Friendly2} />
@@ -28,6 +33,20 @@ const AuthzModelSnippetViewer: React.FC<AuthzModelSnippetViewerProps> = ({ confi
         <AuthzModelCodeBlock configuration={configuration} syntaxFormat={SyntaxFormat.Api} />
       </TabItem>
     </Tabs>
+    {
+      showWrite ?
+        <details>
+          <summary>Write the Authorization Model</summary>
+
+          <Admonition type="note">
+            <div>The OpenFGA API only accepts an authorization model in the API&#39;s JSON syntax.</div>
+            <div>To convert between the API Syntax and the friendly DSL, you can use the <Link href={"https://github.com/openfga/syntax-transformer/"}>syntax transformer</Link> or <Link href={"https://play.fga.dev"}>Auth0 FGA&#39;s Playground</Link>.</div>
+          </Admonition>
+
+          <WriteAuthzModelViewer authorizationModel={configuration} skipSetup={true} />
+        </details> : undefined
+    }
+    </>
   );
 };
 

--- a/src/components/Docs/AuthorizationModel/AuthzModelSnippetViewer.tsx
+++ b/src/components/Docs/AuthorizationModel/AuthzModelSnippetViewer.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 
 import { TypeDefinitions } from '@auth0/fga';
-import Link from "@docusaurus/Link";
+import Link from '@docusaurus/Link';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import Admonition from '@theme/Admonition';
 
-import { SyntaxFormat, WriteAuthzModelViewer } from "@components/Docs";
+import { SyntaxFormat, WriteAuthzModelViewer } from '@components/Docs';
 import { AuthzModelCodeBlock } from './AuthzModelCodeBlock';
 
 type AuthzModelSnippetViewerProps = {
@@ -25,27 +25,30 @@ const AuthzModelSnippetViewer: React.FC<AuthzModelSnippetViewerProps> = ({ confi
 
   return (
     <>
-    <Tabs groupId="dsl">
-      <TabItem value="dsl" label="DSL">
-        <AuthzModelCodeBlock configuration={configuration} syntaxFormat={SyntaxFormat.Friendly2} />
-      </TabItem>
-      <TabItem value="json" label="JSON">
-        <AuthzModelCodeBlock configuration={configuration} syntaxFormat={SyntaxFormat.Api} />
-      </TabItem>
-    </Tabs>
-    {
-      showWrite ?
+      <Tabs groupId="dsl">
+        <TabItem value="dsl" label="DSL">
+          <AuthzModelCodeBlock configuration={configuration} syntaxFormat={SyntaxFormat.Friendly2} />
+        </TabItem>
+        <TabItem value="json" label="JSON">
+          <AuthzModelCodeBlock configuration={configuration} syntaxFormat={SyntaxFormat.Api} />
+        </TabItem>
+      </Tabs>
+      {showWrite ? (
         <details>
           <summary>Write the Authorization Model</summary>
 
           <Admonition type="note">
             <div>The OpenFGA API only accepts an authorization model in the API&#39;s JSON syntax.</div>
-            <div>To convert between the API Syntax and the friendly DSL, you can use the <Link href={"https://github.com/openfga/syntax-transformer/"}>syntax transformer</Link> or <Link href={"https://play.fga.dev"}>Auth0 FGA&#39;s Playground</Link>.</div>
+            <div>
+              To convert between the API Syntax and the friendly DSL, you can use the{' '}
+              <Link href={'https://github.com/openfga/syntax-transformer/'}>syntax transformer</Link> or{' '}
+              <Link href={'https://play.fga.dev'}>Auth0 FGA&#39;s Playground</Link>.
+            </div>
           </Admonition>
 
           <WriteAuthzModelViewer authorizationModel={configuration} skipSetup={true} />
-        </details> : undefined
-    }
+        </details>
+      ) : undefined}
     </>
   );
 };

--- a/src/components/Docs/SnippetViewer/WriteAuthzModelViewer.tsx
+++ b/src/components/Docs/SnippetViewer/WriteAuthzModelViewer.tsx
@@ -1,0 +1,70 @@
+import { getFilteredAllowedLangs, SupportedLanguage, LanguageMappings } from './SupportedLanguage';
+import { defaultOperationsViewer } from './DefaultTabbedViewer';
+import assertNever from 'assert-never/index';
+import { AuthorizationModel } from "@auth0/fga";
+
+
+interface WriteAuthzModelViewerOpts {
+  authorizationModel: AuthorizationModel;
+  skipSetup?: boolean;
+  allowedLanguages?: SupportedLanguage[];
+}
+
+function writeAuthZModelViewer(lang: SupportedLanguage, opts: WriteAuthzModelViewerOpts, languageMappings: LanguageMappings) {
+  switch (lang) {
+    case SupportedLanguage.CURL: {
+      return `curl -X POST $FGA_API_URL/stores/$FGA_STORE_ID/write \\
+  -H "Authorization: Bearer $FGA_BEARER_TOKEN" \\ # Not needed if service does not require authorization
+  -H "content-type: application/json" \\
+  -d '${JSON.stringify(opts.authorizationModel)}'`;
+    }
+
+    case SupportedLanguage.JS_SDK: {
+      return `
+await fgaClient.writeAuthorizationModel(${JSON.stringify(opts.authorizationModel, null, 2)});`;
+    }
+
+    case SupportedLanguage.GO_SDK: {
+      /* eslint-disable no-tabs */
+      return `
+var typeDefinitionsString = ${JSON.stringify(JSON.stringify(opts.authorizationModel))}
+var typeDefinitions TypeDefinitions
+if err := json.Unmarshal([]byte(typeDefinitionsString), &typeDefinitions); err != nil {
+    t.Errorf("%v", err)
+    // .. Handle error
+    return
+}
+
+_, response, err := fgaClient.${languageMappings['go'].apiName}.WriteAuthorizationModel(context.Background()).TypeDefinitions(typeDefinitions).Execute()
+if err != nil {
+    // .. Handle error
+}
+`;
+    }
+
+    case SupportedLanguage.DOTNET_SDK: {
+      return `
+var modelJson = ${JSON.stringify(JSON.stringify(opts.authorizationModel))};
+var body = JsonSerializer.Deserialize<ReadAuthorizationModelsResponse>(modelJson);
+
+await fgaClient.WriteAuthorizationModel(body);`;
+    }
+
+    case SupportedLanguage.RPC:
+    case SupportedLanguage.PLAYGROUND:
+      return '';
+    default:
+      assertNever(lang);
+  }
+}
+
+export function WriteAuthzModelViewer(opts: WriteAuthzModelViewerOpts): JSX.Element {
+  const defaultLangs = [
+    SupportedLanguage.JS_SDK,
+    SupportedLanguage.GO_SDK,
+    SupportedLanguage.DOTNET_SDK,
+    SupportedLanguage.CURL,
+  ];
+  const allowedLanguages = getFilteredAllowedLangs(opts.allowedLanguages, defaultLangs);
+  return defaultOperationsViewer<WriteAuthzModelViewerOpts>(allowedLanguages, opts, writeAuthZModelViewer);
+}

--- a/src/components/Docs/SnippetViewer/WriteAuthzModelViewer.tsx
+++ b/src/components/Docs/SnippetViewer/WriteAuthzModelViewer.tsx
@@ -1,8 +1,7 @@
 import { getFilteredAllowedLangs, SupportedLanguage, LanguageMappings } from './SupportedLanguage';
 import { defaultOperationsViewer } from './DefaultTabbedViewer';
 import assertNever from 'assert-never/index';
-import { AuthorizationModel } from "@auth0/fga";
-
+import { AuthorizationModel } from '@auth0/fga';
 
 interface WriteAuthzModelViewerOpts {
   authorizationModel: AuthorizationModel;
@@ -10,44 +9,64 @@ interface WriteAuthzModelViewerOpts {
   allowedLanguages?: SupportedLanguage[];
 }
 
-function writeAuthZModelViewer(lang: SupportedLanguage, opts: WriteAuthzModelViewerOpts, languageMappings: LanguageMappings) {
-  switch (lang) {
-    case SupportedLanguage.CURL: {
-      return `curl -X POST $FGA_API_URL/stores/$FGA_STORE_ID/write \\
+function writeAuthZModelViewerCurl(authorizationModel: AuthorizationModel): string {
+  return `curl -X POST $FGA_API_URL/stores/$FGA_STORE_ID/write \\
   -H "Authorization: Bearer $FGA_BEARER_TOKEN" \\ # Not needed if service does not require authorization
   -H "content-type: application/json" \\
-  -d '${JSON.stringify(opts.authorizationModel)}'`;
+  -d '${JSON.stringify(authorizationModel)}'`;
+}
+
+function writeAuthZModelViewerJS(authorizationModel: AuthorizationModel): string {
+  return `
+await fgaClient.writeAuthorizationModel(${JSON.stringify(authorizationModel, null, 2)});`;
+}
+
+function writeAuthZModelViewerGo(authorizationModel: AuthorizationModel, apiName: string): string {
+  /* eslint-disable no-tabs */
+  return `
+  var typeDefinitionsString = ${JSON.stringify(JSON.stringify(authorizationModel))}
+  var typeDefinitions TypeDefinitions
+  if err := json.Unmarshal([]byte(typeDefinitionsString), &typeDefinitions); err != nil {
+      t.Errorf("%v", err)
+      // .. Handle error
+      return
+  }
+
+  _, response, err := fgaClient.${apiName}.WriteAuthorizationModel(context.Background()).TypeDefinitions(typeDefinitions).Execute()
+  if err != nil {
+      // .. Handle error
+  }
+  `;
+}
+
+function writeAuthZModelViewerDotnet(authorizationModel: AuthorizationModel): string {
+  return `
+  var modelJson = ${JSON.stringify(JSON.stringify(authorizationModel))};
+  var body = JsonSerializer.Deserialize<ReadAuthorizationModelsResponse>(modelJson);
+
+  await fgaClient.WriteAuthorizationModel(body);`;
+}
+
+function writeAuthZModelViewer(
+  lang: SupportedLanguage,
+  opts: WriteAuthzModelViewerOpts,
+  languageMappings: LanguageMappings,
+) {
+  switch (lang) {
+    case SupportedLanguage.CURL: {
+      return writeAuthZModelViewerCurl(opts.authorizationModel);
     }
 
     case SupportedLanguage.JS_SDK: {
-      return `
-await fgaClient.writeAuthorizationModel(${JSON.stringify(opts.authorizationModel, null, 2)});`;
+      return writeAuthZModelViewerJS(opts.authorizationModel);
     }
 
     case SupportedLanguage.GO_SDK: {
-      /* eslint-disable no-tabs */
-      return `
-var typeDefinitionsString = ${JSON.stringify(JSON.stringify(opts.authorizationModel))}
-var typeDefinitions TypeDefinitions
-if err := json.Unmarshal([]byte(typeDefinitionsString), &typeDefinitions); err != nil {
-    t.Errorf("%v", err)
-    // .. Handle error
-    return
-}
-
-_, response, err := fgaClient.${languageMappings['go'].apiName}.WriteAuthorizationModel(context.Background()).TypeDefinitions(typeDefinitions).Execute()
-if err != nil {
-    // .. Handle error
-}
-`;
+      return writeAuthZModelViewerGo(opts.authorizationModel, languageMappings['go'].apiName);
     }
 
     case SupportedLanguage.DOTNET_SDK: {
-      return `
-var modelJson = ${JSON.stringify(JSON.stringify(opts.authorizationModel))};
-var body = JsonSerializer.Deserialize<ReadAuthorizationModelsResponse>(modelJson);
-
-await fgaClient.WriteAuthorizationModel(body);`;
+      return writeAuthZModelViewerDotnet(opts.authorizationModel);
     }
 
     case SupportedLanguage.RPC:

--- a/src/components/Docs/SnippetViewer/index.ts
+++ b/src/components/Docs/SnippetViewer/index.ts
@@ -6,3 +6,4 @@ export * from './ReadRequestViewer';
 export { SdkSetupHeader } from './SdkSetup';
 export { SupportedLanguage, languageLabelMap } from './SupportedLanguage';
 export * from './WriteRequestViewer';
+export * from './WriteAuthzModelViewer';


### PR DESCRIPTION
<!-- Thanks for opening a PR!  Here are some quick tips for you:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/openfga/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/openfga/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

Provides a component that showcases posting the Authorization Model to the API.

CSS needs a bit of a touch up for nested components (the paddings are weird, and the admonition has a lot of extra space)

## Description


https://user-images.githubusercontent.com/536147/173605916-83c6147d-a776-48c4-b07d-58727afddd6a.mov

To test:
- Import the `WriteAuthzModelViewer` component directly and pass in an authorization model
- Pass `showWrite={true}` to the `AuthzModelSnippetViewer`


## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have added documentation for new/changed functionality in this PR or in [openfga.dev](https://github.com/openfga/openfga.dev)
- [x] The correct base branch is being used, if not `main`
