### PR TITLE
fix: correct expand typo + add in explanation with comments

### DIFF
--- a/src/components/Docs/SnippetViewer/ExpandRequestViewer.tsx
+++ b/src/components/Docs/SnippetViewer/ExpandRequestViewer.tsx
@@ -25,11 +25,10 @@ function expandRequestViewer(
 # Response: {"tree": ...}`;
     case SupportedLanguage.JS_SDK:
       return `
-// Expand relation ${opts.relation} for object ${opts.object}
 const { tree } = await fgaClient.expand({
   tuple_key: {
-    relation: '${opts.relation}',
-    object: '${opts.object}',
+    relation: '${opts.relation}', // expand all who has '${opts.relation}' relation
+    object: '${opts.object}', // with the object '${opts.object}'
   },
 });
 
@@ -40,8 +39,8 @@ const { tree } = await fgaClient.expand({
       return `
 body := fgaSdk.ExpandRequest{
 	TupleKey: &fgaSdk.TupleKey{
-		Relation: fgaSdk.PtrString("${opts.relation}"),
-		Object: fgaSdk.PtrString("${opts.object}"),
+		Relation: fgaSdk.PtrString("${opts.relation}"), // expand all who has "${opts.relation}" relation
+		Object: fgaSdk.PtrString("${opts.object}"), // with the object "${opts.object}"
 	},
 }
 data, response, err := fgaClient.${languageMappings['go'].apiName}.Expand(context.Background()).Body(body).Execute()
@@ -52,8 +51,8 @@ data, response, err := fgaClient.${languageMappings['go'].apiName}.Expand(contex
     case SupportedLanguage.DOTNET_SDK:
       return `
 var response = await fgaClient.Expand(new ExpandRequest(new TupleKey() {
-    Relation = "${opts.relation}",
-    Object = "${opts.object}"
+    Relation = "${opts.relation}",  // expand all who has "${opts.relation}" relation
+    Object = "${opts.object}" // with the object "${opts.object}"
 }));
 // response = { tree: ... }`;
     case SupportedLanguage.RPC:

--- a/src/components/Docs/SnippetViewer/ExpandRequestViewer.tsx
+++ b/src/components/Docs/SnippetViewer/ExpandRequestViewer.tsx
@@ -25,7 +25,7 @@ function expandRequestViewer(
 # Response: {"tree": ...}`;
     case SupportedLanguage.JS_SDK:
       return `
-// Run a check
+// Expand relation ${opts.relation} for object ${opts.object}
 const { tree } = await fgaClient.expand({
   tuple_key: {
     relation: '${opts.relation}',


### PR DESCRIPTION

## Description
1. Remove typo in JS comment that indicates expand is check
2. Add in pseudocode comments for explain to improve clarity


https://user-images.githubusercontent.com/10730463/190675169-ea376f3c-55fd-42ab-8ac8-f140ee7d4a62.mov



## References
- Close https://github.com/openfga/openfga.dev/issues/210
- Close https://github.com/openfga/openfga.dev/issues/209

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
