### PR TITLE
fix: read does not use authorization id

### DIFF
--- a/src/components/Docs/SnippetViewer/CheckRequestViewer.tsx
+++ b/src/components/Docs/SnippetViewer/CheckRequestViewer.tsx
@@ -124,20 +124,20 @@ data, response, err := fgaClient.${languageMappings['go'].apiName}.Check(context
     case SupportedLanguage.DOTNET_SDK:
       return `
 // Run a check
-var response = await fgaClient.Check(new CheckRequest(new TupleKey() {
+var response = await fgaClient.Check{TupleKey = new CheckRequest(new TupleKey() {
   User = "${user}",
   Relation = "${relation}",
   Object = "${object}"
 }${
         contextualTuples
           ? `,
-  new ContextualTupleKeys(new List<TupleKey>({
+    ContextualTuples = new ContextualTupleKeys(new List<TupleKey>({
     ${contextualTuples
       .map((tuple) => `new(user: "${tuple.user}", relation: "${tuple.relation}", _object: "${tuple.object}")`)
       .join(',\n    ')}
 }))`
           : ''
-      }, AuthorizationModelId = "${authorizationModelId ? authorizationModelId : DefaultAuthorizationModelId}");
+      }, AuthorizationModelId = "${authorizationModelId ? authorizationModelId : DefaultAuthorizationModelId}"};
 
 // response.Allowed = ${allowed}`;
     case SupportedLanguage.PYTHON_SDK:

--- a/src/components/Docs/SnippetViewer/ExpandRequestViewer.tsx
+++ b/src/components/Docs/SnippetViewer/ExpandRequestViewer.tsx
@@ -62,10 +62,10 @@ data, response, err := fgaClient.${languageMappings['go'].apiName}.Expand(contex
     /* eslint-enable no-tabs */
     case SupportedLanguage.DOTNET_SDK:
       return `
-var response = await fgaClient.Expand(new ExpandRequest(new TupleKey() {
+var response = await fgaClient.Expand{TupleKey = new ExpandRequest(new TupleKey() {
     Relation = "${opts.relation}",  // expand all who has "${opts.relation}" relation
     Object = "${opts.object}" // with the object "${opts.object}"
-},   AuthorizationModelId = "${opts.authorizationModelId ? opts.authorizationModelId : DefaultAuthorizationModelId}"));
+},   AuthorizationModelId = "${opts.authorizationModelId ? opts.authorizationModelId : DefaultAuthorizationModelId}"});
 // response = { tree: ... }`;
     case SupportedLanguage.RPC:
       return `expand(

--- a/src/components/Docs/SnippetViewer/ReadRequestViewer.tsx
+++ b/src/components/Docs/SnippetViewer/ReadRequestViewer.tsx
@@ -1,9 +1,4 @@
-import {
-  getFilteredAllowedLangs,
-  SupportedLanguage,
-  LanguageMappings,
-  DefaultAuthorizationModelId,
-} from './SupportedLanguage';
+import { getFilteredAllowedLangs, SupportedLanguage, LanguageMappings } from './SupportedLanguage';
 import { defaultOperationsViewer } from './DefaultTabbedViewer';
 import assertNever from 'assert-never/index';
 
@@ -14,7 +9,7 @@ interface ReadTuples {
 }
 
 interface ReadRequestViewerOpts {
-  authorizationModelId?: string;
+  ModelId?: string;
   user?: string;
   relation?: string;
   object: string;
@@ -45,9 +40,7 @@ function readRequestViewer(lang: SupportedLanguage, opts: ReadRequestViewerOpts,
       return `curl -X POST $FGA_API_URL/stores/$FGA_STORE_ID/read \\
   -H "Authorization: Bearer $FGA_BEARER_TOKEN" \\ # Not needed if service does not require authorization
   -H "content-type: application/json" \\
-  -d '{"tuple_key":{${requestTuples}}, "authorization_model_id":"${
-        opts.authorizationModelId ? opts.authorizationModelId : DefaultAuthorizationModelId
-      }"}'
+  -d '{"tuple_key":{${requestTuples}}}'
 
 # Response: "tuples": {[${readTuples}]}`;
     }
@@ -63,7 +56,6 @@ const { tuples } = await fgaClient.read({
   tuple_key: {
 ${requestTuples}
   },
-  authorization_model_id: "${opts.authorizationModelId ? opts.authorizationModelId : DefaultAuthorizationModelId}",
 });
 
 // tuples = [${readTuples}]
@@ -82,9 +74,6 @@ body := fgaSdk.ReadRequest{
 	TupleKey: &fgaSdk.TupleKey{
 ${requestTuples}
 	},
-\tAuthorizationModelId: fgaSdk.PtrString("${
-        opts.authorizationModelId ? opts.authorizationModelId : DefaultAuthorizationModelId
-      }"),
 }
 data, response, err := fgaClient.${languageMappings['go'].apiName}.Read(context.Background()).Body(body).Execute()
 
@@ -101,7 +90,7 @@ data, response, err := fgaClient.${languageMappings['go'].apiName}.Read(context.
       return `
 var response = fgaClient.Read(new ReadRequest(new TupleKey() {
 ${requestTuples}
-}, AuthorizationModelId = "${opts.authorizationModelId ? opts.authorizationModelId : DefaultAuthorizationModelId}"));
+}));
 
 // data = { "tuples": [${readTuples}] }`;
     }
@@ -121,7 +110,6 @@ async def read():
         tuple_key=TupleKey(
 ${requestTuples}
         ),
-        authorization_model_id="${opts.authorizationModelId ? opts.authorizationModelId : DefaultAuthorizationModelId}",
     )
     response = await fga_client_instance.read(body)
     # response = ReadResponse({"tuples":[${readTuples}]})`;
@@ -148,7 +136,6 @@ ${requestTuples}
       return `read(
   // read all stored tuples
 ${requestTuples}
-  authorization_model_id="${opts.authorizationModelId ? opts.authorizationModelId : DefaultAuthorizationModelId}"
 );
 
 Reply: tuples:[${readTuples}]`;


### PR DESCRIPTION

## Description
Read does not take in authorization model id
Also, the .NET Request should use {} if we want to use optional parameter such as AuthorizationModelId.

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
