### PR TITLE
feat: reformat favicon to support light/darkmode

### DIFF
--- a/static/img/openfga-icon.svg
+++ b/static/img/openfga-icon.svg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2d1766854c90a69ca461e0ca0b36b4323d284175824d2ee042fe186d4392f130
-size 11963
+oid sha256:2b1d27a35c3108f54ec70390eb3ea25f7ecb8cc3b2dcdb1c08d701b4071ce128
+size 17449


### PR DESCRIPTION
A reformatted SVG favicon based on our original intended design, with some CSS to change the fill colour based on whether the browser is in lightmode or darkmode.

## Description
A nice by-product of this is the actual number of pixels allotted to the logo design is a bit larger, because it doesn't need the framing black shape.

Before: 
![image](https://user-images.githubusercontent.com/6372810/187747600-96ea96c4-f1bc-439b-8687-4c5b4456810e.png)
![image](https://user-images.githubusercontent.com/6372810/187747659-79a38a5f-ad14-474b-8e6c-4fbec60a27c5.png)


After:
![image](https://user-images.githubusercontent.com/6372810/187746339-addc496d-75a0-44c2-b967-27dd1cfb45bc.png)
![image](https://user-images.githubusercontent.com/6372810/187747468-61b1d8ac-49e2-4c10-a700-4aa5c3c6c468.png)


## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
