### PR TITLE
fix: mobile browser cannot see menu + margin issue

### DIFF
--- a/src/features/LandingPage/ResourcesSection/ResourcesSection.module.css
+++ b/src/features/LandingPage/ResourcesSection/ResourcesSection.module.css
@@ -12,8 +12,14 @@
   /* disable grid template for now until we have updates */
   /* grid-template-columns: 27.5rem 1fr; */
   color: var(--ofga-neutral-darkest);
-  margin: 0 -1.75rem;
+
   padding: 0 3rem;
+}
+
+@media screen and (min-width: 600px) {
+  .container {
+    margin: 0 -1.75rem;
+  }
 }
 
 @media screen and (min-width: 996px) {

--- a/static/css/openfga.css
+++ b/static/css/openfga.css
@@ -396,7 +396,7 @@ a.table-of-contents__link.table-of-contents__link--active {
   display: flex;
   flex-direction: row-reverse;
   justify-content: space-between;
-  width: var(--ifm-container-width-xl);
+  max-width: var(--ifm-container-width-xl);
 }
 
 @media screen and (min-width: 1200px) {


### PR DESCRIPTION
## Description

1. Fix problem where mobile browser cannot see menu.
2. Landing pages require horizontal scaling due to resource section
margin not set properly for mobile browser.


https://user-images.githubusercontent.com/10730463/174092684-6d959bba-9403-4c2b-bc3c-d87b1da6f0f8.mov



## References

- Close https://github.com/openfga/openfga.dev/issues/87
- Close https://github.com/openfga/openfga.dev/issues/78


## Review Checklist
- [ ] I have added documentation for new/changed functionality in this PR or in [openfga.dev](https://github.com/openfga/openfga.dev)
- [x] The correct base branch is being used, if not `main`
