### PR TITLE
chore: ignore .dccache file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 .env.development.local
 .env.test.local
 .env.production.local
+.dccache
 
 npm-debug.log*
 yarn-debug.log*


### PR DESCRIPTION
## Description

File is used by Snyk analysis and can be ignored.

## Review Checklist
- [ ] I have added documentation for new/changed functionality in this PR or in [openfga.dev](https://github.com/openfga/openfga.dev)
- [x] The correct base branch is being used, if not `main`
