### PR TITLE
improve docker-compose example

### DIFF
--- a/docs/content/getting-started/setup-openfga.mdx
+++ b/docs/content/getting-started/setup-openfga.mdx
@@ -128,7 +128,10 @@ services:
       pause:
         condition: service_completed_successfully
     command: |
-      migrate --datastore-engine postgres --datastore-uri postgres://postgres:password@db:5432/openfga
+      migrate
+    environment: 
+      - OPENFGA_DATASTORE_ENGINE=postgres
+      - OPENFGA_DATASTORE_URI=postgres://postgres:password@db:5432/openfga
     networks:
       - openfga
 

--- a/docs/content/getting-started/setup-openfga.mdx
+++ b/docs/content/getting-started/setup-openfga.mdx
@@ -157,7 +157,7 @@ services:
 
 In a terminal, navigate to that directory and run:
 ```shell
-docker-compose up openfga
+docker-compose up
 ```
 </TabItem>
 </Tabs>

--- a/docs/content/getting-started/setup-openfga.mdx
+++ b/docs/content/getting-started/setup-openfga.mdx
@@ -115,6 +115,23 @@ services:
       timeout: 5s
       retries: 5
 
+  pause:
+    image: ubuntu
+    command: sleep 5
+    depends_on:
+      db:
+        condition: service_started
+
+  migrate:
+    image: openfga/openfga
+    depends_on:
+      pause:
+        condition: service_completed_successfully
+    command: |
+      migrate --datastore-engine postgres --datastore-uri postgres://postgres:password@db:5432/openfga
+    networks:
+      - openfga
+
   openfga:
     image: openfga/openfga
     environment:
@@ -123,7 +140,10 @@ services:
       - OPENFGA_LOG_FORMAT=json
     command: run
     depends_on:
-      - db
+      db:
+        condition: service_started
+      migrate:
+        condition: service_completed_successfully
     networks:
       - openfga
     ports:
@@ -137,16 +157,12 @@ services:
 
 In a terminal, navigate to that directory and run:
 ```shell
-docker-compose up -d db && \
-  sleep 1 && \
-  docker-compose run openfga migrate \
-    --datastore-engine postgres \
-    --datastore-uri 'postgres://postgres:password@db:5432/postgres' && \
-  docker-compose up openfga
+docker-compose up openfga
 ```
 </TabItem>
 </Tabs>
 
+This will start the postgres database, run `openfga migrate` to configure the database and finally start the OpenFGA server.
 OpenFGA should start and you should see `using 'postgres' storage engine` in the logs.
 
 Now you can try to [Create a Store](./create-store.mdx).


### PR DESCRIPTION
The original docker-compose example didn't work for me. Proposing an improved compose where the migrate command is run inline instead of manually.


## Description
Update the example docker-compose file to run the "migrate" step automatically, instead of having to do that in a separate shell command (which didn't work when I attempted it)

## References

## Review Checklist
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
