### PR TITLE
fix: read does not have authorization model id

### DIFF
--- a/docs/content/modeling/migrating/migrating-schema-1-1.mdx
+++ b/docs/content/modeling/migrating/migrating-schema-1-1.mdx
@@ -38,7 +38,7 @@ To facilitate migration to the new DSL schema, you will need to update tuples th
 
 :::info
 
-Before starting to migrate to the new model schema, it is recommended that you obtain your current [authorization model ID](/api/service#/Authorization%20Models/ReadAuthorizationModels) and ensure that all your [check](../../concepts.mdx#what-is-a-check-request), [write](../../getting-started/update-tuples.mdx), [read](../../interacting/relationship-queries.mdx#read), [expand](../../interacting/relationship-queries.mdx#expand) and [list object](../../interacting/relationship-queries.mdx#listobjects) are performed against that model id. This allows consistent behavior in your production system until you are ready to switch to the new model. 
+Before starting to migrate to the new model schema, it is recommended that you obtain your current [authorization model ID](/api/service#/Authorization%20Models/ReadAuthorizationModels) and ensure that all your [check](../../concepts.mdx#what-is-a-check-request), [write](../../getting-started/update-tuples.mdx), [expand](../../interacting/relationship-queries.mdx#expand) and [list object](../../interacting/relationship-queries.mdx#listobjects) are performed against that model id. This allows consistent behavior in your production system until you are ready to switch to the new model. 
 
 :::
 


### PR DESCRIPTION

## Description
Migration schema page should not tell user to read for particular authorization model id.


## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [X] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [X] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
