### PR TITLE
feat: add classes to allow showing and hiding header logo per view/route

### DIFF
--- a/src/features/LandingPage/HeroHeader/index.tsx
+++ b/src/features/LandingPage/HeroHeader/index.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
 
 import styles from './HeroHeader.module.css';
 
@@ -36,7 +37,9 @@ const HeroHeader = () => {
   }, [scrollHandler]);
 
   // Provide a way to identify landing/home page in CSS
-  document.getElementById('__docusaurus').className = 'docs-landing-page';
+  if (ExecutionEnvironment.canUseDOM) {
+    document.getElementById('__docusaurus').className = 'docs-landing-page';
+  }
 
   return (
     <header>

--- a/src/features/LandingPage/HeroHeader/index.tsx
+++ b/src/features/LandingPage/HeroHeader/index.tsx
@@ -35,6 +35,9 @@ const HeroHeader = () => {
     };
   }, [scrollHandler]);
 
+  // Provide a way to identify landing/home page in CSS
+  document.getElementById('__docusaurus').className = 'docs-landing-page';
+
   return (
     <header>
       <div className="container__no-padding">

--- a/src/pages/api/service.tsx
+++ b/src/pages/api/service.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import Layout from '@theme/Layout';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
 
 import { SwaggerUI } from '../../components/SwaggerUI/swagger-ui';
 
@@ -9,7 +10,9 @@ const ApiService = () => {
   const apiDocsBasePath = siteConfig.customFields?.apiDocsBasePath as string | undefined;
 
   // Provide a way to identify API page in CSS
-  document.getElementById('__docusaurus').className = 'docs-api-page';
+  if (ExecutionEnvironment.canUseDOM) {
+    document.getElementById('__docusaurus').className = 'docs-api-page';
+  }
 
   return (
     <Layout title="Open FGA API Explorer">

--- a/src/pages/api/service.tsx
+++ b/src/pages/api/service.tsx
@@ -8,6 +8,9 @@ const ApiService = () => {
   const { siteConfig } = useDocusaurusContext();
   const apiDocsBasePath = siteConfig.customFields?.apiDocsBasePath as string | undefined;
 
+  // Provide a way to identify API page in CSS
+  document.getElementById('__docusaurus').className = 'docs-api-page';
+
   return (
     <Layout title="Open FGA API Explorer">
       <SwaggerUI apiDocsBasePath={apiDocsBasePath} />

--- a/static/css/openfga.css
+++ b/static/css/openfga.css
@@ -107,10 +107,19 @@ a:visited {
 
 .navbar__logo {
   height: 2.6rem;
-  width: 174px;
+  width: 42px;
   overflow: hidden;
   margin-right: 29px;
   transition: all 0.3s ease-in-out;
+}
+
+.docs-doc-page .navbar__logo,
+.docs-api-page .navbar__logo {
+  width: 174px;
+}
+
+html:has('* #quick-start') .navbar__logo {
+  background: red;
 }
 
 .navbar__logo img {
@@ -119,8 +128,8 @@ a:visited {
   height: auto;
 }
 
-.navbar__logo[data-minimal='true'] {
-  width: 42px;
+.navbar__logo[data-minimal='false'] {
+  width: 174px;
 }
 
 .navbar__items {

--- a/static/css/openfga.css
+++ b/static/css/openfga.css
@@ -118,10 +118,6 @@ a:visited {
   width: 174px;
 }
 
-html:has('* #quick-start') .navbar__logo {
-  background: red;
-}
-
 .navbar__logo img {
   max-width: inherit;
   width: 174px;


### PR DESCRIPTION
Added a class to the containing `#__docusaurus` div in order to help identify different views in css rules.

## Description
In order to hide the logomark's text (`OpenFGA`) from view by default on the landing page, and ensure that it shows on the Docs and APIs page, we need a unique identifier that we can use in CSS rules.

Open to any different ideas on how to achieve this, but one line of JS in the respective views seemed simple and durable enough.

## Review Checklist
- [ ] I have added documentation for new/changed functionality in this PR or in [openfga.dev](https://github.com/openfga/openfga.dev)
- [x] The correct base branch is being used, if not `main`
