### PR TITLE
fix: handle slashes at end of URL link

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -16,6 +16,7 @@ const config = {
   tagline: 'Relationship-based access control made fast, scalable, and easy to use.',
   url: 'https://openfga.dev',
   baseUrl: baseUrl,
+  trailingSlash: false,
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',
   favicon: '/img/openfga-icon.svg',


### PR DESCRIPTION

## Description

Allow handling of slashes at the end of the URL link so that it does not lead to 404


https://user-images.githubusercontent.com/10730463/173844983-54cf091c-8137-4b8e-9b02-96e2c6ac0673.mov



## References

Close https://github.com/openfga/openfga.dev/issues/48


## Review Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in [openfga.dev](https://github.com/openfga/openfga.dev)
- [X] The correct base branch is being used, if not `main`
