### PR TITLE
feat: add configure model page

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,7 @@ hide_title: true
   - [Install SDK Client](./content/getting-started/install-sdk.mdx)
   - [Create a Store](./content/getting-started/create-store.mdx)
   - [Setup SDK Client for Store](./content/getting-started/setup-sdk-client.mdx)
+  - [Configure Authorization Model](./content/getting-started/configure-model.mdx)
   - [Update Relationship Tuples](./content/getting-started/update-tuples.mdx)
   - [Perform a Check](./content/getting-started/perform-check.mdx)
   - [Integrate Within a Framework](./content/getting-started/framework.mdx)

--- a/docs/content/getting-started/configure-model.mdx
+++ b/docs/content/getting-started/configure-model.mdx
@@ -24,7 +24,7 @@ import TabItem from '@theme/TabItem';
 
 <DocumentationNotice />
 
-This article explains how to configure <ProductConcept section="what-is-an-authorization-model" linkName="authorization model" /> to the OpenFGA server for a <ProductConcept section="what-is-a-store" linkName="store" />.
+This article explains how to configure an <ProductConcept section="what-is-an-authorization-model" linkName="authorization model" /> for a <ProductConcept section="what-is-a-store" linkName="store" /> in an OpenFGA server.
 
 ## Before you start
 
@@ -101,9 +101,9 @@ To obtain the [access token](https://auth0.com/docs/authorization/flows/call-you
 </TabItem>
 </Tabs>
 
-### 02. Calling Configuration Model API to Configure Authorization Model
+### 02. Calling Write Authorization Model API 
 
-To configure authorization model, we can invoke the [authorization models API](/api/service#/Authorization%20Models/WriteAuthorizationModel).
+To configure authorization model, we can invoke the [write authorization models API](/api/service#/Authorization%20Models/WriteAuthorizationModel).
 
 <WriteAuthzModelViewer
   authorizationModel={{
@@ -142,10 +142,10 @@ To convert between the API Syntax and the friendly DSL, you can use the
 [Auth0 FGA's Playground](https://play.fga.dev).
 :::
 
-## Related Section
+## Related Sections
 
 <RelatedSection
-  description="Take a look at the following section for more on how to configure authorization model in your system"
+  description="Take a look at the following sections for more information on how to configure authorization model in your store."
   relatedLinks={[
     {
       title: 'Getting Started with Modeling',

--- a/docs/content/getting-started/configure-model.mdx
+++ b/docs/content/getting-started/configure-model.mdx
@@ -5,7 +5,7 @@ slug: /getting-started/configure-model
 ---
 
 import {
-	AuthzModelSnippetViewer,
+    AuthzModelSnippetViewer,
     DocumentationNotice,
     languageLabelMap,
     ProductConcept,

--- a/docs/content/getting-started/configure-model.mdx
+++ b/docs/content/getting-started/configure-model.mdx
@@ -8,6 +8,7 @@ import {
 	AuthzModelSnippetViewer,
     DocumentationNotice,
     languageLabelMap,
+    ProductConcept,
     ProductName,
     ProductNameFormat,
     RelatedSection,
@@ -23,7 +24,7 @@ import TabItem from '@theme/TabItem';
 
 <DocumentationNotice />
 
-This article explains how to configure [authorization model](../concepts#what-is-an-authorization-model) to the OpenFGA server for a [store](../concepts#what-is-a-store).
+This article explains how to configure <ProductConcept section="what-is-an-authorization-model" linkName="authorization model" /> to the OpenFGA server for a <ProductConcept section="what-is-a-store" linkName="store" />.
 
 ## Before you start
 

--- a/docs/content/getting-started/configure-model.mdx
+++ b/docs/content/getting-started/configure-model.mdx
@@ -72,37 +72,6 @@ Assume that you want to configure your store with the following model.
 />
 
 
-### 01. Configure the <ProductName format={ProductNameFormat.ShortForm}/> API client
-
-Before calling the write API, you will need to configure the API client.
-
-<Tabs groupId="languages">
-<TabItem value={SupportedLanguage.JS_SDK} label={languageLabelMap.get(SupportedLanguage.JS_SDK)}>
-
-<SdkSetupHeader lang={SupportedLanguage.JS_SDK} />
-
-</TabItem>
-<TabItem value={SupportedLanguage.GO_SDK} label={languageLabelMap.get(SupportedLanguage.GO_SDK)}>
-
-<SdkSetupHeader lang={SupportedLanguage.GO_SDK} />
-
-</TabItem>
-<TabItem value={SupportedLanguage.DOTNET_SDK} label={languageLabelMap.get(SupportedLanguage.DOTNET_SDK)}>
-
-<SdkSetupHeader lang={SupportedLanguage.DOTNET_SDK} />
-
-</TabItem>
-<TabItem value={SupportedLanguage.CURL} label={languageLabelMap.get(SupportedLanguage.CURL)}>
-
-To obtain the [access token](https://auth0.com/docs/authorization/flows/call-your-api-using-the-client-credentials-flow):
-
-<SdkSetupHeader lang={SupportedLanguage.CURL} />
-
-</TabItem>
-</Tabs>
-
-### 02. Calling Write Authorization Model API 
-
 To configure authorization model, we can invoke the [write authorization models API](/api/service#/Authorization%20Models/WriteAuthorizationModel).
 
 <WriteAuthzModelViewer

--- a/docs/content/getting-started/configure-model.mdx
+++ b/docs/content/getting-started/configure-model.mdx
@@ -1,0 +1,160 @@
+---
+title: Configure Authorization Model
+description: How to configure authorization model for a store
+slug: /getting-started/configure-model
+---
+
+import {
+	AuthzModelSnippetViewer,
+    DocumentationNotice,
+    languageLabelMap,
+    ProductName,
+    ProductNameFormat,
+    RelatedSection,
+    SdkSetupHeader,
+    SdkSetupPrerequisite,
+    SupportedLanguage,
+    WriteAuthzModelViewer,
+} from '@components/Docs';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Configure Authorization Model for a Store
+
+<DocumentationNotice />
+
+This article explains how to configure [authorization model](../concepts#what-is-an-authorization-model) to the OpenFGA server for a [store](../concepts#what-is-a-store).
+
+## Before you start
+
+<Tabs groupId="languages">
+{[SupportedLanguage.JS_SDK, SupportedLanguage.GO_SDK, SupportedLanguage.DOTNET_SDK].map(lang =>
+<TabItem value={lang} label={languageLabelMap.get(lang)}>
+
+1. <SdkSetupPrerequisite />
+2. You have [installed the SDK](./install-sdk.mdx), [created the store](./create-store.mdx) and [setup the SDK client](./setup-sdk-client.mdx).
+3. You have loaded `FGA_STORE_ID` and `FGA_API_HOST` as environment variables.
+
+</TabItem>
+)}
+<TabItem value={SupportedLanguage.CURL} label={languageLabelMap.get(SupportedLanguage.CURL)}>
+
+1. <SdkSetupPrerequisite />
+2. You have [created the store](./create-store.mdx) and have loaded `FGA_STORE_ID` and `FGA_API_HOST` as environment variables.
+
+</TabItem>
+</Tabs>
+
+## Step by Step
+
+Assume that you want to configure your store with the following model.
+
+<AuthzModelSnippetViewer
+  configuration={{
+    type_definitions: [
+      {
+        type: 'document',
+        relations: {
+          reader: {
+            this: {},
+          },
+          writer: {
+            this: {},
+          },
+          owner: {
+            this: {},
+          },
+        },
+      },
+    ],
+  }}
+/>
+
+
+### 01. Configure the <ProductName format={ProductNameFormat.ShortForm}/> API client
+
+Before calling the write API, you will need to configure the API client.
+
+<Tabs groupId="languages">
+<TabItem value={SupportedLanguage.JS_SDK} label={languageLabelMap.get(SupportedLanguage.JS_SDK)}>
+
+<SdkSetupHeader lang={SupportedLanguage.JS_SDK} />
+
+</TabItem>
+<TabItem value={SupportedLanguage.GO_SDK} label={languageLabelMap.get(SupportedLanguage.GO_SDK)}>
+
+<SdkSetupHeader lang={SupportedLanguage.GO_SDK} />
+
+</TabItem>
+<TabItem value={SupportedLanguage.DOTNET_SDK} label={languageLabelMap.get(SupportedLanguage.DOTNET_SDK)}>
+
+<SdkSetupHeader lang={SupportedLanguage.DOTNET_SDK} />
+
+</TabItem>
+<TabItem value={SupportedLanguage.CURL} label={languageLabelMap.get(SupportedLanguage.CURL)}>
+
+To obtain the [access token](https://auth0.com/docs/authorization/flows/call-your-api-using-the-client-credentials-flow):
+
+<SdkSetupHeader lang={SupportedLanguage.CURL} />
+
+</TabItem>
+</Tabs>
+
+### 02. Calling Configuration Model API to Configure Authorization Model
+
+To configure authorization model, we can invoke the [authorization models API](/api/service#/Authorization%20Models/WriteAuthorizationModel).
+
+<WriteAuthzModelViewer
+  authorizationModel={{
+    type_definitions: [
+      {
+        type: 'document',
+        relations: {
+          reader: {
+            this: {},
+          },
+          writer: {
+            this: {},
+          },
+          owner: {
+            this: {},
+          },
+        },
+      },
+    ],
+  }}
+  allowedLanguages={[
+    SupportedLanguage.JS_SDK,
+    SupportedLanguage.GO_SDK,
+    SupportedLanguage.DOTNET_SDK,
+    SupportedLanguage.CURL,
+  ]}
+/>
+
+The API will then return the authorization model ID. 
+
+:::info Note
+The OpenFGA API only accepts an authorization model in the API&#39;s JSON syntax.
+
+To convert between the API Syntax and the friendly DSL, you can use the
+[syntax transformer](https://github.com/openfga/syntax-transformer/) or
+[Auth0 FGA's Playground](https://play.fga.dev).
+:::
+
+## Related Section
+
+<RelatedSection
+  description="Take a look at the following section for more on how to configure authorization model in your system"
+  relatedLinks={[
+    {
+      title: 'Getting Started with Modeling',
+      description: 'Read how to get started with modeling.',
+      link: '../modeling/getting-started',
+    },
+    {
+      title: 'Modeling: Direct Relationships',
+      description: 'Read the basics of modeling authorization and granting access to users.',
+      link: '../modeling/direct-access',
+    },
+  ]}
+/>

--- a/docs/content/getting-started/framework.mdx
+++ b/docs/content/getting-started/framework.mdx
@@ -30,7 +30,7 @@ This section will illustrate how to integrate <ProductName format={ProductNameFo
 
 1. <SdkSetupPrerequisite />
 2. You have [installed the OpenFGA SDK](./install-sdk.mdx).
-3. You have [configured the _authorization model_](../modeling) and [updated the _relationship tuples_](./update-tuples.mdx).
+3. You have [configured the _authorization model_](./configure-model.mdx) and [updated the _relationship tuples_](./update-tuples.mdx).
 4. You know how to [perform a Check](./perform-check.mdx).
 5. You have loaded `FGA_API_HOST` and `FGA_STORE_ID` as environment variables.
 
@@ -39,7 +39,7 @@ This section will illustrate how to integrate <ProductName format={ProductNameFo
 
 1. <SdkSetupPrerequisite />
 2. You have [installed the OpenFGA SDK](./install-sdk.mdx).
-3. You have [configured the _authorization model_](../modeling) and [updated the _relationship tuples_](./update-tuples.mdx).
+3. You have [configured the _authorization model_](./configure-model.mdx) and [updated the _relationship tuples_](./update-tuples.mdx).
 4. You know how to [perform a Check](./perform-check.mdx).
 5. You have loaded `FGA_API_HOST` and `FGA_STORE_ID` as environment variables.
 

--- a/docs/content/getting-started/overview.mdx
+++ b/docs/content/getting-started/overview.mdx
@@ -40,7 +40,11 @@ The following will provide a step by step guide on how to get started with <Prod
       description: 'Configure the SDK client for your store.',
       to: 'getting-started/setup-sdk-client',
     },
-    // Future location of adding authorization via SDK
+    {
+      title: 'Configure Authorization Model',
+      description: 'Programmatically configure authorization model for an {ProductName} store.',
+      to: 'getting-started/configure-model',
+    },
     {
       title: 'Update Relationship Tuples',
       description: 'Programmatically write authorization data to an {ProductName} store.',

--- a/docs/content/getting-started/perform-check.mdx
+++ b/docs/content/getting-started/perform-check.mdx
@@ -33,16 +33,16 @@ This section will illustrate how to perform a <ProductConcept section="what-is-a
 
 1. <SdkSetupPrerequisite />
 2. You have [installed the SDK](./install-sdk.mdx).
-3. You have [configured the _authorization model_](../modeling) and [updated the _relationship tuples_](./update-tuples.mdx).
-4. You have loaded `FGA_ENVIRONMENT`, `FGA_STORE_ID`, `FGA_CLIENT_ID` and `FGA_CLIENT_SECRET` as environment variables.
+3. You have [configured the _authorization model_](./configure-model.mdx) and [updated the _relationship tuples_](./update-tuples.mdx).
+4. You have loaded `FGA_STORE_ID` and `FGA_API_HOST` as environment variables.
 
 </TabItem>
 )}
 <TabItem value={SupportedLanguage.CURL} label={languageLabelMap.get(SupportedLanguage.CURL)}>
 
 1. <SdkSetupPrerequisite />
-2. You have [configured the _authorization model_](../modeling) and [updated the _relationship tuples_](./update-tuples.mdx).
-3. You have loaded `FGA_ENVIRONMENT`, `FGA_BEARER_TOKEN` and `FGA_STORE_ID` as environment variables.
+2. You have [configured the _authorization model_](./configure-model.mdx) and [updated the _relationship tuples_](./update-tuples.mdx).
+3. You have loaded `FGA_STORE_ID` and `FGA_API_HOST` as environment variables.
 
 </TabItem>
 </Tabs>

--- a/docs/content/getting-started/update-tuples.mdx
+++ b/docs/content/getting-started/update-tuples.mdx
@@ -33,16 +33,16 @@ This section will illustrate how to update _<ProductConcept section="what-is-a-r
 
 1. <SdkSetupPrerequisite />
 2. You have [installed the SDK](./install-sdk.mdx).
-3. You have [configured the _authorization model_](../modeling).
-4. You have loaded `FGA_ENVIRONMENT`, `FGA_STORE_ID`, `FGA_CLIENT_ID` and `FGA_CLIENT_SECRET` as environment variables.
+3. You have [configured the _authorization model_](./configure-model.mdx).
+4. You have loaded `FGA_STORE_ID` and `FGA_API_HOST` as environment variables.
 
 </TabItem>
 )}
 <TabItem value={SupportedLanguage.CURL} label={languageLabelMap.get(SupportedLanguage.CURL)}>
 
 1. <SdkSetupPrerequisite />
-2. You have [configured the _authorization model_](../modeling).
-3. You have loaded `FGA_ENVIRONMENT`, `FGA_BEARER_TOKEN` and `FGA_STORE_ID` as environment variables.
+2. You have [configured the _authorization model_](./configure-model.mdx).
+3. You have loaded `FGA_STORE_ID` and `FGA_API_HOST` as environment variables.
 
 </TabItem>
 </Tabs>

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -48,6 +48,11 @@ const sidebars = {
         },
         {
           type: 'doc',
+          label: 'Configure Authorization Model',
+          id: 'content/getting-started/configure-model',
+        },
+        {
+          type: 'doc',
           label: 'Update Relationship Tuples',
           id: 'content/getting-started/update-tuples',
         },

--- a/src/components/Docs/SnippetViewer/WriteAuthzModelViewer.tsx
+++ b/src/components/Docs/SnippetViewer/WriteAuthzModelViewer.tsx
@@ -18,7 +18,8 @@ function writeAuthZModelViewerCurl(authorizationModel: AuthorizationModel): stri
 
 function writeAuthZModelViewerJS(authorizationModel: AuthorizationModel): string {
   return `
-await fgaClient.writeAuthorizationModel(${JSON.stringify(authorizationModel, null, 2)});`;
+const { authorization_model_id: id } = await fgaClient.writeAuthorizationModel(${JSON.stringify(authorizationModel, null, 2)});
+// id = "1uHxCSuTP0VKPYSnkq1pbb1jeZw"`;
 }
 
 function writeAuthZModelViewerGo(authorizationModel: AuthorizationModel, apiName: string): string {
@@ -32,10 +33,12 @@ function writeAuthZModelViewerGo(authorizationModel: AuthorizationModel, apiName
       return
   }
 
-  _, response, err := fgaClient.${apiName}.WriteAuthorizationModel(context.Background()).TypeDefinitions(typeDefinitions).Execute()
+  data, response, err := fgaClient.${apiName}.WriteAuthorizationModel(context.Background()).TypeDefinitions(typeDefinitions).Execute()
   if err != nil {
       // .. Handle error
   }
+
+  // data.AuthorizationModelId = "1uHxCSuTP0VKPYSnkq1pbb1jeZw"
   `;
 }
 
@@ -44,7 +47,8 @@ function writeAuthZModelViewerDotnet(authorizationModel: AuthorizationModel): st
   var modelJson = ${JSON.stringify(JSON.stringify(authorizationModel))};
   var body = JsonSerializer.Deserialize<ReadAuthorizationModelsResponse>(modelJson);
 
-  await fgaClient.WriteAuthorizationModel(body);`;
+  var response = await fgaClient.WriteAuthorizationModel(body);
+  // response.AuthorizationModelId = "1uHxCSuTP0VKPYSnkq1pbb1jeZw"`;
 }
 
 function writeAuthZModelViewer(

--- a/src/components/Docs/SnippetViewer/WriteAuthzModelViewer.tsx
+++ b/src/components/Docs/SnippetViewer/WriteAuthzModelViewer.tsx
@@ -18,7 +18,11 @@ function writeAuthZModelViewerCurl(authorizationModel: AuthorizationModel): stri
 
 function writeAuthZModelViewerJS(authorizationModel: AuthorizationModel): string {
   return `
-const { authorization_model_id: id } = await fgaClient.writeAuthorizationModel(${JSON.stringify(authorizationModel, null, 2)});
+const { authorization_model_id: id } = await fgaClient.writeAuthorizationModel(${JSON.stringify(
+    authorizationModel,
+    null,
+    2,
+  )});
 // id = "1uHxCSuTP0VKPYSnkq1pbb1jeZw"`;
 }
 


### PR DESCRIPTION
## Description
Add page in getting-started section on how to configure authorization
model (after store is created and SDK is setup).


https://user-images.githubusercontent.com/10730463/173669118-768d36e6-a525-4182-88d6-3439e7a9cd16.mov



## References
Close https://github.com/openfga/openfga.dev/issues/35


## Review Checklist
- [ ] I have added documentation for new/changed functionality in this PR or in [openfga.dev](https://github.com/openfga/openfga.dev)
- [X] The correct base branch is being used, if not `main`
