### PR TITLE
feat: add authorization model in callout

### DIFF
--- a/docs/content/interacting/relationship-queries.mdx
+++ b/docs/content/interacting/relationship-queries.mdx
@@ -295,6 +295,7 @@ The current implementation of List Objects API is not optimized and can return i
 Use the ListObjects API to get what objects a user can see based on the relationships they have. See [Search with Permissions](./search-with-permissions.mdx) for more guidance.
 
 <ListObjectsRequestViewer
+  authorizationModelId="1uHxCSuTP0VKPYSnkq1pbb1jeZw"
   objectType="document"
   relation="reader"
   user="user:bob"

--- a/docs/content/modeling/migrating/migrating-schema-1-1.mdx
+++ b/docs/content/modeling/migrating/migrating-schema-1-1.mdx
@@ -36,6 +36,12 @@ In short, we will be:
 
 To facilitate migration to the new DSL schema, you will need to update tuples that are no longer valid. In particular, all tuples whose `user` field involves a wildcard character (`*` or `user:*`) defined with model schema 1.0 <u><strong>MUST</strong></u> be deleted and re-added back.
 
+:::info
+
+Before starting to migrate to the new model schema, it is recommended that you obtain your current [authorization model ID](/api/service#/Authorization%20Models/ReadAuthorizationModels) and ensure that all your [check](../../concepts.mdx#what-is-a-check-request), [write](../../getting-started/update-tuples), [read](../../interacting/relationship-queries#read), [expand](../../interacting/relationship-queries#expand) and [list object](../../interacting/relationship-queries#listobjects) are performed against that model id. This allows consistent behavior in your production system until you are ready to switch to the new model. 
+
+:::
+
 ## <ProductName format={ProductNameFormat.ShortForm}/> Model Schema Versions
 
 Since the changes in the DSL are significant, we have decided to add a schema version to the DSL. The previous version of the DSL’s schema was `1.0`, and the new schema version will be `1.1`. To use the new syntax please add the following to the top of the model:

--- a/docs/content/modeling/migrating/migrating-schema-1-1.mdx
+++ b/docs/content/modeling/migrating/migrating-schema-1-1.mdx
@@ -38,7 +38,7 @@ To facilitate migration to the new DSL schema, you will need to update tuples th
 
 :::info
 
-Before starting to migrate to the new model schema, it is recommended that you obtain your current [authorization model ID](/api/service#/Authorization%20Models/ReadAuthorizationModels) and ensure that all your [check](../../concepts.mdx#what-is-a-check-request), [write](../../getting-started/update-tuples), [read](../../interacting/relationship-queries#read), [expand](../../interacting/relationship-queries#expand) and [list object](../../interacting/relationship-queries#listobjects) are performed against that model id. This allows consistent behavior in your production system until you are ready to switch to the new model. 
+Before starting to migrate to the new model schema, it is recommended that you obtain your current [authorization model ID](/api/service#/Authorization%20Models/ReadAuthorizationModels) and ensure that all your [check](../../concepts.mdx#what-is-a-check-request), [write](../../getting-started/update-tuples.mdx), [read](../../interacting/relationship-queries.mdx#read), [expand](../../interacting/relationship-queries.mdx#expand) and [list object](../../interacting/relationship-queries.mdx#listobjects) are performed against that model id. This allows consistent behavior in your production system until you are ready to switch to the new model. 
 
 :::
 

--- a/src/components/Docs/SnippetViewer/ExpandRequestViewer.tsx
+++ b/src/components/Docs/SnippetViewer/ExpandRequestViewer.tsx
@@ -1,8 +1,14 @@
-import { getFilteredAllowedLangs, SupportedLanguage, LanguageMappings } from './SupportedLanguage';
+import {
+  getFilteredAllowedLangs,
+  SupportedLanguage,
+  LanguageMappings,
+  DefaultAuthorizationModelId,
+} from './SupportedLanguage';
 import { defaultOperationsViewer } from './DefaultTabbedViewer';
 import assertNever from 'assert-never/index';
 
 interface ExpandRequestViewerOpts {
+  authorizationModelId?: string;
   relation: string;
   object: string;
   skipSetup?: boolean;
@@ -20,7 +26,9 @@ function expandRequestViewer(
       return `curl -X POST $FGA_API_URL/stores/$FGA_STORE_ID/expand \\
   -H "Authorization: Bearer $FGA_BEARER_TOKEN" \\ # Not needed if service does not require authorization
   -H "content-type: application/json" \\
-  -d '{"tuple_key":{"relation":"${opts.relation}","object":"${opts.object}"}}'
+  -d '{"tuple_key":{"relation":"${opts.relation}","object":"${opts.object}"}, "authorization_model_id": "${
+        opts.authorizationModelId ? opts.authorizationModelId : DefaultAuthorizationModelId
+      }"}'
 
 # Response: {"tree": ...}`;
     case SupportedLanguage.JS_SDK:
@@ -30,6 +38,7 @@ const { tree } = await fgaClient.expand({
     relation: '${opts.relation}', // expand all who has '${opts.relation}' relation
     object: '${opts.object}', // with the object '${opts.object}'
   },
+  authorization_model_id: '${opts.authorizationModelId ? opts.authorizationModelId : DefaultAuthorizationModelId}'
 });
 
 // tree = ...`;
@@ -42,6 +51,9 @@ body := fgaSdk.ExpandRequest{
 		Relation: fgaSdk.PtrString("${opts.relation}"), // expand all who has "${opts.relation}" relation
 		Object: fgaSdk.PtrString("${opts.object}"), // with the object "${opts.object}"
 	},
+\tAuthorizationModelId: fgaSdk.PtrString("${
+        opts.authorizationModelId ? opts.authorizationModelId : DefaultAuthorizationModelId
+      }"),
 }
 data, response, err := fgaClient.${languageMappings['go'].apiName}.Expand(context.Background()).Body(body).Execute()
 
@@ -53,12 +65,13 @@ data, response, err := fgaClient.${languageMappings['go'].apiName}.Expand(contex
 var response = await fgaClient.Expand(new ExpandRequest(new TupleKey() {
     Relation = "${opts.relation}",  // expand all who has "${opts.relation}" relation
     Object = "${opts.object}" // with the object "${opts.object}"
-}));
+},   AuthorizationModelId = "${opts.authorizationModelId ? opts.authorizationModelId : DefaultAuthorizationModelId}"));
 // response = { tree: ... }`;
     case SupportedLanguage.RPC:
       return `expand(
   "${opts.relation}", // expand all who has \`${opts.relation}\` relation
-  "${opts.object}" // with the object \`${opts.object}\`
+  "${opts.object}", // with the object \`${opts.object}\`
+  authorization_model_id="${opts.authorizationModelId ? opts.authorizationModelId : DefaultAuthorizationModelId}"
 );
 
 Reply: {tree:...}`;
@@ -74,7 +87,10 @@ async def expand():
         tuple_key=TupleKey(
             relation: "${opts.relation}",
             object: "${opts.object}",
-        )
+        ),
+        authorization_model_id: "${
+          opts.authorizationModelId ? opts.authorizationModelId : DefaultAuthorizationModelId
+        }",
     )
     response = await fga_client_instance.expand(body)
     # response = ExpandResponse({"tree":...})

--- a/src/components/Docs/SnippetViewer/ListObjectsRequestViewer.tsx
+++ b/src/components/Docs/SnippetViewer/ListObjectsRequestViewer.tsx
@@ -1,4 +1,9 @@
-import { getFilteredAllowedLangs, SupportedLanguage, LanguageMappings } from './SupportedLanguage';
+import {
+  getFilteredAllowedLangs,
+  SupportedLanguage,
+  LanguageMappings,
+  DefaultAuthorizationModelId,
+} from './SupportedLanguage';
 import { defaultOperationsViewer } from './DefaultTabbedViewer';
 import assertNever from 'assert-never/index';
 import { TupleKey } from '@openfga/sdk';
@@ -29,7 +34,7 @@ function listObjectsRequestViewer(
       return `curl -X POST $FGA_API_URL/stores/$FGA_STORE_ID/list-objects \\
   -H "Authorization: Bearer $FGA_BEARER_TOKEN" \\ # Not needed if service does not require authorization
   -H "content-type: application/json" \\
-  -d '{
+  -d '{ "authorization_model_id": "${authorizationModelId ? authorizationModelId : DefaultAuthorizationModelId}",
         "type": "${objectType}",
         "relation": "${relation}",
         "user":"${user}"${
@@ -52,12 +57,8 @@ function listObjectsRequestViewer(
 # Response: {"object_ids": [${expectedResults.map((r) => `"${r}"`).join(', ')}]}`;
     /* eslint-enable max-len */
     case SupportedLanguage.JS_SDK:
-      return `const response = await fgaClient.listObjects({${
-        authorizationModelId
-          ? `
-  authorization_model_id: "${authorizationModelId}",`
-          : ``
-      }
+      return `const response = await fgaClient.listObjects({
+  authorization_model_id: "${authorizationModelId ? authorizationModelId : DefaultAuthorizationModelId}",
   user: "${user}",
   relation: "${relation}",
   type: "${objectType}",${
@@ -80,12 +81,8 @@ function listObjectsRequestViewer(
 // response.object_ids = [${expectedResults.map((r) => `"${r}"`).join(', ')}]`;
     case SupportedLanguage.GO_SDK:
       /* eslint-disable no-tabs */
-      return `body := fgaSdk.ListObjectsRequest{${
-        authorizationModelId
-          ? `
-    AuthorizationModelId: PtrString("${authorizationModelId}"),`
-          : ``
-      }
+      return `body := fgaSdk.ListObjectsRequest{
+    AuthorizationModelId: PtrString("${authorizationModelId ? authorizationModelId : DefaultAuthorizationModelId}"),
     User:                 PtrString("${user}"),
     Relation:             PtrString("${relation}"),
     Type:                 PtrString("${objectType}"),${
@@ -112,12 +109,8 @@ data, response, err := apiClient.${
 
 // data = { "object_ids": [${expectedResults.map((r) => `"${r}"`).join(', ')}] }`;
     case SupportedLanguage.DOTNET_SDK:
-      return `var body = new ListObjectsRequest{${
-        authorizationModelId
-          ? `
-    AuthorizationModelId = "${authorizationModelId}",`
-          : ``
-      }
+      return `var body = new ListObjectsRequest{
+    AuthorizationModelId = "${authorizationModelId ? authorizationModelId : DefaultAuthorizationModelId}",
     User = "${user}",
     Relation = "${relation}",
     Type = "${objectType}",${
@@ -145,7 +138,8 @@ var response = await openFgaApi.ListObjects(body);
 # from openfga_sdk.models.contextual_tuple_keys import ContextualTupleKeys
 
 async def list_objects():
-    body = ListObjectsRequest(${authorizationModelId ? `authorization_model_id="${authorizationModelId}",` : ``}
+    body = ListObjectsRequest(
+        authorization_model_id="${authorizationModelId ? authorizationModelId : DefaultAuthorizationModelId}",
         user="${user}",
         relation="${relation}",
         type="${objectType}",${
@@ -172,12 +166,10 @@ async def list_objects():
       return `listObjects(
   "${user}", // list the objects that the user \`${user}\`
   "${relation}", // has an \`${relation}\` relation
-  "${objectType}", // and that are of type \`${objectType}\`${
-        authorizationModelId
-          ? `
-  authorization_model_id = "${authorizationModelId}", // for this particular authorization model id`
-          : ``
-      }${
+  "${objectType}", // and that are of type \`${objectType}\`
+  authorization_model_id = "${
+    authorizationModelId ? authorizationModelId : DefaultAuthorizationModelId
+  }", // for this particular authorization model id ${
         contextualTuples
           ? `
   contextual_tuples = [ // Assuming the following is true

--- a/src/components/Docs/SnippetViewer/SupportedLanguage.tsx
+++ b/src/components/Docs/SnippetViewer/SupportedLanguage.tsx
@@ -64,3 +64,5 @@ export interface LanguageMapping {
 export interface LanguageMappings {
   [key: string]: LanguageMapping;
 }
+
+export const DefaultAuthorizationModelId = '1uHxCSuTP0VKPYSnkq1pbb1jeZw';


### PR DESCRIPTION


## Description
For Check, Expand, Read, Write, ListObject API callout, include authorization model id.  In addition, mention obtaining authorization model id as first step in migrating schema.


https://user-images.githubusercontent.com/10730463/207643663-4e86044d-54fd-4ede-a103-935d77f861ac.mov


https://user-images.githubusercontent.com/10730463/207643918-7f3675dd-1857-44a6-b068-d11211afbdf1.mov


## References
Close https://github.com/openfga/openfga.dev/issues/307

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
