### PR TITLE
fix: update trademark line to satisfy clomonitor

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -99,8 +99,8 @@ import json
 import openfga_sdk
 from openfga_sdk.api import open_fga_api`,
         apiName: `OpenFgaApi`,
-        setupNote: `# ApiTokenIssuer, ApiAudience, ClientId and ClientSecret are optional.\n`, 
-      }
+        setupNote: `# ApiTokenIssuer, ApiAudience, ClientId and ClientSecret are optional.\n`,
+      },
     },
     contentSecurityPolicy: `default-src 'none';
       base-uri 'self';
@@ -281,7 +281,7 @@ from openfga_sdk.api import open_fga_api`,
             label: 'Github',
           },
         ],
-        copyright: `<div><a href="https://www.linuxfoundation.org/legal/trademark-usage"><img src="/img/cncf-icon-white.svg" alt="CNCF" style="vertical-align:middle" /></a> @ ${new Date().getFullYear()}</div>`,
+        copyright: `<div><a href="https://www.linuxfoundation.org/trademark-usage"><img src="/img/cncf-icon-white.svg" alt="CNCF" style="vertical-align:middle; margin-right:8px;" /></a> &copy; ${new Date().getFullYear()} <a href="https://www.linuxfoundation.org/" target="_blank">The Linux Foundation</a>®. All rights reserved. <span class="display-on-desktop">For a list of trademarks of The Linux Foundation, see our <a href="https://www.linuxfoundation.org/trademark-usage" class="light-text" target="blank">Trademark Usage page</a>.</span></div>`,
       },
       prism: {
         theme: lightCodeTheme,

--- a/package-lock.json
+++ b/package-lock.json
@@ -16861,7 +16861,7 @@
       "requires": {
         "@humanwhocodes/object-schema": "^1.2.1",
         "debug": "^4.1.1",
-        "minimatch": "3.0.5"
+        "minimatch": "^3.0.4"
       },
       "dependencies": {
         "minimatch": {
@@ -20215,7 +20215,7 @@
         "fs-extra": "^9.0.0",
         "glob": "^7.1.6",
         "memfs": "^3.1.2",
-        "minimatch": "3.0.5",
+        "minimatch": "^3.0.4",
         "schema-utils": "2.7.0",
         "semver": "^7.3.2",
         "tapable": "^1.0.0"

--- a/static/css/openfga.css
+++ b/static/css/openfga.css
@@ -21,12 +21,12 @@
   --ofga-neutral-lightest: #f4f6f7;
   --ofga-neutral-white: #ffffff;
 
-  --ofga-color-default: #FFFFFF;
+  --ofga-color-default: #ffffff;
   --ofga-color-comment: #737981;
-  --ofga-color-keyword: #AAAAAA;
-  --ofga-color-type: #79ED83;
-  --ofga-color-relation: #20F1F5;
-  --ofga-color-directly-assignable: #CEEC93;
+  --ofga-color-keyword: #aaaaaa;
+  --ofga-color-type: #79ed83;
+  --ofga-color-relation: #20f1f5;
+  --ofga-color-directly-assignable: #ceec93;
 
   --ofga-color-primary: var(--ofga-green-neon);
   --ofga-color-primary-dark: var(--ofga-green-dark);
@@ -643,4 +643,14 @@ pre {
   color: #522c09;
   letter-spacing: 0.8px;
   text-transform: uppercase;
+}
+
+.display-on-desktop {
+  display: none;
+}
+
+@media screen and (min-width: 1200px) {
+  .display-on-desktop {
+    display: inline;
+  }
 }


### PR DESCRIPTION
Change the docusaurus footer config to make sure the trademark and copyright info satisfies clomonitor.

## Description
Currently we have a very bare-bones footer:

![SCR-20221216-i5v](https://user-images.githubusercontent.com/6372810/208151421-9d45f9e4-5978-4978-a6d0-ac36a079ff1f.png)

The clomonitor service looks for a different trademark URL in order to be satisfied that we're accounting for The Linux Foundation's trademark ownership:

`"https://(?:w{3}\.)?linuxfoundation.org/trademark-usage"`

While updating that, I've added some additional words and links in order to be more complete:

![SCR-20221216-i5f](https://user-images.githubusercontent.com/6372810/208151455-a536bc8c-a3d7-4382-9ab4-cdc183019ddb.png)

And added a CSS rule to hide part of it and simplify the footer on mobile:

![SCR-20221216-i5k](https://user-images.githubusercontent.com/6372810/208151514-c63ea846-0187-45e5-acd6-12ced3247df8.png)

## References
https://clomonitor.io/docs/topics/checks/#trademark-disclaimer

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
