### PR TITLE
fix: incorrect golang check callout

### DIFF
--- a/src/components/Docs/SnippetViewer/CheckRequestViewer.tsx
+++ b/src/components/Docs/SnippetViewer/CheckRequestViewer.tsx
@@ -59,7 +59,8 @@ const { allowed } = await fgaClient.check({
     object: '${object}',
   },${
     !contextualTuples
-      ? ''
+      ? `
+`
       : `
   contextual_tuples: {
     tuple_keys: [${contextualTuples
@@ -102,7 +103,8 @@ ${contextualTuples
 \t\t}
 \t}
 }`
-          : ''
+          : `
+}`
       }
 data, response, err := fgaClient.${languageMappings['go'].apiName}.Check(context.Background()).Body(body).Execute()
 


### PR DESCRIPTION

## Description

Check was missing closing bracket if there are no context 


https://user-images.githubusercontent.com/10730463/194071888-04d5eaa4-7e33-4d5d-b3ac-44f1e178d3b7.mov


https://user-images.githubusercontent.com/10730463/194071906-954c6729-ebca-4487-b642-287725a1d12f.mov


## References
Close https://github.com/openfga/openfga.dev/issues/228


## Review Checklist
- [X] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [X] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
