### PR TITLE
chore: allow npm audit to fail

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -30,6 +30,8 @@ jobs:
 
       - name: Audit dependencies
         run: npm audit
+        # Audit will fail until update-notifier is updated by Docusaurus
+        continue-on-error: true
 
       - name: Check types
         run: npm run typecheck


### PR DESCRIPTION
## Description
Allow `npm audit` to fail due to update-notifier dependency by Docusaurus.


## Review Checklist
- [ ] I have added documentation for new/changed functionality in this PR or in [openfga.dev](https://github.com/openfga/openfga.dev)
- [x] The correct base branch is being used, if not `main`
