### PR TITLE
fix: add description for pages where the first line uses JS component

### DIFF
--- a/docs/content/concepts.mdx
+++ b/docs/content/concepts.mdx
@@ -2,7 +2,7 @@
 title: Concepts
 sidebar_position: 2
 slug: /concepts
-description: Learn about FGA concepts
+description: Learning about FGA concepts
 ---
 
 import {

--- a/docs/content/concepts.mdx
+++ b/docs/content/concepts.mdx
@@ -2,6 +2,7 @@
 title: Concepts
 sidebar_position: 2
 slug: /concepts
+description: Learn about FGA concepts
 ---
 
 import {

--- a/docs/content/configuration-language.mdx
+++ b/docs/content/configuration-language.mdx
@@ -2,7 +2,7 @@
 title: Configuration Language
 sidebar_position: 2
 slug: /configuration-language
-description: Learn how to use configuration language to build a representation of a system's authorization model
+description: Learning about FGA configuration language and using it to build a representation of a system's authorization model
 ---
 
 import {

--- a/docs/content/configuration-language.mdx
+++ b/docs/content/configuration-language.mdx
@@ -2,6 +2,7 @@
 title: Configuration Language
 sidebar_position: 2
 slug: /configuration-language
+description: Learn how to use configuration language to build a representation of a system's authorization model
 ---
 
 import {

--- a/docs/content/getting-started/configure-model.mdx
+++ b/docs/content/getting-started/configure-model.mdx
@@ -1,6 +1,6 @@
 ---
 title: Configure Authorization Model
-description: How to configure authorization model for a store
+description: Configuring authorization model for a store
 slug: /getting-started/configure-model
 ---
 

--- a/docs/content/getting-started/create-store.mdx
+++ b/docs/content/getting-started/create-store.mdx
@@ -1,6 +1,6 @@
 ---
 title: Create a Store
-description: How to create a store
+description: Creating a store
 slug: /getting-started/create-store
 ---
 

--- a/docs/content/getting-started/framework.mdx
+++ b/docs/content/getting-started/framework.mdx
@@ -2,6 +2,8 @@
 title: Integrate Within a Framework
 sidebar_position: 5
 slug: /getting-started/framework
+description: Integrate FGA within a framework environment, such as Fastify or Fiber.
+
 ---
 
 import {

--- a/docs/content/getting-started/framework.mdx
+++ b/docs/content/getting-started/framework.mdx
@@ -2,7 +2,7 @@
 title: Integrate Within a Framework
 sidebar_position: 5
 slug: /getting-started/framework
-description: Integrate FGA within a framework environment, such as Fastify or Fiber.
+description: Integrating FGA within a framework, such as Fastify or Fiber
 
 ---
 
@@ -23,7 +23,7 @@ import TabItem from '@theme/TabItem';
 
 <DocumentationNotice />
 
-This section will illustrate how to integrate <ProductName format={ProductNameFormat.LongForm}/> within a framework environment, such as [Fastify](https://www.fastify.io/) or [Fiber](https://docs.gofiber.io/).
+This section will illustrate how to integrate <ProductName format={ProductNameFormat.LongForm}/> within a framework, such as [Fastify](https://www.fastify.io/) or [Fiber](https://docs.gofiber.io/).
 
 ## Before You Start
 

--- a/docs/content/getting-started/install-sdk.mdx
+++ b/docs/content/getting-started/install-sdk.mdx
@@ -2,7 +2,7 @@
 title: Install SDK Client
 sidebar_position: 2
 slug: /getting-started/install-sdk
-description: Installing the SDK client
+description: Installing SDK client
 ---
 
 import {

--- a/docs/content/getting-started/install-sdk.mdx
+++ b/docs/content/getting-started/install-sdk.mdx
@@ -2,6 +2,7 @@
 title: Install SDK Client
 sidebar_position: 2
 slug: /getting-started/install-sdk
+description: Installing the SDK client
 ---
 
 import {

--- a/docs/content/getting-started/perform-check.mdx
+++ b/docs/content/getting-started/perform-check.mdx
@@ -2,7 +2,7 @@
 title: Perform a Check
 sidebar_position: 4
 slug: /getting-started/perform-check
-description: Perform a check request to determine whether a user has a certain relationship with an object.
+description: Checking if a user is authorized to perform an action on a resource
 ---
 
 import {

--- a/docs/content/getting-started/perform-check.mdx
+++ b/docs/content/getting-started/perform-check.mdx
@@ -2,6 +2,7 @@
 title: Perform a Check
 sidebar_position: 4
 slug: /getting-started/perform-check
+description: Perform a check request to determine whether a user has a certain relationship with an object.
 ---
 
 import {

--- a/docs/content/getting-started/setup-openfga.mdx
+++ b/docs/content/getting-started/setup-openfga.mdx
@@ -1,6 +1,6 @@
 ---
 title: Setup OpenFGA Server
-description: Setup the OpenFGA server
+description: Setting up an OpenFGA server
 sidebar_position: 1
 slug: /getting-started/setup-openfga
 ---

--- a/docs/content/getting-started/update-tuples.mdx
+++ b/docs/content/getting-started/update-tuples.mdx
@@ -2,6 +2,7 @@
 title: Update Relationship Tuples
 sidebar_position: 3
 slug: /getting-started/update-tuples
+description: Update relationship tuples
 ---
 
 import {

--- a/docs/content/getting-started/update-tuples.mdx
+++ b/docs/content/getting-started/update-tuples.mdx
@@ -2,7 +2,7 @@
 title: Update Relationship Tuples
 sidebar_position: 3
 slug: /getting-started/update-tuples
-description: Update relationship tuples
+description: Updating system state by writing and deleting relationship tuples
 ---
 
 import {

--- a/docs/content/interacting/managing-group-access.mdx
+++ b/docs/content/interacting/managing-group-access.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 3
 slug: /interacting/managing-group-access
+description: Granting a group of users access to a particular object 
 ---
 
 import {
@@ -20,7 +21,7 @@ import {
 
 <DocumentationNotice />
 
-In this guide you will learn how to give a group of users access to a particular object.
+In this guide you will learn how to grant a group of users access to a particular object.
 
 <CardBox title="When to use" appearance="filled" description=<div>
 

--- a/docs/content/interacting/managing-group-membership.mdx
+++ b/docs/content/interacting/managing-group-membership.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 1
 slug: /interacting/managing-group-membership
+description: Updating a user's membership to a group by adding and removing them from it
 ---
 
 import {

--- a/docs/content/interacting/managing-relationships-between-objects.mdx
+++ b/docs/content/interacting/managing-relationships-between-objects.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 2
 slug: /interacting/managing-relationships-between-objects
+description: Granting a user access to a particular object through a relationship with another object
 ---
 
 import {
@@ -19,7 +20,7 @@ import {
 
 <DocumentationNotice />
 
-In this guide you will learn how to give a user access to a particular object through a relationship with another object.
+In this guide you will learn how to grant a user access to a particular object through a relationship with another object.
 
 <CardBox title="When to use" appearance="filled" description=<div>
 

--- a/docs/content/interacting/managing-user-access.mdx
+++ b/docs/content/interacting/managing-user-access.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 3
 slug: /interacting/managing-user-access
+description: Give a user access to a particular object.
 ---
 
 import {

--- a/docs/content/interacting/managing-user-access.mdx
+++ b/docs/content/interacting/managing-user-access.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 3
 slug: /interacting/managing-user-access
-description: Give a user access to a particular object.
+description: Granting a user access to a particular object
 ---
 
 import {
@@ -21,7 +21,7 @@ import {
 
 <DocumentationNotice />
 
-In this guide you will learn how to give a <ProductConcept section="what-is-a-user" linkName="user" /> access to a particular <ProductConcept section="what-is-an-object" linkName="object" />.
+In this guide you will learn how to grant a <ProductConcept section="what-is-a-user" linkName="user" /> access to a particular <ProductConcept section="what-is-an-object" linkName="object" />.
 
 <CardBox title="When to use" appearance="filled" description=<div>
 

--- a/docs/content/interacting/overview.mdx
+++ b/docs/content/interacting/overview.mdx
@@ -3,7 +3,7 @@ id: overview
 title: 'Interacting with the API'
 slug: /interacting
 sidebar_position: 0
-description: Programmatically write authorization related data and interact with the API
+description: Programmatically writing authorization related data and interact with the API
 ---
 
 import { DocumentationNotice, IntroCard, CardGrid, ProductName, ProductNameFormat } from '@components/Docs';

--- a/docs/content/interacting/overview.mdx
+++ b/docs/content/interacting/overview.mdx
@@ -3,6 +3,7 @@ id: overview
 title: 'Interacting with the API'
 slug: /interacting
 sidebar_position: 0
+description: Programmatically write authorization related data and interact with the API
 ---
 
 import { DocumentationNotice, IntroCard, CardGrid, ProductName, ProductNameFormat } from '@components/Docs';

--- a/docs/content/interacting/read-tuple-changes.mdx
+++ b/docs/content/interacting/read-tuple-changes.mdx
@@ -2,6 +2,7 @@
 title: How to get tuple changes
 sidebar_position: 1
 slug: /interacting/read-tuple-changes
+description: Getting tuple changes
 ---
 
 import {

--- a/docs/content/interacting/relationship-queries.mdx
+++ b/docs/content/interacting/relationship-queries.mdx
@@ -2,7 +2,7 @@
 title: 'Relationship Queries: Check, Read, Expand, and ListObjects'
 sidebar_position: 6
 slug: /interacting/relationship-queries
-description: An overview of how to use the Check, Read, Expand, and ListObject APIs.
+description: An overview of how to use the Check, Read, Expand, and ListObject APIs
 ---
 
 import {

--- a/docs/content/interacting/search-with-permissions.mdx
+++ b/docs/content/interacting/search-with-permissions.mdx
@@ -1,6 +1,6 @@
 ---
 title: Search With Permissions
-description: The recommended ways to integrate FGA into your search
+description: Integrating FGA into your search
 sidebar_position: 1
 slug: /interacting/search-with-permissions
 ---

--- a/docs/content/interacting/transactional-writes.mdx
+++ b/docs/content/interacting/transactional-writes.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 2
 slug: /interacting/transactional-writes
+description: Update multiple relationship tuples in a single transaction.
 ---
 
 import {

--- a/docs/content/interacting/transactional-writes.mdx
+++ b/docs/content/interacting/transactional-writes.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 2
 slug: /interacting/transactional-writes
-description: Update multiple relationship tuples in a single transaction.
+description: Updating multiple relationship tuples in a single transaction
 ---
 
 import {

--- a/docs/content/modeling/advanced/entitlements.mdx
+++ b/docs/content/modeling/advanced/entitlements.mdx
@@ -1,6 +1,6 @@
 ---
 title: Entitlements
-description: Modeling Entitlements for a System
+description: Modeling entitlements for a system
 sidebar_position: 1
 slug: /modeling/advanced/entitlements
 ---

--- a/docs/content/modeling/advanced/iot.mdx
+++ b/docs/content/modeling/advanced/iot.mdx
@@ -1,6 +1,6 @@
 ---
 title: IoT
-description: Modeling Fine Grained Authorization for an IoT Security Camera System
+description: Modeling fine grained authorization for an IoT security camera system
 sidebar_position: 3
 slug: /modeling/advanced/iot
 ---

--- a/docs/content/modeling/advanced/overview.mdx
+++ b/docs/content/modeling/advanced/overview.mdx
@@ -3,6 +3,7 @@ id: overview
 title: 'Advanced Use-Cases'
 slug: /modeling/advanced
 sidebar_position: 0
+description: Advanced use cases and patterns for authorization modeling
 ---
 
 import { CardGrid, DocumentationNotice, IntroCard, ProductName, ProductNameFormat } from '@components/Docs';

--- a/docs/content/modeling/advanced/slack.mdx
+++ b/docs/content/modeling/advanced/slack.mdx
@@ -1,6 +1,6 @@
 ---
 title: Slack
-description: Modeling Authorization for Slack
+description: Modeling authorization for Slack
 sidebar_position: 4
 slug: /modeling/advanced/slack
 ---

--- a/docs/content/modeling/blocklists.mdx
+++ b/docs/content/modeling/blocklists.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 8
 slug: /modeling/blocklists
+description: Model to prevent certain users from accessing objects.
 ---
 
 import {

--- a/docs/content/modeling/blocklists.mdx
+++ b/docs/content/modeling/blocklists.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 8
 slug: /modeling/blocklists
-description: Model to prevent certain users from accessing objects.
+description: Preventing certain users from accessing objects
 ---
 
 import {

--- a/docs/content/modeling/building-blocks/object-to-object-relationships.mdx
+++ b/docs/content/modeling/building-blocks/object-to-object-relationships.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 2
 slug: /modeling/building-blocks/object-to-object-relationships
-description: Model your application with objects that are not specifically tied to a user
+description: Modeling relationships between objects (e.g. folder parent of a document)
 ---
 
 import {

--- a/docs/content/modeling/building-blocks/object-to-object-relationships.mdx
+++ b/docs/content/modeling/building-blocks/object-to-object-relationships.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 2
 slug: /modeling/building-blocks/object-to-object-relationships
+description: Model your application with objects that are not specifically tied to a user
 ---
 
 import {

--- a/docs/content/modeling/building-blocks/usersets.mdx
+++ b/docs/content/modeling/building-blocks/usersets.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 2
 slug: /modeling/building-blocks/usersets
+description: Modeling with userset
 ---
 
 import {

--- a/docs/content/modeling/contextual-time-based-authorization.mdx
+++ b/docs/content/modeling/contextual-time-based-authorization.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 8
 slug: /modeling/contextual-time-based-authorization
-description: Model where the expected authorization check may depend on certain dynamic or contextual data (such as time, location, ip address, weather) that have not been written.
+description: Checking relations that depends on certain dynamic or contextual data (such as time, location, ip address, weather) that have not been written
 ---
 
 import {

--- a/docs/content/modeling/contextual-time-based-authorization.mdx
+++ b/docs/content/modeling/contextual-time-based-authorization.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 8
 slug: /modeling/contextual-time-based-authorization
+description: Model where the expected authorization check may depend on certain dynamic or contextual data (such as time, location, ip address, weather) that have not been written.
 ---
 
 import {

--- a/docs/content/modeling/custom-roles.mdx
+++ b/docs/content/modeling/custom-roles.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 8
 slug: /modeling/custom-roles
-description: Model custom & dynamically changing roles in your system
+description: Modeling custom and dynamically changing roles in your system
 ---
 
 import {

--- a/docs/content/modeling/direct-access.mdx
+++ b/docs/content/modeling/direct-access.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 1
 slug: /modeling/direct-access
+description: Model to grant a user access to an object
 ---
 
 import {

--- a/docs/content/modeling/direct-access.mdx
+++ b/docs/content/modeling/direct-access.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 1
 slug: /modeling/direct-access
-description: Model to grant a user access to an object
+description: Granting a user access to an object
 ---
 
 import {

--- a/docs/content/modeling/migrating/migrating-relations.mdx
+++ b/docs/content/modeling/migrating/migrating-relations.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 1
 slug: /modeling/migrating/migrating-relations
+description: Migrating relations
 ---
 
 import {

--- a/docs/content/modeling/migrating/migrating-schema-1-1.mdx
+++ b/docs/content/modeling/migrating/migrating-schema-1-1.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 2
 slug: /modeling/migrating/migrating-schema-1-1
-description: Migrate existing models to schema 1.1
+description: Migrating existing authorization models to schema version 1.1
 ---
 
 import {

--- a/docs/content/modeling/migrating/migrating-schema-1-1.mdx
+++ b/docs/content/modeling/migrating/migrating-schema-1-1.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 2
 slug: /modeling/migrating/migrating-schema-1-1
+description: Migrate existing models to schema 1.1
 ---
 
 import {

--- a/docs/content/modeling/multiple-restrictions.mdx
+++ b/docs/content/modeling/multiple-restrictions.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 9
 slug: /modeling/multiple-restrictions
+description: Model requiring multiple authorizations before allowing users to perform actions on particular objects.
 ---
 
 import {

--- a/docs/content/modeling/multiple-restrictions.mdx
+++ b/docs/content/modeling/multiple-restrictions.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 9
 slug: /modeling/multiple-restrictions
-description: Model requiring multiple authorizations before allowing users to perform actions on particular objects.
+description: Modeling system that requires multiple authorizations before allowing users to perform actions on particular objects
 ---
 
 import {
@@ -20,7 +20,7 @@ import {
 
 <DocumentationNotice />
 
-In this guide we are going to model requiring multiple authorizations before allowing users to perform actions on particular objects using <ProductName format={ProductNameFormat.ProductLink}/>.
+In this guide we are going to model system that requires multiple authorizations before allowing users to perform actions on particular objects using <ProductName format={ProductNameFormat.ProductLink}/>.
 For example, _<ProductConcept section="what-is-a-user" linkName="users" />_ are allowed to delete a `document` if both of these conditions are met:
 
 - they are a member of the organization that owns the document

--- a/docs/content/modeling/organization-context-authorization.mdx
+++ b/docs/content/modeling/organization-context-authorization.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 9
 slug: /modeling/organization-context-authorization
+description: Modeling authorization through organization context
 ---
 
 import {

--- a/docs/content/modeling/parent-child.mdx
+++ b/docs/content/modeling/parent-child.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 7
 slug: /modeling/parent-child
-description: Indicate relationships between objects, and how users relationships to one object can affect their relationship with another.
+description: Indicating relationships between objects, and how users' relationships to one object can affect their relationship with another
 ---
 
 import {
@@ -21,7 +21,7 @@ import {
 
 <DocumentationNotice />
 
-In this guide you will learn how to indicate <ProductConcept section="what-is-a-relationship" linkName="relationships" /> between <ProductConcept section="what-is-an-object" linkName="objects" />, and how users relationships to one object can affect their relationship with another. For example: how a `editor` of a `folder` can be an `editor` of all `documents` the `folder` is a `parent` of.
+In this guide you will learn how to indicate <ProductConcept section="what-is-a-relationship" linkName="relationships" /> between <ProductConcept section="what-is-an-object" linkName="objects" />, and how users' relationships to one object can affect their relationship with another. For example: how a `editor` of a `folder` can be an `editor` of all `documents` the `folder` is a `parent` of.
 
 <CardBox title="When to use" appearance="filled" description=<div>
 

--- a/docs/content/modeling/parent-child.mdx
+++ b/docs/content/modeling/parent-child.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 7
 slug: /modeling/parent-child
+description: Indicate relationships between objects, and how users relationships to one object can affect their relationship with another.
 ---
 
 import {

--- a/docs/content/modeling/public-access.mdx
+++ b/docs/content/modeling/public-access.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 3
 slug: /modeling/public-access
-description: Model to grant public access to an object.
+description: Granting public access to an object
 ---
 
 import {

--- a/docs/content/modeling/public-access.mdx
+++ b/docs/content/modeling/public-access.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 3
 slug: /modeling/public-access
+description: Model to grant public access to an object.
 ---
 
 import {

--- a/docs/content/modeling/roles-and-permissions.mdx
+++ b/docs/content/modeling/roles-and-permissions.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 5
 slug: /modeling/roles-and-permissions
+description: Model roles and permissions using the authorization model and relationship tuple.
 ---
 
 import {

--- a/docs/content/modeling/roles-and-permissions.mdx
+++ b/docs/content/modeling/roles-and-permissions.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 5
 slug: /modeling/roles-and-permissions
-description: Model roles and permissions using the authorization model and relationship tuple.
+description: Modeling basic roles and permissions
 ---
 
 import {

--- a/docs/content/modeling/user-groups.mdx
+++ b/docs/content/modeling/user-groups.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 6
 slug: /modeling/user-groups
+description: Add users to groups and grant groups access to an object.
 ---
 
 import {

--- a/docs/content/modeling/user-groups.mdx
+++ b/docs/content/modeling/user-groups.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 6
 slug: /modeling/user-groups
-description: Add users to groups and grant groups access to an object.
+description: Adding users to groups and granting group members access to an object
 ---
 
 import {


### PR DESCRIPTION
## Description
Allow correct description to be rendered for snippets

## References
Close https://github.com/openfga/openfga.dev/issues/268

## Review Checklist
- [X] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [X] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
