### PR TITLE
fix: correct python write model example

### DIFF
--- a/src/components/Docs/SnippetViewer/WriteAuthzModelViewer.tsx
+++ b/src/components/Docs/SnippetViewer/WriteAuthzModelViewer.tsx
@@ -61,15 +61,7 @@ function writeAuthZModelViewerPython(authorizationModel: AuthorizationModel): st
 
 async def write_authorization_model():
     body_string = ${JSON.stringify(JSON.stringify(authorizationModel))}
-    body = openfga_sdk.model_utils.validate_and_convert_types(
-        json.loads(body_string),
-        (WriteAuthorizationModelRequest,),
-        ['WriteAuthorizationModelRequest'],
-        True,
-        True,
-        configuration=configuration
-    )
-    response = await fga_client_instance.write_authorization_model(body)
+    response = await fga_client_instance.write_authorization_model(json.loads(body))
     # response.authorization_model_id = "1uHxCSuTP0VKPYSnkq1pbb1jeZw"
 `;
 }


### PR DESCRIPTION

## Description
Do not use validate_and_convert_types as it is not available in our current python SDK.

<img width="1904" alt="Screen Shot 2022-11-18 at 9 40 43 AM" src="https://user-images.githubusercontent.com/10730463/202730950-d85a9083-e802-4691-8359-3570bcb5ce4d.png">


## References
Close https://github.com/openfga/openfga.dev/issues/281

## Review Checklist
- [X] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [X] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
