### PR TITLE
Update cncf logo to adhere to brand guidelines

### DIFF
--- a/static/img/cncf-icon-white.svg
+++ b/static/img/cncf-icon-white.svg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c9684229babd4affc78303fd8237f85c1f5f45321dc7c281b2708e3c1a06eac9
-size 670
+oid sha256:6728460332816f730afc962013d66bbb0030690485cafc0950e8d0a659c7b1c8
+size 660


### PR DESCRIPTION
The CNCF logo had its colours reversed in the *Features* section and footer, and the grey used was implemented with #FFF and opacity 0.75 instead of the correct colour code. This PR matches their brand guidelines.

## Description
Ref:
![image](https://user-images.githubusercontent.com/6372810/200360394-35820186-00b6-4f76-82c0-b67d94683939.png)


Before:
![image](https://user-images.githubusercontent.com/6372810/200360284-1bd25e1c-28d5-47f9-b6c6-475886ce6206.png)

After:
![image](https://user-images.githubusercontent.com/6372810/200360112-db4de9f7-a70b-40ea-b94b-82221e92415b.png)


## References
- https://www.cncf.io/brand-guidelines/#logo

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
