### PR TITLE
style: many CSS improvements for API page

### DIFF
--- a/src/components/SwaggerUI/swagger-ui-override.css
+++ b/src/components/SwaggerUI/swagger-ui-override.css
@@ -7116,6 +7116,14 @@
   }
 }
 
+.opblock-tag-section::before {
+  content: 'ENDPOINTS RELATED TO';
+  display: block;
+  font-size: 12px;
+  flex-grow: 100;
+  margin-bottom: -12px;
+}
+
 .swagger-ui .opblock-tag-section {
   display: flex;
   flex-direction: column;
@@ -7215,7 +7223,6 @@
 .swagger-ui .view-line-link {
   cursor: pointer;
   margin: 0 5px;
-  position: relative;
   top: 3px;
   transition: all 0.5s;
   width: 20px;
@@ -7255,11 +7262,8 @@
 }
 .swagger-ui .opblock .opblock-section-header {
   align-items: center;
-  background: hsla(0, 0%, 100%, 0.8);
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
   display: flex;
   min-height: 50px;
-  padding: 8px 20px;
 }
 .swagger-ui .opblock .opblock-section-header > label {
   align-items: center;
@@ -7271,11 +7275,14 @@
 }
 .swagger-ui .opblock .opblock-section-header > label > span {
   padding: 0 10px 0 0;
+  color: var(--ofga-neutral-base);
+  font-weight: 400;
 }
 .swagger-ui .opblock .opblock-section-header h4 {
-  color: #3b4151;
+  color: var(--ofga-color-foreground);
   flex: 1;
-  font-size: 14px;
+  font-weight: 400;
+  font-size: 18px;
   margin: 0;
 }
 .swagger-ui .opblock .opblock-summary-method {
@@ -7345,7 +7352,6 @@
     display: none;
   }
 }
-
 .swagger-ui .opblock .opblock-summary {
   align-items: center;
   cursor: pointer;
@@ -7353,20 +7359,22 @@
 }
 .swagger-ui .opblock .opblock-summary .view-line-link {
   cursor: pointer;
-  margin: 0;
-  position: relative;
+  margin: 0 -28px 0 0;
   top: 2px;
+  position: relative;
   transition: all 0.5s;
-  width: 0;
+  opacity: 0;
+}
+.swagger-ui .opblock:hover .opblock-summary .view-line-link {
+  margin: 0 -30px 0 0;
 }
 .swagger-ui .opblock .opblock-summary:hover .view-line-link {
-  margin: 0 5px;
-  width: 18px;
+  width: 32px;
+  opacity: 1;
 }
 .swagger-ui .opblock.opblock-post {
   border-color: transparent;
 }
-
 .swagger-ui .opblock.opblock-post .opblock-summary-method {
   background: var(--ofga-color-primary);
   color: var(--ofga-color-background);
@@ -7637,7 +7645,7 @@
   color: #fff;
   font-family: monospace;
   font-size: 12px;
-  font-weight: 600;
+  font-weight: 400;
   -webkit-hyphens: auto;
   -ms-hyphens: auto;
   hyphens: auto;
@@ -7853,7 +7861,6 @@
   color: #555;
   font-weight: 700;
 }
-
 .swagger-ui .btn {
   background: transparent;
   border: 2px solid gray;
@@ -7937,17 +7944,15 @@
   display: flex;
   /* align-content: center; */
   align-items: center;
+  padding: 0;
 }
-
 .swagger-ui .model-box-control {
   flex-direction: row;
   grid-gap: 0.5rem;
 }
-
 .swagger-ui .brace-open {
   margin-top: 1rem;
 }
-
 .swagger-ui .model-box-control svg,
 .swagger-ui .models-control svg,
 .swagger-ui .opblock-summary-control svg {
@@ -7956,7 +7961,8 @@
 .swagger-ui .model-box-control:focus,
 .swagger-ui .models-control:focus,
 .swagger-ui .opblock-summary-control:focus {
-  outline: auto;
+  outline: 0;
+  background-color: var(--ofga-color-background);
 }
 .swagger-ui .expand-methods,
 .swagger-ui .expand-operation {
@@ -7991,7 +7997,6 @@
 }
 .swagger-ui .copy-to-clipboard {
   align-items: center;
-  background: #7d8293;
   border: none;
   border-radius: 4px;
   bottom: 10px;
@@ -8001,6 +8006,14 @@
   position: absolute;
   right: 100px;
   width: 30px;
+}
+.swagger-ui .copy-to-clipboard::before {
+  content: 'copy';
+  display: block;
+  overflow: visible;
+  margin-left: -32px;
+  margin-right: 6px;
+  font-size: 12px;
 }
 .swagger-ui .copy-to-clipboard button {
   background: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="15" aria-hidden="true"><path fill="%23fff" fill-rule="evenodd" d="M4 12h4v1H4v-1zm5-6H4v1h5V6zm2 3V7l-3 3 3 3v-2h5V9h-5zM6.5 8H4v1h2.5V8zM4 11h2.5v-1H4v1zm9 1h1v2c-.02.28-.11.52-.3.7-.19.18-.42.28-.7.3H3c-.55 0-1-.45-1-1V3c0-.55.45-1 1-1h3c0-1.11.89-2 2-2 1.11 0 2 .89 2 2h3c.55 0 1 .45 1 1v5h-1V5H3v9h10v-2zM4 4h8c0-.55-.45-1-1-1h-1c-.55 0-1-.45-1-1s-.45-1-1-1-1 .45-1 1-.45 1-1 1H5c-.55 0-1 .45-1 1z"/></svg>')
@@ -8096,9 +8109,9 @@
 .swagger-ui input[disabled],
 .swagger-ui select[disabled],
 .swagger-ui textarea[disabled] {
-  background-color: #fafafa;
-  color: #888;
-  cursor: not-allowed;
+  background-color: var(--ofga-color-background);
+  border: 0;
+  color: #fff;
 }
 .swagger-ui select[disabled] {
   border-color: #888;
@@ -8644,15 +8657,14 @@
   font-weight: 700;
 }
 .swagger-ui .parameter__name.required span {
-  color: red;
+  color: transparent;
 }
 .swagger-ui .parameter__name.required:after {
-  color: rgba(255, 0, 0, 0.6);
+  color: var(--ofga-neon-green);
   content: 'required';
-  font-size: 10px;
-  padding: 5px;
+  font-size: 12px;
   position: relative;
-  top: -6px;
+  left: 0.5em;
 }
 .swagger-ui .parameter__extension,
 .swagger-ui .parameter__in {
@@ -8764,11 +8776,22 @@
   margin: 64px 0;
 }
 
+.description::before {
+  display: block;
+  content: 'DESCRIPTION';
+  font-size: 12px;
+  line-height: 2;
+}
+
+.swagger-ui .description p {
+  font-size: 18px;
+}
+
 .swagger-ui .info .description {
   background-color: var(--ofga-neutral-darker);
-  padding: 32px;
-  border-radius: 8px;
-  margin: 16px -32px;
+  border-radius: 0;
+  margin: 32px -32px;
+  padding: 48px 32px;
 }
 
 .swagger-ui .info.failed-config {
@@ -8820,8 +8843,23 @@
 }
 .swagger-ui .info .title {
   color: var(--ifm-color-primary-contrast-foreground);
-  font-size: 36px;
+  font-size: 48px;
   margin: 0;
+}
+.swagger-ui .info .title::after {
+  color: var(--ofga-neutral-light);
+  content: ' API Documentation';
+}
+.swagger-ui .url::before {
+  color: white;
+  content: 'JSON REFERENCE URL';
+  display: block;
+  font-size: 12px;
+  line-height: 2;
+  margin-top: 32px;
+}
+.swagger-ui .url {
+  font-size: 16px;
 }
 .swagger-ui .info .title small {
   background: #7d8492;
@@ -8992,15 +9030,22 @@
   padding: 0;
   white-space: pre-wrap;
 }
+.markdown > h2 {
+  margin-top: 3rem;
+}
 .swagger-ui .markdown code,
 .swagger-ui .renderedMarkdown code {
-  background: rgba(0, 0, 0, 0.05);
+  background: var(--ofga-color-background);
   border-radius: 4px;
   color: var(--ofga-color-primary-light);
   font-family: monospace;
   font-size: 14px;
-  font-weight: 600;
-  padding: 5px 7px;
+  font-weight: 400;
+  padding: 8px;
+}
+.swagger-ui .markdown p code {
+  padding: 2px 4px;
+  margin: 0px 4px;
 }
 .swagger-ui .markdown pre > code,
 .swagger-ui .renderedMarkdown pre > code {


### PR DESCRIPTION
## Description
- Copy endpoint button label
- focus outlines replaced with background colour cues
- code blocks styling updated
- disabled inputs less obtrusive
- contrast improved to readable level on several elements
- font weight in several areas (code blocks, code snippets) improved

## Before
![openfga-before](https://user-images.githubusercontent.com/6372810/205353461-5ca77cba-7327-4eac-987d-728f8c53ad12.gif)

## After
![openfga-after](https://user-images.githubusercontent.com/6372810/205353141-a901f848-1a82-498d-a905-3f13ab5595f6.gif)

## References
#289 

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
