### PR TITLE
chore: update docker running instruction

### DIFF
--- a/docs/content/getting-started/setup-openfga.mdx
+++ b/docs/content/getting-started/setup-openfga.mdx
@@ -19,8 +19,9 @@ This article explains how to start your own OpenFGA server using Docker, and how
 
 If you want to run OpenFGA locally as a Docker container, follow these steps:
 
-1. [Install Docker](https://docs.docker.com/get-docker/).
-2. Run `docker run -p 127.0.0.1:8080:8080 -p 127.0.0.1:8081:8081 openfga/openfga`.
+1. [Install Docker](https://docs.docker.com/get-docker/) if Docker was not already installed.
+2. Run `docker pull openfga/openfga` to get the latest docker image.
+3. Run `docker run -p 8080:8080 openfga/openfga run`.
 
 This will start an HTTP server and gRPC server with the default configuration options.
 


### PR DESCRIPTION
## Description

1. Change to run command `run`.
2. Instruct reader to do `docker pull` to ensure they have the latest image.

## References

To match changes provided by https://github.com/openfga/openfga/pull/48

## Review Checklist
- [ ] I have added documentation for new/changed functionality in this PR or in [openfga.dev](https://github.com/openfga/openfga.dev)
- [X] The correct base branch is being used, if not `main`
