### PR TITLE
chore: static asset should use alias

### DIFF
--- a/docs/content/modeling/getting-started.mdx
+++ b/docs/content/modeling/getting-started.mdx
@@ -21,11 +21,11 @@ import {
   UpdateProductNameInLinks,
 } from '@components/Docs';
 
-import DocIcon from '../../../static/img/getting-started-icon-doc.svg';
-import DirIcon from '../../../static/img/getting-started-icon-dir.svg';
-import OrgIcon from '../../../static/img/getting-started-icon-org.svg';
-import DriveIcon from '../../../static/img/getting-started-icon-drive.svg';
-import FGAIcon from '../../../static/img/getting-started-fga-logo.svg';
+import DocIcon from '@site/static/img/getting-started-icon-doc.svg';
+import DirIcon from '@site/static/img/getting-started-icon-dir.svg';
+import OrgIcon from '@site/static/img/getting-started-icon-org.svg';
+import DriveIcon from '@site/static/img/getting-started-icon-drive.svg';
+import FGAIcon from '@site/static/img/getting-started-fga-logo.svg';
 
 # Get Started with Modeling
 

--- a/src/components/Docs/Feedback/Callout.tsx
+++ b/src/components/Docs/Feedback/Callout.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Link from '@docusaurus/Link';
 import { ColumnLayout } from '../Column';
-import Notifications from '../../../../static/img/Notifications.svg';
-import Pattern from '../../../../static/img/Pattern.svg';
+import Notifications from '@site/static/img/Notifications.svg';
+import Pattern from '@site/static/img/Pattern.svg';
 import styles from './Callout.module.css';
 
 interface FeedbackCalloutProps {

--- a/src/features/LandingPage/FeaturesSection/index.tsx
+++ b/src/features/LandingPage/FeaturesSection/index.tsx
@@ -10,7 +10,7 @@ import {
   OpenAnimatedIcon,
 } from '@components/icons';
 
-import CNCFIcon from '../../../../static/img/cncf-icon-white.svg';
+import CNCFIcon from '@site/static/img/cncf-icon-white.svg';
 
 import styles from './FeaturesSection.module.css';
 import { StyleGrid } from '../StyleGrid';


### PR DESCRIPTION



## Description
Cleanup include by having static asset include to use alias instead of hard coded link

## References
Close https://github.com/openfga/openfga.dev/issues/223
https://docusaurus.io/docs/next/static-assets


## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
