### PR TITLE
chore: disable showing the migration schema page in sidebar

### DIFF
--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -214,11 +214,14 @@ const sidebars = {
               label: 'Migrating Relations',
               id: 'content/modeling/migrating-relations',
             },
+            /*
+            // for now, do not show the migrating schema page
             {
               type: 'doc',
               label: 'Migrating to Schema 1.1',
               id: 'content/modeling/migrating-schema-1-1',
             },
+            */
           ],
         },
       ],


### PR DESCRIPTION


## Description
Only show when everything is ready

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
