### PR TITLE
fix: HeroLogo viewbox wasn't sized properly

### DIFF
--- a/src/features/LandingPage/HeroHeader/HeroLogo.tsx
+++ b/src/features/LandingPage/HeroHeader/HeroLogo.tsx
@@ -10,7 +10,7 @@ const HeroLogo: React.FC<HeroLogoProps> = ({ width = '413', height = '89', class
   <svg
     width={width}
     height={height}
-    viewBox="0 0 471 101"
+    viewBox="0 0 472 101"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
     className={className}


### PR DESCRIPTION
Corrected viewbox of HeroLogo svg so that the trademark doesn't get cut off. ✨ 

Before:
![image](https://user-images.githubusercontent.com/6372810/173830551-56e3ea81-9526-4d45-8e47-76faa3f7968c.png)
![image](https://user-images.githubusercontent.com/6372810/173830571-a68dee46-1ac6-478c-a3b4-82e5f2741867.png)

After:
![image](https://user-images.githubusercontent.com/6372810/173830479-f1ca97a5-0dac-44b2-b13c-192b79160e7b.png)
![Screen Shot 2022-06-15 at 9 47 40 AM](https://user-images.githubusercontent.com/6372810/173830524-49012998-5875-4d8e-bf7e-70ac14555a8a.png)

## References
Closes #76 

## Review Checklist
- [ ] I have added documentation for new/changed functionality in this PR or in [openfga.dev](https://github.com/openfga/openfga.dev)
- [x] The correct base branch is being used, if not `main`
