### PR TITLE
fix: dotnet write callout authorization model id

### DIFF
--- a/src/components/Docs/SnippetViewer/WriteRequestViewer.tsx
+++ b/src/components/Docs/SnippetViewer/WriteRequestViewer.tsx
@@ -169,7 +169,7 @@ ${deleteTuples}
       return `
 await fgaClient.Write(new WriteRequest{
   ${opts.relationshipTuples ? writes : ''}${separator}${opts.deleteRelationshipTuples ? deletes : ''},
-  authorization_model_id: "${opts.authorizationModelId ? opts.authorizationModelId : DefaultAuthorizationModelId}"
+  AuthorizationModelId = "${opts.authorizationModelId ? opts.authorizationModelId : DefaultAuthorizationModelId}"
 });`;
     }
 


### PR DESCRIPTION
## Description
Correct the .NET callout for write.  It should be `AuthorizationModelId="xxx"` instead of `authorization_model_id:"xxx"`

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
