### PR TITLE
Fixes incorrect endpoint for creating an authorization model

### DIFF
--- a/src/components/Docs/SnippetViewer/WriteAuthzModelViewer.tsx
+++ b/src/components/Docs/SnippetViewer/WriteAuthzModelViewer.tsx
@@ -10,7 +10,7 @@ interface WriteAuthzModelViewerOpts {
 }
 
 function writeAuthZModelViewerCurl(authorizationModel: AuthorizationModel): string {
-  return `curl -X POST $FGA_API_URL/stores/$FGA_STORE_ID/write \\
+  return `curl -X POST $FGA_API_URL/stores/$FGA_STORE_ID/authorization-models \\
   -H "Authorization: Bearer $FGA_BEARER_TOKEN" \\ # Not needed if service does not require authorization
   -H "content-type: application/json" \\
   -d '${JSON.stringify(authorizationModel)}'`;


### PR DESCRIPTION
The current `curl` example for creating an authorization model uses the `/stores/<store_id>/write` endpoint. The correct endpoint is `/stores/<store_id>/authorization-models`.