### PR TITLE
chore: clarify playground url in openfga server setup

### DIFF
--- a/docs/content/getting-started/setup-openfga.mdx
+++ b/docs/content/getting-started/setup-openfga.mdx
@@ -165,7 +165,7 @@ If you are going to use this setup in production, you should enable TLS in your 
 
 The Playground facilitates rapid development by allowing you to visualize and model your application's authorization model(s) and manage relationship tuples with a locally running OpenFGA instance.
 
-The Playground is enabled on port 3000 by default. To disable the Playground, please take a look at [Configuring the Server](#configuring-the-server) for more information.
+The Playground is enabled on port 3000 by default (if using the docker or docker-compose examples above, the url will be http://localhost:3000/playground). To disable the Playground, please take a look at [Configuring the Server](#configuring-the-server) for more information.
 
 ### Profiler (pprof)
 :::caution Warning

--- a/docs/content/getting-started/setup-openfga.mdx
+++ b/docs/content/getting-started/setup-openfga.mdx
@@ -165,7 +165,7 @@ If you are going to use this setup in production, you should enable TLS in your 
 
 The Playground facilitates rapid development by allowing you to visualize and model your application's authorization model(s) and manage relationship tuples with a locally running OpenFGA instance.
 
-The Playground is enabled on port 3000 by default (if using the docker or docker-compose examples above, the url will be http://localhost:3000/playground). To disable the Playground, please take a look at [Configuring the Server](#configuring-the-server) for more information.
+The Playground is enabled on port 3000 by default and accessible at http://localhost:3000/playground (if using the docker make sure port 3000 is exposed to your local network). To disable the Playground, please take a look at [Configuring the Server](#configuring-the-server) for more information.
 
 ### Profiler (pprof)
 :::caution Warning


### PR DESCRIPTION
It wasn't clear to me that playground is at path `/playground`. Propose to clarify that

## Description
Clarify that "playground" is reachable only on path `/playground`. The existing docs made me thing it would be available at `http://<host>:3000` since only the port number was mentioned

## References


## Review Checklist
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
