### PR TITLE
chore: remove un-needed apiToFriendlySyntaxV1 function

### DIFF
--- a/src/components/Docs/AuthorizationModel/SyntaxTransformer.ts
+++ b/src/components/Docs/AuthorizationModel/SyntaxTransformer.ts
@@ -1,67 +1,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import yaml from 'js-yaml';
 import _ from 'lodash';
 import { TypeDefinitions } from '@openfga/sdk';
 
 import { Keywords } from './Dsl';
-
-const apiToFriendlySyntaxV1 = (config: Record<string, any>) => {
-  const result: Record<string, any> = {};
-
-  for (const entry of Object.entries(config)) {
-    let [key, value]: any = entry;
-
-    switch (key) {
-      case 'difference':
-        key = 'diff';
-        break;
-      case 'intersection':
-        key = 'allOf';
-        value = value.child;
-        break;
-      case 'computedUserset':
-        key = 'usersRelatedToObjectAs';
-        value = value.relation;
-        break;
-      case 'union':
-        key = 'anyOf';
-        value = value.child;
-        break;
-      case 'this':
-        return 'self';
-      case 'tupleToUserset':
-        key = 'fromObjects';
-        break;
-      case 'tupleset':
-        key = 'relatedToObjectAs';
-        value = value.relation;
-        break;
-      default:
-        break;
-    }
-
-    if (Array.isArray(value)) {
-      const xs = [];
-
-      for (const item of value) {
-        xs.push(apiToFriendlySyntaxV1(item));
-      }
-
-      result[key] = xs;
-      continue;
-    }
-
-    if (typeof value === 'object') {
-      result[key] = apiToFriendlySyntaxV1(value);
-      continue;
-    }
-
-    result[key] = value;
-  }
-
-  return result;
-};
 
 const readFrom = (obj, define) => {
   const childKeys = Object.keys(obj);
@@ -168,14 +110,11 @@ const apiToFriendlySyntaxV2 = (config: Record<string, any>, newSyntax: string[] 
 
 export enum SyntaxFormat {
   Api = 'api',
-  Friendly1 = 'friendly_v1',
   Friendly2 = 'friendly_v2',
 }
 
 export const loadSyntax = (configuration: TypeDefinitions, format: SyntaxFormat = SyntaxFormat.Api) => {
   switch (format) {
-    case SyntaxFormat.Friendly1:
-      return yaml.dump(apiToFriendlySyntaxV1(configuration));
     case SyntaxFormat.Friendly2:
       return apiToFriendlySyntaxV2(configuration);
     case SyntaxFormat.Api:


### PR DESCRIPTION
## Description
We do not support Friendly1 syntax. Thus, remove it from syntax
transformer.


## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have added documentation for new/changed functionality in this PR or in [openfga.dev](https://github.com/openfga/openfga.dev)
- [X] The correct base branch is being used, if not `main`
