### PR TITLE
chore: switch to use syntax-transformer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@lottiefiles/react-lottie-player": "^3.4.7",
         "@mdx-js/react": "1.6.22",
         "@openfga/sdk": "0.0.2",
+        "@openfga/syntax-transformer": "^0.0.5",
         "assert-never": "1.2.1",
         "clsx": "1.2.1",
         "path-browserify": "1.0.1",
@@ -3213,6 +3214,23 @@
         "axios": "^0.27.2"
       }
     },
+    "node_modules/@openfga/syntax-transformer": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@openfga/syntax-transformer/-/syntax-transformer-0.0.5.tgz",
+      "integrity": "sha512-cZ6ni4tZGl+JT+IClaWABVq09zTlcX/6ToTyk61knhQ+1AZJWOh4TstMZ2TwA+sIEdFtGgdV5iVj58CQ/N8+/A==",
+      "dependencies": {
+        "@openfga/sdk": "^0.1.0",
+        "nearley": "^2.20.1"
+      }
+    },
+    "node_modules/@openfga/syntax-transformer/node_modules/@openfga/sdk": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@openfga/sdk/-/sdk-0.1.0.tgz",
+      "integrity": "sha512-570tI80PPLiMbUS1TgAE9ULQbeo/MdGSdNjEgsAUcBUfvcY8O8/ufWff1oe5jIq8G5g43FbyQjv5rSn6a8qMpQ==",
+      "dependencies": {
+        "axios": "^0.27.2"
+      }
+    },
     "node_modules/@polka/url": {
       "version": "1.0.0-next.21",
       "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.21.tgz",
@@ -6101,6 +6119,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/discontinuous-range": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
+      "integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ=="
     },
     "node_modules/dns-equal": {
       "version": "1.0.0",
@@ -9557,6 +9580,11 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
       "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
+    "node_modules/moo": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.1.tgz",
+      "integrity": "sha512-I1mnb5xn4fO80BH9BLcF0yLypy2UKl+Cb01Fu0hJRkJjlCRtxZMWkTdAtDd5ZqCOxtCkhmRwyI57vWT+1iZ67w=="
+    },
     "node_modules/mrmime": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-1.0.1.tgz",
@@ -9598,6 +9626,52 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "devOptional": true
+    },
+    "node_modules/nearley": {
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
+      "integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
+      "dependencies": {
+        "commander": "^2.19.0",
+        "moo": "^0.5.0",
+        "railroad-diagrams": "^1.0.0",
+        "randexp": "0.4.6"
+      },
+      "bin": {
+        "nearley-railroad": "bin/nearley-railroad.js",
+        "nearley-test": "bin/nearley-test.js",
+        "nearley-unparse": "bin/nearley-unparse.js",
+        "nearleyc": "bin/nearleyc.js"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://nearley.js.org/#give-to-nearley"
+      }
+    },
+    "node_modules/nearley/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+    },
+    "node_modules/nearley/node_modules/randexp": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
+      "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
+      "dependencies": {
+        "discontinuous-range": "1.0.0",
+        "ret": "~0.1.10"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/nearley/node_modules/ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "engines": {
+        "node": ">=0.12"
+      }
     },
     "node_modules/negotiator": {
       "version": "0.6.3",
@@ -11093,6 +11167,11 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/railroad-diagrams": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
+      "integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A=="
     },
     "node_modules/randexp": {
       "version": "0.5.3",
@@ -16821,6 +16900,25 @@
         "axios": "^0.27.2"
       }
     },
+    "@openfga/syntax-transformer": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@openfga/syntax-transformer/-/syntax-transformer-0.0.5.tgz",
+      "integrity": "sha512-cZ6ni4tZGl+JT+IClaWABVq09zTlcX/6ToTyk61knhQ+1AZJWOh4TstMZ2TwA+sIEdFtGgdV5iVj58CQ/N8+/A==",
+      "requires": {
+        "@openfga/sdk": "^0.1.0",
+        "nearley": "^2.20.1"
+      },
+      "dependencies": {
+        "@openfga/sdk": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/@openfga/sdk/-/sdk-0.1.0.tgz",
+          "integrity": "sha512-570tI80PPLiMbUS1TgAE9ULQbeo/MdGSdNjEgsAUcBUfvcY8O8/ufWff1oe5jIq8G5g43FbyQjv5rSn6a8qMpQ==",
+          "requires": {
+            "axios": "^0.27.2"
+          }
+        }
+      }
+    },
     "@polka/url": {
       "version": "1.0.0-next.21",
       "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.21.tgz",
@@ -18918,6 +19016,11 @@
       "requires": {
         "path-type": "^4.0.0"
       }
+    },
+    "discontinuous-range": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
+      "integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ=="
     },
     "dns-equal": {
       "version": "1.0.0",
@@ -21412,6 +21515,11 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
       "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
+    "moo": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.1.tgz",
+      "integrity": "sha512-I1mnb5xn4fO80BH9BLcF0yLypy2UKl+Cb01Fu0hJRkJjlCRtxZMWkTdAtDd5ZqCOxtCkhmRwyI57vWT+1iZ67w=="
+    },
     "mrmime": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-1.0.1.tgz",
@@ -21441,6 +21549,38 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "devOptional": true
+    },
+    "nearley": {
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
+      "integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
+      "requires": {
+        "commander": "^2.19.0",
+        "moo": "^0.5.0",
+        "railroad-diagrams": "^1.0.0",
+        "randexp": "0.4.6"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+        },
+        "randexp": {
+          "version": "0.4.6",
+          "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
+          "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
+          "requires": {
+            "discontinuous-range": "1.0.0",
+            "ret": "~0.1.10"
+          }
+        },
+        "ret": {
+          "version": "0.1.15",
+          "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+          "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
+        }
+      }
     },
     "negotiator": {
       "version": "0.6.3",
@@ -22431,6 +22571,11 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
+    },
+    "railroad-diagrams": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
+      "integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A=="
     },
     "randexp": {
       "version": "0.5.3",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@lottiefiles/react-lottie-player": "^3.4.7",
     "@mdx-js/react": "1.6.22",
     "@openfga/sdk": "0.0.2",
+    "@openfga/syntax-transformer": "^0.0.5",
     "assert-never": "1.2.1",
     "clsx": "1.2.1",
     "path-browserify": "1.0.1",

--- a/src/components/Docs/AuthorizationModel/SyntaxTransformer.ts
+++ b/src/components/Docs/AuthorizationModel/SyntaxTransformer.ts
@@ -2,7 +2,7 @@
 
 import _ from 'lodash';
 import { TypeDefinitions } from '@openfga/sdk';
-import { apiSyntaxToFriendlySyntax } from "@openfga/syntax-transformer";
+import { apiSyntaxToFriendlySyntax } from '@openfga/syntax-transformer';
 
 export enum SyntaxFormat {
   Api = 'api',

--- a/src/components/Docs/AuthorizationModel/SyntaxTransformer.ts
+++ b/src/components/Docs/AuthorizationModel/SyntaxTransformer.ts
@@ -2,111 +2,7 @@
 
 import _ from 'lodash';
 import { TypeDefinitions } from '@openfga/sdk';
-
-import { Keywords } from './Dsl';
-
-const readFrom = (obj, define) => {
-  const childKeys = Object.keys(obj);
-
-  _.forEach(childKeys, (childKey: string) => {
-    if (childKey === 'this') {
-      define.push(Keywords.SELF);
-    }
-
-    if (childKey === 'tupleToUserset') {
-      define.push(`${obj[childKey].computedUserset.relation} ${Keywords.FROM} ${obj[childKey].tupleset.relation}`);
-    }
-
-    if (childKey === 'computedUserset') {
-      define.push(`${obj[childKey].relation}`);
-    }
-  });
-};
-
-const apiToFriendlyV2Relation = (
-  relation: string,
-  relationDefinition: any,
-  relations: string[],
-  idx: number,
-  newSyntax: string[],
-) => {
-  const relationKeys = Object.keys(relationDefinition);
-  const define = [`    ${Keywords.DEFINE} ${relation}${relationKeys?.length ? ` ${Keywords.AS} ` : ''}`];
-
-  // Read simple definitions
-  readFrom(relationDefinition, define);
-
-  _.forEach(relationKeys, (relationKey: any) => {
-    if (relationKey === 'union') {
-      const children = relationDefinition[relationKey].child;
-      _.forEach(children, (child: any, idx: number) => {
-        readFrom(child, define);
-
-        if (idx < children.length - 1) {
-          define.push(` ${Keywords.OR} `);
-        }
-      });
-    }
-
-    if (relationKey === 'intersection') {
-      const children = relationDefinition[relationKey].child;
-      _.forEach(children, (child: any, idx: number) => {
-        readFrom(child, define);
-
-        if (idx < children.length - 1) {
-          define.push(` ${Keywords.AND} `);
-        }
-      });
-    }
-
-    if (relationKey === 'difference') {
-      const { base, subtract } = relationDefinition[relationKey];
-
-      readFrom(base, define);
-      define.push(` ${Keywords.BUT_NOT} `);
-      readFrom(subtract, define);
-    }
-  });
-
-  if (relations.length === idx + 1) {
-    // define.push("\n");
-  }
-
-  newSyntax.push(define.join(''));
-};
-
-const apiToFriendlyV2Type = (typeDef: Record<string, any>, newSyntax: string[]) => {
-  if (typeDef.relations) {
-    newSyntax.push(`${Keywords.NAMESPACE} ${typeDef.name || typeDef.type}`);
-    if (Object.keys(typeDef.relations).length) {
-      newSyntax.push(`  ${Keywords.RELATIONS}`);
-
-      const relations = Object.keys(typeDef.relations);
-
-      _.forEach(relations, (relation: any, idx: number) => {
-        const relationDefinition = typeDef.relations[relation];
-        apiToFriendlyV2Relation(relation, relationDefinition, relations, idx, newSyntax);
-      });
-    }
-  } else {
-    const relations = Object.keys(typeDef);
-    const relation = relations[0];
-    apiToFriendlyV2Relation(relation, typeDef[relation], relations, 0, newSyntax);
-  }
-};
-
-const apiToFriendlySyntaxV2 = (config: Record<string, any>, newSyntax: string[] = []) => {
-  const typeDefs = config.namespaces || config.type_definitions;
-  if (typeDefs) {
-    _.forEach(typeDefs, (typeDef: any) => {
-      apiToFriendlySyntaxV2(typeDef, newSyntax);
-    });
-  } else {
-    apiToFriendlyV2Type(config, newSyntax);
-  }
-
-  return newSyntax.join('\n') + '\n';
-};
+import { apiSyntaxToFriendlySyntax } from "@openfga/syntax-transformer";
 
 export enum SyntaxFormat {
   Api = 'api',
@@ -116,7 +12,7 @@ export enum SyntaxFormat {
 export const loadSyntax = (configuration: TypeDefinitions, format: SyntaxFormat = SyntaxFormat.Api) => {
   switch (format) {
     case SyntaxFormat.Friendly2:
-      return apiToFriendlySyntaxV2(configuration);
+      return apiSyntaxToFriendlySyntax(configuration);
     case SyntaxFormat.Api:
     default:
       return JSON.stringify(configuration, null, '  ');


### PR DESCRIPTION
## Description
Switch to use openfga's syntax-transformer when switching between model

## References
Close https://github.com/openfga/openfga.dev/issues/16


## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
