### PR TITLE
fix: ensure github check action is run on pull request

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -1,6 +1,9 @@
 name: 'Run Checks: Lint, Audit and Build'
 
-on: [push]
+on:
+  pull_request:
+    branches:
+      - main
 
 jobs:
   build:


### PR DESCRIPTION

## Description
Github action `check` did not run if the pull request is from external account.


## References

- Close https://github.com/openfga/openfga.dev/issues/146


## Review Checklist
- [ ] I have added documentation for new/changed functionality in this PR or in [openfga.dev](https://github.com/openfga/openfga.dev)
- [X] The correct base branch is being used, if not `main`
