### PR TITLE
fix: correct github label in navbar

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -252,7 +252,7 @@ using OpenFga.Sdk.Configuration;`,
           {
             to: 'https://github.com/openfga',
             position: 'right',
-            label: 'Github',
+            label: 'GitHub',
             className: 'header-social header-github-link',
             'aria-label': 'OpenFGA on GitHub',
           },


### PR DESCRIPTION
## Description
GitHub should read GitHub
<img width="390" alt="Screen Shot 2022-09-16 at 10 36 24 AM" src="https://user-images.githubusercontent.com/10730463/190664626-dd85f6b9-4720-4aaa-af79-d998c4e728d6.png">


<img width="2032" alt="Screen Shot 2022-09-16 at 10 31 16 AM" src="https://user-images.githubusercontent.com/10730463/190664088-dd438cb2-1fa9-447e-b08a-0c1f18596bcb.png">


## References
close https://github.com/openfga/openfga.dev/issues/199

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [X] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
