### PR TITLE
Fix: hero video switch

### DIFF
--- a/src/features/LandingPage/HeroHeader/index.tsx
+++ b/src/features/LandingPage/HeroHeader/index.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
+import BrowserOnly from '@docusaurus/BrowserOnly';
 
 import styles from './HeroHeader.module.css';
 
@@ -44,11 +45,16 @@ const HeroHeader = () => {
   }
 
   // To avoid weird colour issues, force Firefox to use webm, other browsers get mp4
-  const injectVideo = () => {
-    const isFirefox = ExecutionEnvironment.canUseDOM && navigator.userAgent.toLowerCase().includes('firefox');
-
-    return isFirefox ? <source src={patternWebm} type="video/webm" /> : <source src={patternMp4} type="video/mp4" />;
-  };
+  const injectVideo = () => (
+    <BrowserOnly>
+      {() => {
+        if (navigator.userAgent.toLowerCase().includes('firefox')) {
+          return <source src={patternWebm} type="video/webm" />;
+        }
+        return <source src={patternMp4} type="video/mp4" />;
+      }}
+    </BrowserOnly>
+  );
 
   return (
     <header>


### PR DESCRIPTION
The previous strategy for selecting video formats was always evaluating false in a build environment.

## Description
In order to keep the execution environment check from always making our useragent check return false, I'm wrapping the logic in a <BrowserOnly> component instead. Thanks @adriantam for the catch. 🙇 

## References
- Corrects #83 
- Addresses original issue #51 

## Review Checklist
- [ ] I have added documentation for new/changed functionality in this PR or in [openfga.dev](https://github.com/openfga/openfga.dev)
- [x] The correct base branch is being used, if not `main`
