### PR TITLE
fix: incorrect order of parameters in docker run

### DIFF
--- a/docs/content/getting-started/setup-openfga.mdx
+++ b/docs/content/getting-started/setup-openfga.mdx
@@ -35,7 +35,7 @@ OPENFGA_DATASTORE_ENGINE=postgres
 OPENFGA_AUTH_PRESHARED_KEYS=key1,key2
 # etc
 
-$ docker run openfga/openfga --env-file ./myenv
+$ docker run --env-file ./myenv openfga/openfga run
 ```
 
 All the possible configuration options are:


### PR DESCRIPTION
## Description
The environment variable needs to be before the image name.  In addition, the invocation needs to pass in the option run.

## Review Checklist
- [ ] I have added documentation for new/changed functionality in this PR or in [openfga.dev](https://github.com/openfga/openfga.dev)
- [x] The correct base branch is being used, if not `main`
