### PR TITLE
fix: hide swagger version number in docs

### DIFF
--- a/src/components/SwaggerUI/swagger-ui-feature-override.css
+++ b/src/components/SwaggerUI/swagger-ui-feature-override.css
@@ -1,0 +1,3 @@
+.swagger-ui .info .title small {
+  display: none;
+}

--- a/src/components/SwaggerUI/swagger-ui.tsx
+++ b/src/components/SwaggerUI/swagger-ui.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import SwaggerUIComponent from 'swagger-ui-react';
 
 import './swagger-ui-override.css';
+import './swagger-ui-feature-override.css';
 
 const DisableAuthorizePlugin = function () {
   return {


### PR DESCRIPTION

## Description
Hide swagger version number as it renders poorly.  
<img width="2032" alt="Screen Shot 2022-10-31 at 11 14 59 AM" src="https://user-images.githubusercontent.com/10730463/199042702-3cb741ef-4de0-4128-b180-3b8e6b2bee88.png">

 

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
