### PR TITLE
docs: add guidelines about environment variables

### DIFF
--- a/docs/content/getting-started/setup-openfga.mdx
+++ b/docs/content/getting-started/setup-openfga.mdx
@@ -50,6 +50,11 @@ authn:
 
 All possible configurations and their default values are defined in [config-schema.json](https://github.com/openfga/openfga/blob/main/.config-schema.json).
 
+:::info Information
+The OpenFGA server supports **environment variables** for configuration, it will take priority against your configuration file. 
+Each variable must be prefixed with `OPENFGA_` and followed by your option in uppercase (e.g `--grpc-tls-key` becomes `OPENFGA_GRPC_TLS_KEY`).
+:::
+
 ### Configuring Data Storage
 
 OpenFGA supports multiple storage engine options including:


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

Add a brief note about configuration overrides through environment variables.

## Description

In version [`v0.1.6`](https://github.com/orgs/openfga/discussions/14), a feature created the ability to override configuration files options through environment variables. It's something very useful to know when deploying OpenFGA, and there isn't any reference yet in the documentation about it. 

This PR adds a simple note in the configuration section to tell people that it's possible to use environment variables. 

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

There is no references. 

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
