### PR TITLE
fix: disable mobile search bar transition and update width

### DIFF
--- a/static/css/openfga.css
+++ b/static/css/openfga.css
@@ -1,4 +1,4 @@
-/* Custome OpenFGA styling (not ifm vars) */
+/* Custom OpenFGA styling (not ifm vars) */
 
 :root {
   /* Colors */
@@ -212,7 +212,7 @@ a:visited {
   cursor: pointer;
 }
 
-/* Normally we wouldn't use max-width, but it appears to be neccessary */
+/* Normally we wouldn't use max-width, but it appears to be necessary */
 /* here to avoid !important due to Docusaurus styles specificity       */
 @media screen and (max-width: 576px) {
   .navbar__search-input {
@@ -220,7 +220,7 @@ a:visited {
     color: var(--ofga-neutral-darkest);
   }
   .navbar__search-input:focus {
-    transition: 0.2s all ease-in-out;
+    width: 8rem;
   }
   .navbar__search-input:not(:focus) {
     background-position: center center;
@@ -228,7 +228,6 @@ a:visited {
     cursor: pointer;
     height: 2rem;
     padding: 0;
-    transition: 0.2s all ease-in-out;
     width: 2rem;
   }
   .navbar__search button {


### PR DESCRIPTION
## Description

1. Disable mobile search bar's focus/not focus transition as it causes
consecutive transition during initial search.
2. Reduce width of search bar during focus so that it does not block
the logo.

https://user-images.githubusercontent.com/10730463/174353109-8bf21ef1-c772-4d85-8792-2a0fe2cfaf4c.mov

## References

- Close https://github.com/openfga/openfga.dev/issues/103
- Close https://github.com/openfga/openfga.dev/issues/102


## Review Checklist
- [ ] I have added documentation for new/changed functionality in this PR or in [openfga.dev](https://github.com/openfga/openfga.dev)
- [X] The correct base branch is being used, if not `main`
