### PR TITLE
chore(docs): add a note about openfga not evaluating the tupleset

### DIFF
--- a/docs/content/configuration-language.mdx
+++ b/docs/content/configuration-language.mdx
@@ -583,73 +583,9 @@ This particular use of referencing relations on related objects is defining a tr
 This can be used to indicate that **viewers** of a **folders** are **viewers** of all **documents** in that **folder**.
 
 :::caution
-<details>
-<summary>
-Note that when searching tuples that are related to the object (the word after `from`, also called the tupleset), <ProductName format={ProductNameFormat.LongForm}/> will not do any evaluation and will only consider concrete objects (of the form `object_type:object_id`) that were directly assigned, and will throw an error if it encounters any rewrites, or a `*`, a type bound public access (`object_type:*`) or a userset (`object_type:object_id#relation`).
-</summary>
-  In the case below:
+Note that <ProductName format={ProductNameFormat.LongForm}/> does not allow the referenced relation (the word after `from`, also called the tupleset) to be referencing another relation or allow non-concrete types (type bound public access (`<object_type>:*`) or usersets (`<object_type>#<relation>`)) in its type restrictions and will throw a validation error when attempting to call `WriteAuthorizationModel`.
 
-  <AuthzModelSnippetViewer
-  configuration={{
-    type_definitions: [
-      {
-        type: 'user',
-      },
-      {
-        type: 'folder',
-        relations: {
-          parent: {
-            this: {},
-          },
-          ancestor: {
-            computedUserset: {
-              relation: 'parent',
-            }
-          },
-          editor: {
-            union: {
-              child: [
-                {
-                  this: {},
-                },
-                {
-                  tupleToUserset: {
-                    tupleset: {
-                      relation: 'ancestor',
-                    },
-                    computedUserset: {
-                      relation: 'editor',
-                    },
-                  },
-                },
-              ],
-            },
-          },
-        },
-      },
-    ],
-  }}
-/>
-
-  If you add two tuples:
-  <WriteRequestViewer
-    skipSetup={true}
-    relationshipTuples={[
-    {
-      user: 'folder:product',
-      relation: 'parent',
-      object: 'folder:planning'
-    },
-    {
-      user: 'user:anne',
-      relation: 'editor',
-      object: 'folder:product'
-    }
-  ]} />
-
-  Run the following check will return `false` because the `ancestor` relation contains a rewrite which will not be evaluated.
-  <CheckRequestViewer skipSetup={true} user={'user:anne'} relation={'editor'} object={'folder:planning'} allowed={false} />
-</details>
+Note: In the deprecated 1.0 schema version, the validation error will be thrown at the time of evaluation (`Check`, etc..).
 :::
 
 For more examples, take look at [Modeling: Parent-Child Objects](./modeling/parent-child.mdx), [Advanced Modeling: Google Drive](./modeling/advanced/gdrive.mdx), [Advanced Modeling: GitHub](./modeling/advanced/github.mdx), and [Advanced Modeling: Entitlements](./modeling/advanced/entitlements.mdx).

--- a/docs/content/configuration-language.mdx
+++ b/docs/content/configuration-language.mdx
@@ -585,7 +585,7 @@ This can be used to indicate that **viewers** of a **folders** are **viewers** o
 :::caution
 Note that <ProductName format={ProductNameFormat.LongForm}/> does not allow the referenced relation (the word after `from`, also called the tupleset) to be referencing another relation or allow non-concrete types (type bound public access (`<object_type>:*`) or usersets (`<object_type>#<relation>`)) in its type restrictions and will throw a validation error when attempting to call `WriteAuthorizationModel`.
 
-Note: In the deprecated 1.0 schema version, the validation error will be thrown at the time of evaluation (`Check`, etc..).
+Note: In the [deprecated 1.0 schema version](./modeling/migrating/migrating-schema-1-1.mdx), the validation error will be thrown at the time of evaluation (`Check`, etc..).
 :::
 
 For more examples, take look at [Modeling: Parent-Child Objects](./modeling/parent-child.mdx), [Advanced Modeling: Google Drive](./modeling/advanced/gdrive.mdx), [Advanced Modeling: GitHub](./modeling/advanced/github.mdx), and [Advanced Modeling: Entitlements](./modeling/advanced/entitlements.mdx).

--- a/docs/content/configuration-language.mdx
+++ b/docs/content/configuration-language.mdx
@@ -7,6 +7,7 @@ description: Learning about the FGA configuration language and using it to build
 
 import {
   AuthzModelSnippetViewer,
+  CheckRequestViewer,
   DocumentationNotice,
   ProductConcept,
   ProductName,
@@ -15,6 +16,7 @@ import {
   RelationshipTuplesViewer,
   SyntaxFormat,
   UpdateProductNameInLinks,
+  WriteRequestViewer,
 } from '@components/Docs';
 
 # Configuration Language
@@ -579,6 +581,76 @@ In the _authorization model_ above, `user:anne` is a `viewer` of `document:new-r
 This particular use of referencing relations on related objects is defining a transitive implied relationship. If **user A** is related to a certain **object B** as a **viewer**, and **object B** is related to **object C** as **parent**, then **user A** is related to **object C** as **viewer**.
 
 This can be used to indicate that **viewers** of a **folders** are **viewers** of all **documents** in that **folder**.
+
+:::caution
+<details>
+<summary>
+Note that when searching tuples that are related to the object (the word after `from`, also called the tupleset), <ProductName format={ProductNameFormat.LongForm}/> will not do any evaluation and will only consider concrete objects (of the form `object_type:object_id`) that were directly assigned, and will throw an error if it encounters any rewrites, or a `*`, a type bound public access (`object_type:*`) or a userset (`object_type:object_id#relation`).
+</summary>
+  In the case below:
+
+  <AuthzModelSnippetViewer
+  configuration={{
+    type_definitions: [
+      {
+        type: 'user',
+      },
+      {
+        type: 'folder',
+        relations: {
+          parent: {
+            this: {},
+          },
+          ancestor: {
+            computedUserset: {
+              relation: 'parent',
+            }
+          },
+          editor: {
+            union: {
+              child: [
+                {
+                  this: {},
+                },
+                {
+                  tupleToUserset: {
+                    tupleset: {
+                      relation: 'ancestor',
+                    },
+                    computedUserset: {
+                      relation: 'editor',
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        },
+      },
+    ],
+  }}
+/>
+
+  If you add two tuples:
+  <WriteRequestViewer
+    skipSetup={true}
+    relationshipTuples={[
+    {
+      user: 'folder:product',
+      relation: 'parent',
+      object: 'folder:planning'
+    },
+    {
+      user: 'user:anne',
+      relation: 'editor',
+      object: 'folder:product'
+    }
+  ]} />
+
+  Run the following check will return `false` because the `ancestor` relation contains a rewrite which will not be evaluated.
+  <CheckRequestViewer skipSetup={true} user={'user:anne'} relation={'editor'} object={'folder:planning'} allowed={false} />
+</details>
+:::
 
 For more examples, take look at [Modeling: Parent-Child Objects](./modeling/parent-child.mdx), [Advanced Modeling: Google Drive](./modeling/advanced/gdrive.mdx), [Advanced Modeling: GitHub](./modeling/advanced/github.mdx), and [Advanced Modeling: Entitlements](./modeling/advanced/entitlements.mdx).
 

--- a/docs/content/modeling/migrating/migrating-schema-1-1.mdx
+++ b/docs/content/modeling/migrating/migrating-schema-1-1.mdx
@@ -494,7 +494,7 @@ In these cases, <ProductName format={ProductNameFormat.ShortForm}/> will not con
 
 Type restrictions allow <ProductName format={ProductNameFormat.ShortForm} /> to validate the schema better at the time of writing the schema instead of at the time of query evaluation.
 
-In <ProductName format={ProductNameFormat.ShortForm} />, when [referencing relations on related objects](../configuration-language.mdx#referencing-relations-on-related-objects) the relation tying the related objects (the word after `from`, also called the tupleset) cannot be evaluated - that means it cannot be referencing another relation, or allow non-concrete types (type bound public access (`<object_type>:*`) or usersets (`<object_type>#<relation>`)) in its type restrictions.
+In <ProductName format={ProductNameFormat.ShortForm} />, when [referencing relations on related objects](../../configuration-language.mdx#referencing-relations-on-related-objects) the relation tying the related objects (the word after `from`, also called the tupleset) cannot be evaluated - that means it cannot be referencing another relation, or allow non-concrete types (type bound public access (`<object_type>:*`) or usersets (`<object_type>#<relation>`)) in its type restrictions.
 
 
 

--- a/docs/content/modeling/migrating/migrating-schema-1-1.mdx
+++ b/docs/content/modeling/migrating/migrating-schema-1-1.mdx
@@ -490,6 +490,15 @@ It is possible to introduce new models and have existing tuples (from prior mode
 
 In these cases, <ProductName format={ProductNameFormat.ShortForm}/> will not consider those invalid tuples when evaluating queries ([Check](/api/service#/Relationship%20Queries/Check), [Expand](/api/service#/Relationship%20Queries/Expand), [List-objects](/api/service#/Relationship%20Queries/ListObjects), etc). However, after any of the changes above happen, you should delete those tuples as having a large number of invalid tuples will negatively affect performance.
 
+## Improved Schema Validation
+
+Type restriction allow <ProductName format={ProductNameFormat.ShortForm} /> to validate schema better at the time of writing the schema instead of at time of query evaluation.
+
+In particular, models that used to allow referencing related objects than can be evaluated used to error out at the time of evaluation (e.g. during a Check call). As of schema v1.1, the error will be encountered when preforming a `WriteAuthorizationModel`, because <ProductName format={ProductNameFormat.ShortForm} /> is able to know what types are expected beforehand.
+
+See [Referencing Relations on Related Objects](../configuration-language.mdx#referencing-relations-on-related-objects) for more.
+
+
 ## Related Sections
 
 <RelatedSection

--- a/docs/content/modeling/migrating/migrating-schema-1-1.mdx
+++ b/docs/content/modeling/migrating/migrating-schema-1-1.mdx
@@ -492,12 +492,76 @@ In these cases, <ProductName format={ProductNameFormat.ShortForm}/> will not con
 
 ## Improved Schema Validation
 
-Type restriction allow <ProductName format={ProductNameFormat.ShortForm} /> to validate schema better at the time of writing the schema instead of at time of query evaluation.
+Type restrictions allow <ProductName format={ProductNameFormat.ShortForm} /> to validate the schema better at the time of writing the schema instead of at the time of query evaluation.
 
-In particular, models that used to allow referencing related objects than can be evaluated used to error out at the time of evaluation (e.g. during a Check call). As of schema v1.1, the error will be encountered when preforming a `WriteAuthorizationModel`, because <ProductName format={ProductNameFormat.ShortForm} /> is able to know what types are expected beforehand.
+In <ProductName format={ProductNameFormat.ShortForm} />, when [referencing relations on related objects](../configuration-language.mdx#referencing-relations-on-related-objects) the relation tying the related objects (the word after `from`, also called the tupleset) cannot be evaluated - that means it cannot be referencing another relation, or allow non-concrete types (type bound public access (`<object_type>:*`) or usersets (`<object_type>#<relation>`)) in its type restrictions.
 
-See [Referencing Relations on Related Objects](../configuration-language.mdx#referencing-relations-on-related-objects) for more.
 
+
+<details>
+<summary>
+
+In schema 1.0, because type restrictions were not available, the validation error would occur at the time of evaluation (e.g. a `Check` call), while in schema 1.1, the error will be thrown when writing the model (during the `WriteAuthorizationModel` request).
+
+</summary>
+  In the case below, the write request will fail in the new schema 1.1 version, but would have succeeded in schema version 1.0:
+
+  <AuthzModelSnippetViewer
+    showSchemaOneDotZero={true}
+    configuration={{
+      schema_version: "1.1",
+      type_definitions: [
+        {
+          type: 'user',
+        },
+        {
+          type: 'folder',
+          relations: {
+            parent: {
+              this: {},
+            },
+            editor: {
+              union: {
+                child: [
+                  {
+                    this: {},
+                  },
+                  {
+                    tupleToUserset: {
+                      tupleset: {
+                        relation: 'parent',
+                      },
+                      computedUserset: {
+                        relation: 'editor',
+                      },
+                    },
+                  },
+                ],
+              },
+            },
+          },
+          metadata: {
+            relations: {
+              parent: { directly_related_user_types: [{ type: 'folder' }, { type: 'folder', relation: "parent" }] },
+              editor: { directly_related_user_types: [{ type: 'user' }] },
+            },
+          }
+        },
+      ],
+    }}
+  />
+
+  In schema 1.0, the `WriteAuthorizationModel` would have succeeded, but when attempting to write a tuple such as the one below, you would have received an error:
+  <WriteRequestViewer
+    skipSetup={true}
+    relationshipTuples={[
+    {
+      user: 'folder:product#parent',
+      relation: 'parent',
+      object: 'folder:planning'
+    }
+  ]} />
+</details>
 
 ## Related Sections
 

--- a/docs/content/modeling/parent-child.mdx
+++ b/docs/content/modeling/parent-child.mdx
@@ -261,6 +261,10 @@ To leverage our _cascading_ relation, we need to create a relationship tuple tha
   ]}
 />
 
+:::caution
+**Note:** Make sure to use unique ids for each object and user within your application domain when creating relationship tuples for <ProductName format={ProductNameFormat.LongForm}/>. We are using first names and simple ids to illustrate an easy-to-follow example.
+:::
+
 ### 04. Create A New Relationship Tuple To Indicate That folder:notes Is A Parent Of document:meeting_notes.doc
 
 Now that **bob** is an `editor` of **folder:notes**, we need to indicate that **folder:notes** is a `parent` of `document`:**meeting_notes.doc**
@@ -292,7 +296,9 @@ The chain of resolution becomes:
 - Therefore, **bob** is an `editor` of **document:meeting_notes.doc**
 
 :::caution
-**Note:** When creating relationship tuples for <ProductName format={ProductNameFormat.LongForm}/> make sure to use unique ids for each object and user within your application domain. We are using first names and simple ids to just illustrate an easy-to-follow example.
+Note that when searching tuples that are related to the object (the word after `from`, also called the tupleset), <ProductName format={ProductNameFormat.LongForm}/> will not do any evaluation and will only consider concrete objects (of the form `<object_type>:<object_id>`) that were directly assigned, and will throw an error if it encounters any rewrites, or a `*`, a type bound public access (`<object_type>:*`) or a userset (`<object_type>:<object_id>#<relation>`).
+
+See [Referencing Relations on Related Objects](../configuration-language.mdx#referencing-relations-on-related-objects) for more.
 :::
 
 ## Related Sections

--- a/src/components/Docs/AuthorizationModel/AuthzModelSnippetViewer.tsx
+++ b/src/components/Docs/AuthorizationModel/AuthzModelSnippetViewer.tsx
@@ -8,6 +8,7 @@ import Admonition from '@theme/Admonition';
 
 import { SyntaxFormat, WriteAuthzModelViewer } from '@components/Docs';
 import { AuthzModelCodeBlock } from './AuthzModelCodeBlock';
+import { SchemaVersion } from "@openfga/syntax-transformer";
 
 type AuthzModelSnippetViewerProps = {
   // Authorization Model in api syntax
@@ -18,20 +19,22 @@ type AuthzModelSnippetViewerProps = {
   showWrite?: boolean;
   // do not display the model schema in DSL and JSON
   skipVersion?: boolean;
+  // Display a roughly equivalent v1.0 schema
+  showSchemaOneDotZero?: boolean;
 };
 
-const AuthzModelSnippetViewer: React.FC<AuthzModelSnippetViewerProps> = ({
-  configuration,
+const BaseAuthzModelSnippetViewer: React.FC<AuthzModelSnippetViewerProps> = ({
   onlyShow,
-  showWrite,
+  configuration,
   skipVersion,
+  showSchemaOneDotZero,
 }) => {
   if (onlyShow) {
     return <AuthzModelCodeBlock configuration={configuration} syntaxFormat={onlyShow} skipVersion={skipVersion} />;
   }
-
-  return (
-    <>
+  
+  if (!showSchemaOneDotZero) {
+    return <>
       <Tabs groupId="dsl">
         <TabItem value="dsl" label="DSL">
           <AuthzModelCodeBlock
@@ -48,6 +51,51 @@ const AuthzModelSnippetViewer: React.FC<AuthzModelSnippetViewerProps> = ({
           />
         </TabItem>
       </Tabs>
+    </>
+  }
+  
+  return <>
+    <Tabs groupId="dsl">
+      <TabItem value="dsl" label="DSL">
+        <AuthzModelCodeBlock
+          configuration={configuration}
+          syntaxFormat={SyntaxFormat.Friendly2}
+          skipVersion={skipVersion}
+        />
+      </TabItem>
+      <TabItem value="dsl-onedotzero" label="DSL (Version 1.0)">
+        <AuthzModelCodeBlock
+          configuration={{ ...configuration, schema_version: SchemaVersion.OneDotZero }}
+          syntaxFormat={SyntaxFormat.Friendly2}
+          skipVersion={skipVersion}
+        />
+      </TabItem>
+      <TabItem value="json" label="JSON">
+        <AuthzModelCodeBlock
+          configuration={configuration}
+          syntaxFormat={SyntaxFormat.Api}
+          skipVersion={skipVersion}
+        />
+      </TabItem>
+    </Tabs>
+  </>
+}
+
+const AuthzModelSnippetViewer: React.FC<AuthzModelSnippetViewerProps> = ({
+  configuration,
+  onlyShow,
+  showWrite,
+  skipVersion,
+  showSchemaOneDotZero,
+}) => {
+  return (
+    <>
+      <BaseAuthzModelSnippetViewer
+        configuration={configuration}
+        skipVersion={skipVersion}
+        onlyShow={onlyShow}
+        showSchemaOneDotZero={showSchemaOneDotZero}
+      />
       {showWrite ? (
         <details>
           <summary>Write the Authorization Model</summary>

--- a/src/components/Docs/AuthorizationModel/AuthzModelSnippetViewer.tsx
+++ b/src/components/Docs/AuthorizationModel/AuthzModelSnippetViewer.tsx
@@ -8,7 +8,7 @@ import Admonition from '@theme/Admonition';
 
 import { SyntaxFormat, WriteAuthzModelViewer } from '@components/Docs';
 import { AuthzModelCodeBlock } from './AuthzModelCodeBlock';
-import { SchemaVersion } from "@openfga/syntax-transformer";
+import { SchemaVersion } from '@openfga/syntax-transformer';
 
 type AuthzModelSnippetViewerProps = {
   // Authorization Model in api syntax
@@ -32,13 +32,43 @@ const BaseAuthzModelSnippetViewer: React.FC<AuthzModelSnippetViewerProps> = ({
   if (onlyShow) {
     return <AuthzModelCodeBlock configuration={configuration} syntaxFormat={onlyShow} skipVersion={skipVersion} />;
   }
-  
+
   if (!showSchemaOneDotZero) {
-    return <>
+    return (
+      <>
+        <Tabs groupId="dsl">
+          <TabItem value="dsl" label="DSL">
+            <AuthzModelCodeBlock
+              configuration={configuration}
+              syntaxFormat={SyntaxFormat.Friendly2}
+              skipVersion={skipVersion}
+            />
+          </TabItem>
+          <TabItem value="json" label="JSON">
+            <AuthzModelCodeBlock
+              configuration={configuration}
+              syntaxFormat={SyntaxFormat.Api}
+              skipVersion={skipVersion}
+            />
+          </TabItem>
+        </Tabs>
+      </>
+    );
+  }
+
+  return (
+    <>
       <Tabs groupId="dsl">
         <TabItem value="dsl" label="DSL">
           <AuthzModelCodeBlock
             configuration={configuration}
+            syntaxFormat={SyntaxFormat.Friendly2}
+            skipVersion={skipVersion}
+          />
+        </TabItem>
+        <TabItem value="dsl-onedotzero" label="DSL (Version 1.0)">
+          <AuthzModelCodeBlock
+            configuration={{ ...configuration, schema_version: SchemaVersion.OneDotZero }}
             syntaxFormat={SyntaxFormat.Friendly2}
             skipVersion={skipVersion}
           />
@@ -52,34 +82,8 @@ const BaseAuthzModelSnippetViewer: React.FC<AuthzModelSnippetViewerProps> = ({
         </TabItem>
       </Tabs>
     </>
-  }
-  
-  return <>
-    <Tabs groupId="dsl">
-      <TabItem value="dsl" label="DSL">
-        <AuthzModelCodeBlock
-          configuration={configuration}
-          syntaxFormat={SyntaxFormat.Friendly2}
-          skipVersion={skipVersion}
-        />
-      </TabItem>
-      <TabItem value="dsl-onedotzero" label="DSL (Version 1.0)">
-        <AuthzModelCodeBlock
-          configuration={{ ...configuration, schema_version: SchemaVersion.OneDotZero }}
-          syntaxFormat={SyntaxFormat.Friendly2}
-          skipVersion={skipVersion}
-        />
-      </TabItem>
-      <TabItem value="json" label="JSON">
-        <AuthzModelCodeBlock
-          configuration={configuration}
-          syntaxFormat={SyntaxFormat.Api}
-          skipVersion={skipVersion}
-        />
-      </TabItem>
-    </Tabs>
-  </>
-}
+  );
+};
 
 const AuthzModelSnippetViewer: React.FC<AuthzModelSnippetViewerProps> = ({
   configuration,

--- a/src/components/Docs/SnippetViewer/CheckRequestViewer.tsx
+++ b/src/components/Docs/SnippetViewer/CheckRequestViewer.tsx
@@ -174,9 +174,9 @@ async def check():
 `;
     case SupportedLanguage.RPC:
       return `check(
-  "${user}", // check if the user \`${user}\`
-  "${relation}", // has an \`${relation}\` relation
-  "${object}", // with the object \`${object}\`
+  user = "${user}", // check if the user \`${user}\`
+  relation = "${relation}", // has an \`${relation}\` relation
+  object = "${object}", // with the object \`${object}\`
   ${
     contextualTuples
       ? `contextual_tuples = [ // Assuming the following is true
@@ -185,7 +185,7 @@ async def check():
       .join(',\n    ')}
   ],`
       : ''
-  } authorization_id="${authorizationModelId ? authorizationModelId : DefaultAuthorizationModelId}"
+  } authorization_id = "${authorizationModelId ? authorizationModelId : DefaultAuthorizationModelId}"
 );
 
 Reply: ${allowed}`;


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

We do not evaluate the tupleset part of a relation definition, which may not be expected. In [OpenFGA `v0.2.4`](https://github.com/orgs/openfga/discussions/59) we took the decision to actually consider that a security issue and throw an error when encountered.

The main problem remains that we do not properly warn against this in the documentation. This PR attempts to add a bit of words of caution.

## Description
<!-- Provide a detailed description of the changes -->

It doesn't look too pretty, but it (hopefully) gets the point across.
<img width="900" alt="Screen Shot 2022-10-31 at 10 04 44 PM" src="https://user-images.githubusercontent.com/536147/199143424-8e15248c-3c3d-40de-a506-2c0f19cc957d.png">

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

- Closes #265 

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
