### PR TITLE
chore: tag model schema as version 1.1

### DIFF
--- a/docs/content/concepts.mdx
+++ b/docs/content/concepts.mdx
@@ -99,6 +99,7 @@ Code snippet below is an example of an authorization model:
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'document',
@@ -262,6 +263,7 @@ These would be defined in the [authorization model](#what-is-an-authorization-mo
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'document',
@@ -320,6 +322,7 @@ For the following model, only [relationship tuple](#what-is-a-relationship-tuple
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'document',
@@ -344,7 +347,6 @@ For the following model, only [relationship tuple](#what-is-a-relationship-tuple
 Relationship tuple with user `user:anne` or `user:3f7768e0-4fa7-4e93-8417-4da68ce1846c` may be written for objects with type `document` and relation `viewer`, so writing `{"user": "user:anne","relation":"viewer","object":"document:roadmap"}` will succeed.
 Relationship tuple writes with user type that is not allowed for the `viewer` relation on objects of type `document`, for example `workspace:auth0` or `folder:planning#editor` will be rejected, so writing `{"user": "folder:product","relation":"viewer","object":"document:roadmap"}` will fail.
 This will affect only relations that are [directly related](#what-are-direct-and-implied-relationships) and have [the direct relationship keyword ("this")](./configuration-language.mdx#the-direct-relationship-keyword) in their relation definition.
-
 
 </details>
 
@@ -452,6 +454,7 @@ An **implied (or computed) relationship** R exists between user X and object Y i
 
   <AuthzModelSnippetViewer
     configuration={{
+      schema_version: '1.1',
       type_definitions: [
         {
           type: 'document',

--- a/docs/content/configuration-language.mdx
+++ b/docs/content/configuration-language.mdx
@@ -34,6 +34,7 @@ Below is a sample authorization model. In the next sections we'll go over the bu
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'user',
@@ -439,6 +440,7 @@ Take a look at the _authorization model_ below.
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'user',
@@ -497,6 +499,7 @@ The snippet below taken from the authorization model above is stating that viewe
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'document',
@@ -574,6 +577,7 @@ The _union operator_ (`or` in the DSL, `union` in the JSON syntax) is used to in
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'document',
@@ -647,6 +651,7 @@ The _intersection operator_ (`and` in the DSL, `intersection` in the JSON syntax
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'document',
@@ -730,6 +735,7 @@ The _exclusion operator_ (`but not` in the DSL, `difference` in the JSON syntax)
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'document',
@@ -851,6 +857,7 @@ In the <ProductName format={ProductNameFormat.ShortForm}/> DSL, it would become:
 <AuthzModelSnippetViewer
   onlyShow={SyntaxFormat.Friendly2}
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'doc',
@@ -914,6 +921,7 @@ And in the <ProductName format={ProductNameFormat.ShortForm}/> JSON, it would be
 <AuthzModelSnippetViewer
   onlyShow={SyntaxFormat.Api}
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'doc',
@@ -978,6 +986,7 @@ So the following:
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'doc',

--- a/docs/content/getting-started/configure-model.mdx
+++ b/docs/content/getting-started/configure-model.mdx
@@ -5,17 +5,17 @@ slug: /getting-started/configure-model
 ---
 
 import {
-    AuthzModelSnippetViewer,
-    DocumentationNotice,
-    languageLabelMap,
-    ProductConcept,
-    ProductName,
-    ProductNameFormat,
-    RelatedSection,
-    SdkSetupHeader,
-    SdkSetupPrerequisite,
-    SupportedLanguage,
-    WriteAuthzModelViewer,
+  AuthzModelSnippetViewer,
+  DocumentationNotice,
+  languageLabelMap,
+  ProductConcept,
+  ProductName,
+  ProductNameFormat,
+  RelatedSection,
+  SdkSetupHeader,
+  SdkSetupPrerequisite,
+  SupportedLanguage,
+  WriteAuthzModelViewer,
 } from '@components/Docs';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
@@ -52,6 +52,7 @@ Assume that you want to configure your store with the following model.
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'user',
@@ -81,11 +82,11 @@ Assume that you want to configure your store with the following model.
   }}
 />
 
-
 To configure authorization model, we can invoke the [write authorization models API](/api/service#Authorization%20Models/WriteAuthorizationModel).
 
 <WriteAuthzModelViewer
   authorizationModel={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'document',
@@ -119,7 +120,7 @@ To configure authorization model, we can invoke the [write authorization models 
   ]}
 />
 
-The API will then return the authorization model ID. 
+The API will then return the authorization model ID.
 
 :::info Note
 The OpenFGA API only accepts an authorization model in the API&#39;s JSON syntax.

--- a/docs/content/interacting/managing-group-access.mdx
+++ b/docs/content/interacting/managing-group-access.mdx
@@ -52,6 +52,7 @@ You have two <ProductConcept section="what-is-a-type" linkName="types" />:
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'user',
@@ -65,7 +66,7 @@ You have two <ProductConcept section="what-is-a-type" linkName="types" />:
         },
         metadata: {
           relations: {
-            employee: { directly_related_user_types: [{type: 'user'}] },
+            employee: { directly_related_user_types: [{ type: 'user' }] },
           },
         },
       },
@@ -78,7 +79,7 @@ You have two <ProductConcept section="what-is-a-type" linkName="types" />:
         },
         metadata: {
           relations: {
-            reader: { directly_related_user_types: [{type: 'company', relation: 'employee'}] },
+            reader: { directly_related_user_types: [{ type: 'company', relation: 'employee' }] },
           },
         },
       },

--- a/docs/content/interacting/managing-group-membership.mdx
+++ b/docs/content/interacting/managing-group-membership.mdx
@@ -52,6 +52,7 @@ You have two <ProductConcept section="what-is-a-type" linkName="types" />:
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'user',
@@ -65,7 +66,7 @@ You have two <ProductConcept section="what-is-a-type" linkName="types" />:
         },
         metadata: {
           relations: {
-            member: { directly_related_user_types: [{type: 'user'}] },
+            member: { directly_related_user_types: [{ type: 'user' }] },
           },
         },
       },
@@ -78,7 +79,7 @@ You have two <ProductConcept section="what-is-a-type" linkName="types" />:
         },
         metadata: {
           relations: {
-            reader: { directly_related_user_types: [{type: 'org', relation: 'member'}] },
+            reader: { directly_related_user_types: [{ type: 'org', relation: 'member' }] },
           },
         },
       },

--- a/docs/content/interacting/managing-relationships-between-objects.mdx
+++ b/docs/content/interacting/managing-relationships-between-objects.mdx
@@ -45,6 +45,7 @@ Assume that you have the following <ProductConcept section="what-is-an-authoriza
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'user',
@@ -58,7 +59,7 @@ Assume that you have the following <ProductConcept section="what-is-an-authoriza
         },
         metadata: {
           relations: {
-            admin: { directly_related_user_types: [{type: 'user'}] },
+            admin: { directly_related_user_types: [{ type: 'user' }] },
           },
         },
       },
@@ -111,6 +112,7 @@ Another way of modeling this is to have an authorization model as follows:
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'user',
@@ -145,8 +147,8 @@ Another way of modeling this is to have an authorization model as follows:
         },
         metadata: {
           relations: {
-            owner: { directly_related_user_types: [{type: 'org'}] },
-            admin: { directly_related_user_types: [{type: 'user'}] },
+            owner: { directly_related_user_types: [{ type: 'org' }] },
+            admin: { directly_related_user_types: [{ type: 'user' }] },
           },
         },
       },
@@ -159,7 +161,7 @@ Another way of modeling this is to have an authorization model as follows:
         },
         metadata: {
           relations: {
-            repo_admin: { directly_related_user_types: [{type: 'user'}] },
+            repo_admin: { directly_related_user_types: [{ type: 'user' }] },
           },
         },
       },

--- a/docs/content/interacting/managing-user-access.mdx
+++ b/docs/content/interacting/managing-user-access.mdx
@@ -24,7 +24,7 @@ In this guide you will learn how to give a <ProductConcept section="what-is-a-us
 
 <CardBox title="When to use" appearance="filled" description=<div>
 
-Granting access with a *<ProductConcept section="what-is-a-relationship-tuple" linkName="relationship tuple" />* is a core part of <ProductName format={ProductNameFormat.ShortForm}/>. Without any relationship tuples, any _<ProductConcept section="what-is-a-check-request" linkName="check" />_ will fail. You should use:
+Granting access with a _<ProductConcept section="what-is-a-relationship-tuple" linkName="relationship tuple" />_ is a core part of <ProductName format={ProductNameFormat.ShortForm}/>. Without any relationship tuples, any _<ProductConcept section="what-is-a-check-request" linkName="check" />_ will fail. You should use:
 
 - _authorization model_ to represent what **relation**s are possible between the users and objects in your system
 - _relationship tuples_ to represent the facts about the relationships between users and objects in your system.
@@ -45,6 +45,7 @@ You have a <ProductConcept section="what-is-a-type" linkName="type" /> called `t
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'user',
@@ -58,7 +59,7 @@ You have a <ProductConcept section="what-is-a-type" linkName="type" /> called `t
         },
         metadata: {
           relations: {
-            reader: { directly_related_user_types: [{type: 'user'}] },
+            reader: { directly_related_user_types: [{ type: 'user' }] },
           },
         },
       },

--- a/docs/content/interacting/read-tuple-changes.mdx
+++ b/docs/content/interacting/read-tuple-changes.mdx
@@ -151,6 +151,7 @@ Once there are no more changes to retrieve, the API will return the same token a
 - The default page size is 50. The maximum page size allowed is 100.
 - The API response will not return all the changes immediately. There will be a delay of one minute between the time that you add or delete a tuple and the time that you see it in the Read Changes API response.
 - The API response does not expand the tuples. If you wrote a tuple that includes a userset, like `{"user": "group:abc#member", "relation": "owner": "doc:budget"}`, the Read Changes API will return that exact tuple.
+
 :::
 
 ### 03. Get Changes For A Specific Object Type
@@ -159,6 +160,7 @@ Imagine you have the following authorization model:
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'user',
@@ -172,7 +174,7 @@ Imagine you have the following authorization model:
         },
         metadata: {
           relations: {
-            member: { directly_related_user_types: [{type: 'user'}] },
+            member: { directly_related_user_types: [{ type: 'user' }] },
           },
         },
       },
@@ -185,7 +187,7 @@ Imagine you have the following authorization model:
         },
         metadata: {
           relations: {
-            owner: { directly_related_user_types: [{type: 'group', relation: 'member'}, {type: 'user'}] },
+            owner: { directly_related_user_types: [{ type: 'group', relation: 'member' }, { type: 'user' }] },
           },
         },
       },
@@ -198,7 +200,7 @@ Imagine you have the following authorization model:
         },
         metadata: {
           relations: {
-            owner: { directly_related_user_types: [{type: 'group', relation: 'member'}, {type: 'user'}] },
+            owner: { directly_related_user_types: [{ type: 'group', relation: 'member' }, { type: 'user' }] },
           },
         },
       },

--- a/docs/content/interacting/relationship-queries.mdx
+++ b/docs/content/interacting/relationship-queries.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Relationship Queries: Check, Read, Expand, and ListObjects"
+title: 'Relationship Queries: Check, Read, Expand, and ListObjects'
 sidebar_position: 6
 slug: /interacting/relationship-queries
 description: An overview of how to use the Check, Read, Expand, and ListObject APIs.
@@ -40,6 +40,7 @@ and `writer`. All writers are readers. `bob` has a `writer` relationship with `d
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'user',
@@ -68,8 +69,8 @@ and `writer`. All writers are readers. `bob` has a `writer` relationship with `d
         },
         metadata: {
           relations: {
-            writer: { directly_related_user_types: [{type: 'user'}] },
-            reader: { directly_related_user_types: [{type: 'user'}] },
+            writer: { directly_related_user_types: [{ type: 'user' }] },
+            reader: { directly_related_user_types: [{ type: 'user' }] },
           },
         },
       },
@@ -273,7 +274,6 @@ From there, we will learn that
 - those related to `document:planning` as `reader` are all those who are related to that document as `writer`
 - `bob` is related to `document:planning` as `writer`
 
-
 ### Caveats And When Not To Use It
 
 The Expand call is expensive and has high latency. As such, it is designed to be used for debugging and understanding why a user has a particular relationship with a specific object. It is not designed for checking whether a user has a particular relationship with a specific object. In that case the Check API call should be used instead.
@@ -294,7 +294,13 @@ The current implementation of List Objects API is not optimized and can return i
 
 Use the ListObjects API to get what objects a user can see based on the relationships they have. See [Search with Permissions](./search-with-permissions.mdx) for more guidance.
 
-<ListObjectsRequestViewer objectType="document" relation="reader" user="user:bob" contextualTuples={[{object: "document:otherdoc", relation: "reader", "user": "user:bob"}]} expectedResults={["otherdoc", "planning"]} />
+<ListObjectsRequestViewer
+  objectType="document"
+  relation="reader"
+  user="user:bob"
+  contextualTuples={[{ object: 'document:otherdoc', relation: 'reader', user: 'user:bob' }]}
+  expectedResults={['otherdoc', 'planning']}
+/>
 
 There's two variations of the List Objects API.
 
@@ -318,7 +324,7 @@ This API is provided to gather your feedback. Due to performance and high-latenc
 
 |             | Check                                                         | Read                                                   | Expand                                                  | ListObjects                                                                        |
 | ----------- | ------------------------------------------------------------- | ------------------------------------------------------ | ------------------------------------------------------- | ---------------------------------------------------------------------------------- |
-| Purpose     | Check if user has particular relationship with certain object | Return all stored relationship tuples that match query | Expand the specific relationship on a particular object | List all objects of a particular type that a user has a specific relationship with |            |
+| Purpose     | Check if user has particular relationship with certain object | Return all stored relationship tuples that match query | Expand the specific relationship on a particular object | List all objects of a particular type that a user has a specific relationship with |
 | When to use | Validate if user X can perform Y on object Z                  | List stored relationships in system                    | Understand why user X can perform Y on object Z         | Filter the objects a user has access to                                            |
 
 ## Related Sections
@@ -344,7 +350,7 @@ This API is provided to gather your feedback. Due to performance and high-latenc
     {
       title: 'ListObjects API Reference',
       description: 'Official reference guide for the ListObjects API',
-      link: '/api/service#Relationship%20Queries/ListObjects',      
+      link: '/api/service#Relationship%20Queries/ListObjects',
     },
   ]}
 />

--- a/docs/content/interacting/transactional-writes.mdx
+++ b/docs/content/interacting/transactional-writes.mdx
@@ -42,6 +42,7 @@ You have another type called `user` that can have a `follower` and `followed_by`
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'tweet',
@@ -53,10 +54,7 @@ You have another type called `user` that can have a `follower` and `followed_by`
         metadata: {
           relations: {
             owner: {
-              directly_related_user_types: [
-                { type: 'user' },
-                { type: 'user', relation: 'follower' },
-              ],
+              directly_related_user_types: [{ type: 'user' }, { type: 'user', relation: 'follower' }],
             },
           },
         },

--- a/docs/content/modeling/advanced/entitlements.mdx
+++ b/docs/content/modeling/advanced/entitlements.mdx
@@ -139,6 +139,7 @@ Similar to the example above, start with a basic listing of the types and their 
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'user',
@@ -362,6 +363,7 @@ The resulting updated configuration would be:
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'user',
@@ -484,9 +486,7 @@ If you want to give all subscribers on a plan access to a feature, you can do it
       relations: {
         associated_plan: { directly_related_user_types: [{ type: 'plan' }] },
         access: {
-          directly_related_user_types: [
-            { type: 'user' },
-          ],
+          directly_related_user_types: [{ type: 'user' }],
         },
       },
     },
@@ -523,6 +523,7 @@ Replace all the existing code you had previously with the updated authorization 
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'user',
@@ -557,9 +558,7 @@ Replace all the existing code you had previously with the updated authorization 
           relations: {
             associated_plan: { directly_related_user_types: [{ type: 'plan' }] },
             access: {
-              directly_related_user_types: [
-                { type: 'user' },
-              ],
+              directly_related_user_types: [{ type: 'user' }],
             },
           },
         },
@@ -608,6 +607,7 @@ In order to do that, you will add a relation on the plan, that indicates that al
   description={`Notice that \`subscriber\` has been updated to \`subscriber_member\` in the \`access\` relation of the \`feature\` type.
   Under the \`plan\` type, in order for someone to have a \`subscriber_member\` relation to the plan, they have to be related as a \`member\` to the object related as a \`subscriber\` to the plan (as in they have to be a member of on of the plan's subscribers).`}
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'user',
@@ -642,9 +642,7 @@ In order to do that, you will add a relation on the plan, that indicates that al
           relations: {
             associated_plan: { directly_related_user_types: [{ type: 'plan' }] },
             access: {
-              directly_related_user_types: [
-                { type: 'user' },
-              ],
+              directly_related_user_types: [{ type: 'user' }],
             },
           },
         },
@@ -743,9 +741,7 @@ To disallow a direct relationship, you need to remove `self`. The following snip
       relations: {
         associated_plan: { directly_related_user_types: [{ type: 'plan' }] },
         access: {
-          directly_related_user_types: [
-            { type: 'user' },
-          ],
+          directly_related_user_types: [{ type: 'user' }],
         },
       },
     },
@@ -796,6 +792,7 @@ Ensure that your authorization model matches the one below
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'user',

--- a/docs/content/modeling/advanced/gdrive.mdx
+++ b/docs/content/modeling/advanced/gdrive.mdx
@@ -126,6 +126,7 @@ To represent permissions in <ProductName format={ProductNameFormat.ShortForm}/> 
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'user',
@@ -228,6 +229,7 @@ To make <ProductName format={ProductNameFormat.ShortForm}/> aware of this "conce
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'user',
@@ -328,6 +330,7 @@ To add support for domains and members all we need to do is add this object to t
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'user',
@@ -465,6 +468,7 @@ We need to add the notion that a **document** can be the **parent** of another *
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'user',
@@ -634,6 +638,7 @@ The updated authorization model looks like this:
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'user',

--- a/docs/content/modeling/advanced/github.mdx
+++ b/docs/content/modeling/advanced/github.mdx
@@ -126,6 +126,7 @@ To represent permissions in <ProductName format={ProductNameFormat.LongForm}/> w
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'user',
@@ -167,6 +168,7 @@ The <ProductName format={ProductNameFormat.ShortForm}/> service determines if a 
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'user',
@@ -236,6 +238,7 @@ To make <ProductName format={ProductNameFormat.ShortForm}/> aware of this "conce
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'user',
@@ -376,6 +379,7 @@ To add support for teams and memberships all we need to do is add this object to
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'team', // objects of type "team"
@@ -400,6 +404,7 @@ In addition, the repo's relations should be add team member as a directly relate
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'user',
@@ -562,6 +567,7 @@ Let us add support for organizations and membership. Hopefully this feels famili
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'organization', // objects of type "organization"
@@ -586,6 +592,7 @@ And support for repositories having owners:
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'repo',
@@ -657,34 +664,19 @@ And support for repositories having owners:
         metadata: {
           relations: {
             reader: {
-              directly_related_user_types: [
-                { type: 'user' },
-                { type: 'team', relation: 'member' },
-              ],
+              directly_related_user_types: [{ type: 'user' }, { type: 'team', relation: 'member' }],
             },
             triager: {
-              directly_related_user_types: [
-                { type: 'user' },
-                { type: 'team', relation: 'member' },
-              ],
+              directly_related_user_types: [{ type: 'user' }, { type: 'team', relation: 'member' }],
             },
             writer: {
-              directly_related_user_types: [
-                { type: 'user' },
-                { type: 'team', relation: 'member' },
-              ],
+              directly_related_user_types: [{ type: 'user' }, { type: 'team', relation: 'member' }],
             },
             maintainer: {
-              directly_related_user_types: [
-                { type: 'user' },
-                { type: 'team', relation: 'member' },
-              ],
+              directly_related_user_types: [{ type: 'user' }, { type: 'team', relation: 'member' }],
             },
             admin: {
-              directly_related_user_types: [
-                { type: 'user' },
-                { type: 'team', relation: 'member' },
-              ],
+              directly_related_user_types: [{ type: 'user' }, { type: 'team', relation: 'member' }],
             },
             owner: {
               directly_related_user_types: [{ type: 'organization' }],
@@ -801,6 +793,7 @@ The updated authorization model looks like this:
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'user',
@@ -945,9 +938,7 @@ The updated authorization model looks like this:
               ],
             },
             owner: {
-              directly_related_user_types: [
-                { type: 'organization' },
-              ],
+              directly_related_user_types: [{ type: 'organization' }],
             },
           },
         },
@@ -965,7 +956,7 @@ The updated authorization model looks like this:
         metadata: {
           relations: {
             owner: {
-              directly_related_user_types: [{type: 'organization'}],
+              directly_related_user_types: [{ type: 'organization' }],
             },
             repo_admin: {
               directly_related_user_types: [

--- a/docs/content/modeling/advanced/iot.mdx
+++ b/docs/content/modeling/advanced/iot.mdx
@@ -134,6 +134,7 @@ In <ProductName format={ProductNameFormat.ShortForm}/>, the <ProductConcept sect
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'user',
@@ -262,6 +263,7 @@ The resulting authorization model is:
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'device',
@@ -435,6 +437,7 @@ With this change, the full <ProductConcept section="what-is-an-authorization-mod
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'user',
@@ -621,6 +624,7 @@ To remedy this, remove `self` from `live_video_viewer`, `recorded_video_viewer` 
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'user',

--- a/docs/content/modeling/advanced/slack.mdx
+++ b/docs/content/modeling/advanced/slack.mdx
@@ -222,6 +222,7 @@ To represent permissions in <ProductName /> we use <ProductConcept section="what
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'user',
@@ -400,6 +401,7 @@ With the following updated <ProductConcept section="what-is-a-type-definition" l
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'user',
@@ -630,6 +632,7 @@ As a result, the authorization model is:
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'user',

--- a/docs/content/modeling/blocklists.mdx
+++ b/docs/content/modeling/blocklists.mdx
@@ -49,6 +49,7 @@ Let us also assume that we have a `document` called "planning", shared for editi
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'user',
@@ -161,6 +162,7 @@ The authorization model becomes this:
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'user',
@@ -207,6 +209,7 @@ Now that we can mark users as `blocked` from editing documents, we need to suppo
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'user',

--- a/docs/content/modeling/building-blocks/concentric-relationships.mdx
+++ b/docs/content/modeling/building-blocks/concentric-relationships.mdx
@@ -54,6 +54,7 @@ Let us also assume that we have a `document` called "meeting_notes.doc" and bob 
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'user',
@@ -123,6 +124,7 @@ Our authorization model becomes the following:
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'user',

--- a/docs/content/modeling/building-blocks/direct-relationships.mdx
+++ b/docs/content/modeling/building-blocks/direct-relationships.mdx
@@ -83,6 +83,7 @@ Direct relationships can be enabled for a specific relation on an _<ProductConce
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'user',
@@ -154,6 +155,7 @@ Let us start with the authorization model we had above:
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'user',
@@ -390,6 +392,7 @@ In this section, we will investigate the effect of disabling _direct relationshi
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'user',

--- a/docs/content/modeling/building-blocks/object-to-object-relationships.mdx
+++ b/docs/content/modeling/building-blocks/object-to-object-relationships.mdx
@@ -52,6 +52,7 @@ You will start with the _<ProductConcept section="what-is-an-authorization-model
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'user',
@@ -114,6 +115,7 @@ To represent that a `folder` can be a `parent` of a `document`, we first need to
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'user',
@@ -190,6 +192,7 @@ To do this, the authorization model will have two <ProductConcept section="what-
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'user',

--- a/docs/content/modeling/building-blocks/usersets.mdx
+++ b/docs/content/modeling/building-blocks/usersets.mdx
@@ -35,6 +35,7 @@ Imagine the following authorization model:
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'user',
@@ -48,7 +49,7 @@ Imagine the following authorization model:
         },
         metadata: {
           relations: {
-            member: { directly_related_user_types: [{type: 'user'}] },
+            member: { directly_related_user_types: [{ type: 'user' }] },
           },
         },
       },
@@ -61,7 +62,7 @@ Imagine the following authorization model:
         },
         metadata: {
           relations: {
-            reader: { directly_related_user_types: [{type: 'user'}, {type: 'org', relation: 'member'}] },
+            reader: { directly_related_user_types: [{ type: 'user' }, { type: 'org', relation: 'member' }] },
           },
         },
       },
@@ -98,6 +99,7 @@ Imagine the following authorization model:
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'user',
@@ -126,8 +128,8 @@ Imagine the following authorization model:
         },
         metadata: {
           relations: {
-            reader: { directly_related_user_types: [{type: 'user'}, {type: 'org', relation: 'member'}] },
-            writer: { directly_related_user_types: [{type: 'user'}, {type: 'org', relation: 'member'}] },
+            reader: { directly_related_user_types: [{ type: 'user' }, { type: 'org', relation: 'member' }] },
+            writer: { directly_related_user_types: [{ type: 'user' }, { type: 'org', relation: 'member' }] },
           },
         },
       },

--- a/docs/content/modeling/contextual-time-based-authorization.mdx
+++ b/docs/content/modeling/contextual-time-based-authorization.mdx
@@ -66,6 +66,7 @@ We will start with the following Authorization Model
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'user',
@@ -79,8 +80,8 @@ We will start with the following Authorization Model
         },
         metadata: {
           relations: {
-            account_manager: { directly_related_user_types: [{type: 'user'}] },
-          }
+            account_manager: { directly_related_user_types: [{ type: 'user' }] },
+          },
         },
       },
       {
@@ -131,9 +132,9 @@ We will start with the following Authorization Model
         },
         metadata: {
           relations: {
-            branch: { directly_related_user_types: [{type: 'branch'}] },
-            customer: { directly_related_user_types: [{type: 'user'}] },
-          }
+            branch: { directly_related_user_types: [{ type: 'branch' }] },
+            customer: { directly_related_user_types: [{ type: 'user' }] },
+          },
         },
       },
       {
@@ -157,8 +158,8 @@ We will start with the following Authorization Model
         },
         metadata: {
           relations: {
-            account: { directly_related_user_types: [{type: 'account'}] },
-          }
+            account: { directly_related_user_types: [{ type: 'account' }] },
+          },
         },
       },
     ],
@@ -221,9 +222,11 @@ By the end of this guide we would like to validate that:
 
 In order to solve for the requirements above, we will break the problem down to three steps:
 
-1. [Understand relationships without contextual tuples](#understand-relationships-without-contextual-data). We will want to ensure that 
+1. [Understand relationships without contextual tuples](#understand-relationships-without-contextual-data). We will want to ensure that
+
 - the customer can view a transaction tied to their account
 - the account manager can view a transaction whose account is at the same branch
+
 2. Extend the Authorization Model to [take time and ip address into consideration](#take-time-and-ip-address-into-consideration)
 3. [Use contextual tuples for context related checks](#use-contextual-tuples-for-context-related-checks).
 
@@ -237,9 +240,11 @@ With the Authorization Model and relationship tuples shown above, <ProductName f
 We can verify that using the following checks
 
 Anne can view transaction:A because she is an account manager of an account that is at the same branch.
+
 <CheckRequestViewer user={'user:anne'} relation={'can_view'} object={'transaction:A'} allowed={true} />
 
 Caroline can view transaction:A because she is a customer and the transaction is tied to her account.
+
 <CheckRequestViewer user={'user:caroline'} relation={'can_view'} object={'transaction:A'} allowed={true} />
 
 Additionally, we will check that Mary, an account manager at a different branch _cannot_ view transaction A.
@@ -274,7 +279,7 @@ In order to add time and ip address to our authorization model, we will add appr
     },
     metadata: {
       relations: {
-        user: { directly_related_user_types: [{type: 'user'}] },
+        user: { directly_related_user_types: [{ type: 'user' }] },
       },
     },
   }}
@@ -290,7 +295,7 @@ In order to add time and ip address to our authorization model, we will add appr
     },
     metadata: {
       relations: {
-        user: { directly_related_user_types: [{type: 'user'}] },
+        user: { directly_related_user_types: [{ type: 'user' }] },
       },
     },
   }}
@@ -352,10 +357,10 @@ The branch type definition then becomes:
     },
     metadata: {
       relations: {
-        account_manager: { directly_related_user_types: [{type: 'user'}] },
-        approved_ip_address_range: { directly_related_user_types: [{type: 'ip-address-range'}] },
-        approved_timeslot: { directly_related_user_types: [{type: 'timeslot'}] },
-      }
+        account_manager: { directly_related_user_types: [{ type: 'user' }] },
+        approved_ip_address_range: { directly_related_user_types: [{ type: 'ip-address-range' }] },
+        approved_timeslot: { directly_related_user_types: [{ type: 'timeslot' }] },
+      },
     },
   }}
 />
@@ -440,9 +445,9 @@ The account type definition then becomes:
     },
     metadata: {
       relations: {
-        branch: { directly_related_user_types: [{type: 'branch'}] },
-        customer: { directly_related_user_types: [{type: 'user'}] },
-      }
+        branch: { directly_related_user_types: [{ type: 'branch' }] },
+        customer: { directly_related_user_types: [{ type: 'user' }] },
+      },
     },
   }}
 />
@@ -451,6 +456,7 @@ The account type definition then becomes:
 On the "transaction" type:
 
 - Nothing will need to be done, as it will inherit the updated "viewer" relation definition from "account"
+
 :::
 
 ##### Add The Required Tuples To Mark That Anne Is In An Approved Context
@@ -465,6 +471,7 @@ We need to add relationship tuples to mark some approved timeslots and ip addres
 
 - Here we added the time slots in increments of 1 hour periods, but this is not a requirement.
 - We did not add all the office hours to keep this guide shorter.
+
 :::
 
 <WriteRequestViewer
@@ -522,7 +529,7 @@ Now that we know we can authorize based on present state, we have a different pr
 
 How do we solve this? How do we tie the above two tuples to the context of the request instead of the system state?
 
-First, we will need to undo adding the stored relationship tuples where Anne is connecting from within the 10.0.0.0/16 ip address range and Anne connecting between 12pm and 1pm 
+First, we will need to undo adding the stored relationship tuples where Anne is connecting from within the 10.0.0.0/16 ip address range and Anne connecting between 12pm and 1pm
 
 <WriteRequestViewer
   deleteRelationshipTuples={[
@@ -596,6 +603,7 @@ When Anne is connecting from a denied ip address range or timeslot, <ProductName
   Final version of the Authorization Model and Relationship tuples
 </summary>
 <AuthzModelSnippetViewer configuration={{
+    schema_version: '1.1',
   "type_definitions": [
     {
       "type": "user",
@@ -864,6 +872,7 @@ Contextual tuples:
 - Are not persisted in the store.
 - Are only supported on the [Check API endpoint](/api/service#Relationship%20Queries/Check). They are not supported on read, expand and other endpoints.
 - If you are using the [ReadChanges API endpoint](/api/service#Relationship%20Tuples/ReadChanges) to build a permission aware search index, note that it will not be trivial to take contextual tuples into account.
+
 :::
 
 ### Taking It A Step Further: Banks As A Service Authorization
@@ -874,6 +883,7 @@ In that case, we can extend the model like so:
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'user',
@@ -887,7 +897,7 @@ In that case, we can extend the model like so:
         },
         metadata: {
           relations: {
-            admin: { directly_related_user_types: [{type: 'user'}] },
+            admin: { directly_related_user_types: [{ type: 'user' }] },
           },
         },
       },
@@ -939,10 +949,10 @@ In that case, we can extend the model like so:
         },
         metadata: {
           relations: {
-            bank: { directly_related_user_types: [{type: 'bank'}] },
-            account_manager: { directly_related_user_types: [{type: 'user'}] },
-            approved_ip_address_range: { directly_related_user_types: [{type: 'ip-address-range'}] },
-            approved_timeslot: { directly_related_user_types: [{type: 'timeslot'}] },
+            bank: { directly_related_user_types: [{ type: 'bank' }] },
+            account_manager: { directly_related_user_types: [{ type: 'user' }] },
+            approved_ip_address_range: { directly_related_user_types: [{ type: 'ip-address-range' }] },
+            approved_timeslot: { directly_related_user_types: [{ type: 'timeslot' }] },
           },
         },
       },
@@ -1018,8 +1028,8 @@ In that case, we can extend the model like so:
         },
         metadata: {
           relations: {
-            branch: { directly_related_user_types: [{type: 'branch'}] },
-            customer: { directly_related_user_types: [{type: 'user'}] },
+            branch: { directly_related_user_types: [{ type: 'branch' }] },
+            customer: { directly_related_user_types: [{ type: 'user' }] },
           },
         },
       },
@@ -1044,7 +1054,7 @@ In that case, we can extend the model like so:
         },
         metadata: {
           relations: {
-            account: { directly_related_user_types: [{type: 'account'}] },
+            account: { directly_related_user_types: [{ type: 'account' }] },
           },
         },
       },
@@ -1057,7 +1067,7 @@ In that case, we can extend the model like so:
         },
         metadata: {
           relations: {
-            user: { directly_related_user_types: [{type: 'user'}] },
+            user: { directly_related_user_types: [{ type: 'user' }] },
           },
         },
       },
@@ -1070,7 +1080,7 @@ In that case, we can extend the model like so:
         },
         metadata: {
           relations: {
-            user: { directly_related_user_types: [{type: 'user'}] },
+            user: { directly_related_user_types: [{ type: 'user' }] },
           },
         },
       },

--- a/docs/content/modeling/custom-roles.mdx
+++ b/docs/content/modeling/custom-roles.mdx
@@ -54,6 +54,7 @@ We'll start with the following authorization model showing a system with an `ass
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'user',
@@ -152,6 +153,7 @@ The authorization model becomes this:
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'user',

--- a/docs/content/modeling/direct-access.mdx
+++ b/docs/content/modeling/direct-access.mdx
@@ -45,6 +45,7 @@ You have a <ProductConcept section="what-is-a-type" linkName="type" /> called `d
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'user',
@@ -63,7 +64,7 @@ You have a <ProductConcept section="what-is-a-type" linkName="type" /> called `d
           relations: {
             viewer: { directly_related_user_types: [{ type: 'user' }] },
             editor: { directly_related_user_types: [{ type: 'user' }] },
-          }
+          },
         },
       },
     ],

--- a/docs/content/modeling/getting-started.mdx
+++ b/docs/content/modeling/getting-started.mdx
@@ -355,6 +355,7 @@ Now that we have a list of object types we can start defining them using the <Up
 <AuthzModelSnippetViewer
   onlyShow={SyntaxFormat.Friendly2}
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'user',
@@ -505,6 +506,7 @@ Using the <UpdateProductNameInLinks link="../configuration-language" name="{Prod
 <AuthzModelSnippetViewer
   onlyShow={SyntaxFormat.Friendly2}
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'user',
@@ -585,6 +587,7 @@ Remember _"How a user is added as a member to an organization is beyond the scop
 <AuthzModelSnippetViewer
   onlyShow={SyntaxFormat.Friendly2}
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'organization',
@@ -615,6 +618,7 @@ Relation definitions of the form “define {relation} as self" are fairly common
 You can read more about group membership and types in [Modeling User Groups](./user-groups.mdx).
 
 For the direct relationships, we need to figure out the object types that makes sense for the relationship tuples' user. In our organization example, it makes sense for member relations to have user of type
+
 - user
 - organization#member (i.e., other organization's member)
 
@@ -639,6 +643,7 @@ The complete <ProductConcept section="what-is-a-type-definition" linkName="type 
 <AuthzModelSnippetViewer
   onlyShow={SyntaxFormat.Friendly2}
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'organization',
@@ -685,6 +690,7 @@ The relation definition then should be:
 <AuthzModelSnippetViewer
   onlyShow={SyntaxFormat.Friendly2}
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'document',
@@ -718,6 +724,7 @@ The relation definition then should be:
 <AuthzModelSnippetViewer
   onlyShow={SyntaxFormat.Friendly2}
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'document',
@@ -761,6 +768,7 @@ The viewer relation is similar to the document's [editor relation](#relation-edi
 <AuthzModelSnippetViewer
   onlyShow={SyntaxFormat.Friendly2}
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'document',
@@ -792,6 +800,7 @@ When a document is created a relationship tuple will be stored in <ProductName f
 <AuthzModelSnippetViewer
   onlyShow={SyntaxFormat.Friendly2}
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'document',
@@ -1004,6 +1013,7 @@ The complete <ProductConcept section="what-is-a-type-definition" linkName="type 
 <AuthzModelSnippetViewer
   onlyShow={SyntaxFormat.Friendly2}
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'document',
@@ -1165,6 +1175,7 @@ Combining the type definitions for document and organization, we have
 <AuthzModelSnippetViewer
   onlyShow={SyntaxFormat.Friendly2}
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'user',

--- a/docs/content/modeling/multiple-restrictions.mdx
+++ b/docs/content/modeling/multiple-restrictions.mdx
@@ -59,6 +59,7 @@ Let us also assume that we have:
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'user',
@@ -81,8 +82,8 @@ Let us also assume that we have:
         },
         metadata: {
           relations: {
-            owner: { directly_related_user_types: [{type: 'user'}, { type: 'organization', relation: 'member' }] },
-            writer: { directly_related_user_types: [{type: 'user'},{ type: 'organization', relation: 'member' }] },
+            owner: { directly_related_user_types: [{ type: 'user' }, { type: 'organization', relation: 'member' }] },
+            writer: { directly_related_user_types: [{ type: 'user' }, { type: 'organization', relation: 'member' }] },
           },
         },
       },
@@ -190,6 +191,7 @@ The first step is to add the relation definition for `can_delete` so that it req
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'user',
@@ -236,8 +238,8 @@ The first step is to add the relation definition for `can_delete` so that it req
         },
         metadata: {
           relations: {
-            owner: { directly_related_user_types: [{type: 'user'}, { type: 'organization', relation: 'member' }] },
-            writer: { directly_related_user_types: [{type: 'user'},{ type: 'organization', relation: 'member' }] },
+            owner: { directly_related_user_types: [{ type: 'user' }, { type: 'organization', relation: 'member' }] },
+            writer: { directly_related_user_types: [{ type: 'user' }, { type: 'organization', relation: 'member' }] },
           },
         },
       },

--- a/docs/content/modeling/organization-context-authorization.mdx
+++ b/docs/content/modeling/organization-context-authorization.mdx
@@ -75,6 +75,7 @@ We will start with the following authorization model:
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'user',
@@ -94,9 +95,9 @@ We will start with the following authorization model:
         },
         metadata: {
           relations: {
-            member: { directly_related_user_types: [{type: 'user'}] },
-            project_manager: { directly_related_user_types: [{type: 'user'}] },
-            project_editor: { directly_related_user_types: [{type: 'user'}] },
+            member: { directly_related_user_types: [{ type: 'user' }] },
+            project_manager: { directly_related_user_types: [{ type: 'user' }] },
+            project_editor: { directly_related_user_types: [{ type: 'user' }] },
           },
         },
       },
@@ -178,8 +179,8 @@ We will start with the following authorization model:
         },
         metadata: {
           relations: {
-            owner: { directly_related_user_types: [{type: 'organization'}] },
-            partner: { directly_related_user_types: [{type: 'organization'}] },
+            owner: { directly_related_user_types: [{ type: 'organization' }] },
+            partner: { directly_related_user_types: [{ type: 'organization' }] },
           },
         },
       },
@@ -191,6 +192,7 @@ We will start with the following authorization model:
 <summary>
 
 We are considering the case that:
+
 - Anne has a project manager role at organizations A, B and C
 - Beth has a project manager role at organization B
 - Carl has a project manager role at organization C
@@ -283,11 +285,23 @@ We can verify that using the following checks:
   * Beth can view Project X
   <CheckRequestViewer user={'user:beth'} relation={'can_view'} object={'project:X'} allowed={true} skipSetup={true} />
   * Beth cannot delete Project X
-  <CheckRequestViewer user={'user:beth'} relation={'can_delete'} object={'project:X'} allowed={false} skipSetup={true} />
+  <CheckRequestViewer
+    user={'user:beth'}
+    relation={'can_delete'}
+    object={'project:X'}
+    allowed={false}
+    skipSetup={true}
+  />
   * Carl cannot view Project X
   <CheckRequestViewer user={'user:carl'} relation={'can_view'} object={'project:X'} allowed={false} skipSetup={true} />
   * Carl cannot delete Project X
-  <CheckRequestViewer user={'user:carl'} relation={'can_delete'} object={'project:X'} allowed={false} skipSetup={true} />
+  <CheckRequestViewer
+    user={'user:carl'}
+    relation={'can_delete'}
+    object={'project:X'}
+    allowed={false}
+    skipSetup={true}
+  />
 </details>
 
 Note that so far, we have not prevented Anne from viewing "Project X" even if Anne is viewing it from the context of Organization C.
@@ -371,10 +385,10 @@ The "organization" type definition then becomes:
     },
     metadata: {
       relations: {
-        member: { directly_related_user_types: [{type: 'user'}] },
-        project_manager: { directly_related_user_types: [{type: 'user'}] },
-        base_project_editor: { directly_related_user_types: [{type: 'user'}] },
-        user_in_context: { directly_related_user_types: [{type: 'user'}] },
+        member: { directly_related_user_types: [{ type: 'user' }] },
+        project_manager: { directly_related_user_types: [{ type: 'user' }] },
+        base_project_editor: { directly_related_user_types: [{ type: 'user' }] },
+        user_in_context: { directly_related_user_types: [{ type: 'user' }] },
       },
     },
   }}
@@ -404,6 +418,7 @@ In order for Anne to be authorized, a tuple indicating Anne's current organizati
 />
 
 We can verify this by running a check request
+
 <CheckRequestViewer user={'user:anne'} relation={'can_view'} object={'project:X'} allowed={true} skipSetup={true} />
 
 ### Use Contextual Tuples For Context Related Checks
@@ -483,6 +498,7 @@ Using this, you can check that the following requirements are satisfied:
   Final version of the Authorization Model and Relationship tuples
 </summary>
 <AuthzModelSnippetViewer configuration={{
+    schema_version: '1.1',
   "type_definitions": [
     {
       "type": "user",
@@ -686,6 +702,7 @@ Contextual tuples:
 - Are not persisted in the store.
 - Are only supported on the <UpdateProductNameInLinks link="/api/service#Relationship%20Queries/Check" name="Check API endpoint" />. They are not supported on read, expand and other endpoints.
 - If you are using the <UpdateProductNameInLinks link="/api/service#Relationship%20Tuples/ReadChanges" name="Read Changes API endpoint" /> to build a permission aware search index, note that it will not be trivial to take contextual tuples into account.
+
 :::
 
 ## Related Sections

--- a/docs/content/modeling/parent-child.mdx
+++ b/docs/content/modeling/parent-child.mdx
@@ -51,6 +51,7 @@ You have two types:
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'user',
@@ -127,6 +128,7 @@ To allow a `parent` relation between a `folder` and a `document`, we need to upd
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'user',
@@ -178,6 +180,7 @@ To allow _cascading_ relations between `folder` and `document`, we can update ou
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'user',

--- a/docs/content/modeling/public-access.mdx
+++ b/docs/content/modeling/public-access.mdx
@@ -47,6 +47,7 @@ You have a <ProductConcept section="what-is-a-type" linkName="type" /> called `d
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'user',

--- a/docs/content/modeling/roles-and-permissions.mdx
+++ b/docs/content/modeling/roles-and-permissions.mdx
@@ -61,6 +61,7 @@ You have a <ProductConcept section="what-is-a-type" linkName="type" /> called `t
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'user',
@@ -126,6 +127,7 @@ Relating roles within <ProductName format={ProductNameFormat.ShortForm}/> can be
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'user',
@@ -163,6 +165,7 @@ To allow `viewers` of a `trip` to have **permissions to view bookings** and `own
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'user',

--- a/docs/content/modeling/user-groups.mdx
+++ b/docs/content/modeling/user-groups.mdx
@@ -49,6 +49,7 @@ You have an _<ProductConcept section="what-is-an-object" linkName="object" />_ c
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'user',
@@ -107,6 +108,7 @@ We need to define the _<ProductConcept section="what-is-an-object" linkName="obj
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'user',
@@ -120,7 +122,7 @@ We need to define the _<ProductConcept section="what-is-an-object" linkName="obj
         },
         metadata: {
           relations: {
-            member: { directly_related_user_types: [{ type: 'team', 'relation': 'member' }] },
+            member: { directly_related_user_types: [{ type: 'team', relation: 'member' }] },
           },
         },
       },


### PR DESCRIPTION


## Description
1. Tagging model as version 1.1
2. Run format document 

## References
See corresponding change for https://github.com/openfga/syntax-transformer/pull/80. We should tag version so that the correct version will be shown for DSL.

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
