### PR TITLE
chore: extend synk ignore for SNYK-JS-GOT-2932019

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -2,34 +2,25 @@
 version: v1.22.1
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
-  SNYK-JS-AUTOLINKER-2438289:
-    - swagger-ui-react > remarkable > autolinker:
-        reason: >-
-          Autolinker issue described
-          [here](https://github.com/gregjacobs/Autolinker.js/issues/377) does
-          not affect this project. openfga.dev does not accept untrusted user
-          input. Any changes here have to go through a pull request review
-          process.
-        expires: '2022-09-30T23:59:59.999Z'
   SNYK-JS-GOT-2932019:
     - '@docusaurus/core > update-notifier > latest-version > package-json > got':
         reason: >-
           Links are defined at build time. Any updates to them have to go
           through a PR review process.
-        expires: '2022-09-30T23:59:59.999Z'
+        expires: '2022-12-31T23:59:59.999Z'
     - '@docusaurus/plugin-client-redirects > @docusaurus/core > update-notifier > latest-version > package-json > got':
         reason: >-
           Links are defined at build time. Any updates to them have to go
           through a PR review process.
-        expires: '2022-09-30T23:59:59.999Z'
+        expires: '2022-12-31T23:59:59.999Z'
     - '@docusaurus/preset-classic > @docusaurus/core > update-notifier > latest-version > package-json > got':
         reason: >-
           Links are defined at build time. Any updates to them have to go
           through a PR review process.
-        expires: '2022-09-30T23:59:59.999Z'
+        expires: '2022-12-31T23:59:59.999Z'
     - '@easyops-cn/docusaurus-search-local > @docusaurus/plugin-content-docs > @docusaurus/core > update-notifier > latest-version > package-json > got':
         reason: >-
           Links are defined at build time. Any updates to them have to go
           through a PR review process.
-        expires: '2022-09-30T23:59:59.999Z'
+        expires: '2022-12-31T23:59:59.999Z'
 patch: {}

--- a/.snyk
+++ b/.snyk
@@ -1,6 +1,6 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
 version: v1.22.1
-# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date.
 ignore:
   SNYK-JS-GOT-2932019:
     - '@docusaurus/core > update-notifier > latest-version > package-json > got':


### PR DESCRIPTION

## Description
Extend to end of year as the underlying docusaurus still use an out of date update-notifier due to presence of non-ES modules.


## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
