### PR TITLE
fix: correct JS callout for read

### DIFF
--- a/src/components/Docs/SnippetViewer/ReadRequestViewer.tsx
+++ b/src/components/Docs/SnippetViewer/ReadRequestViewer.tsx
@@ -46,9 +46,9 @@ function readRequestViewer(lang: SupportedLanguage, opts: ReadRequestViewerOpts,
 
     case SupportedLanguage.JS_SDK: {
       const requestTuples =
-        (opts.user ? `    user:'${opts.user},\n` : '') +
+        (opts.user ? `    user:'${opts.user}',\n` : '') +
         (opts.relation ? `    relation:'${opts.relation}',\n` : '') +
-        `    object:'${opts.object}',\n`;
+        `    object:'${opts.object}',`;
       return `
 // Execute a read
 const { tuples } = await fgaClient.read({
@@ -81,14 +81,14 @@ data, response, err := fgaClient.${languageMappings['go'].apiName}.Read(context.
 
     case SupportedLanguage.DOTNET_SDK: {
       const requestTuples =
-        (opts.user ? `User = "${opts.user}",\n` : '') +
-        (opts.relation ? `Relation = "${opts.relation}",\n` : '') +
-        `Object = "${opts.object}",\n`;
+        (opts.user ? `  User = "${opts.user}",\n` : '') +
+        (opts.relation ? `  Relation = "${opts.relation}",\n` : '') +
+        `  Object = "${opts.object}",`;
 
       /* eslint-disable no-tabs */
       return `
 var response = fgaClient.Read(new ReadRequest(new TupleKey() {
-  ${requestTuples}
+${requestTuples}
 }));
 
 // data = { "tuples": [${readTuples}] }`;


### PR DESCRIPTION
## Description
Correct JS callout for read by ensuring there is a closing quote.  Also updated spacing for .NET SDK read callout

<img width="2032" alt="Screen Shot 2022-10-06 at 10 14 31 PM" src="https://user-images.githubusercontent.com/10730463/194452373-f9c3bafe-3ce1-4edc-b304-34ac907395f9.png">
<img width="1988" alt="Screen Shot 2022-10-06 at 10 14 19 PM" src="https://user-images.githubusercontent.com/10730463/194452375-a521a163-ca89-47d7-a8f6-efd4fc9596f3.png">

## References
Close https://github.com/openfga/openfga.dev/issues/231

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
