### PR TITLE
style: format search on mobile (and a little on desktop)

### DIFF
--- a/static/css/openfga.css
+++ b/static/css/openfga.css
@@ -200,9 +200,57 @@ a:visited {
 
 .navbar__search-input {
   border: 1px solid var(--ofga-neutral-light);
-  background: transparent;
-  padding: 0 5rem 0 1rem;
-  width: unset;
+}
+
+.navbar__search-input:focus {
+  border: 1px solid var(--ofga-color-primary-dark);
+  outline: 2px solid var(--ofga-color-primary);
+}
+
+.navbar__search button {
+  color: var(--ofga-neutral-darkest);
+  cursor: pointer;
+}
+
+/* Normally we wouldn't use max-width, but it appears to be neccessary */
+/* here to avoid !important due to Docusaurus styles specificity       */
+@media screen and (max-width: 576px) {
+  .navbar__search-input {
+    background-color: var(--ofga-neutral-light);
+    color: var(--ofga-neutral-darkest);
+  }
+  .navbar__search-input:focus {
+    transition: 0.2s all ease-in-out;
+  }
+  .navbar__search-input:not(:focus) {
+    background-position: center center;
+    color: transparent;
+    cursor: pointer;
+    height: 2rem;
+    padding: 0;
+    transition: 0.2s all ease-in-out;
+    width: 2rem;
+  }
+  .navbar__search button {
+    color: var(--ofga-neutral-darkest);
+    cursor: pointer;
+  }
+  .navbar__search-input:not(:focus)::placeholder {
+    color: transparent;
+  }
+  .navbar__search-input::placeholder {
+    color: var(--ofga-neutral-darkest);
+  }
+}
+@media screen and (min-width: 576px) {
+  .navbar .navbar__search-input {
+    background: transparent;
+    padding: 0 5rem 0 1rem;
+    width: unset;
+  }
+  .navbar__search-input::placeholder {
+    color: var(--ofga-neutral-light);
+  }
 }
 
 /* Sidebar */


### PR DESCRIPTION
Make the search bar less terrible on mobile

## Description
* Unset some bad styling
* Formatted a resting state on mobile that's big enough for a finger to tap
* Formatted a focused state on mobile with themed outline and proper contrast vs text
* Formatted placeholder text on both mobile and desktop breakpoints

[View Before video](https://i.imgur.com/mOeVGv7.mp4)
[View After video](https://i.imgur.com/NS2qRTo.mp4)


## References
Closes #79 

## Review Checklist
- [ ] I have added documentation for new/changed functionality in this PR or in [openfga.dev](https://github.com/openfga/openfga.dev)
- [x] The correct base branch is being used, if not `main`
