### PR TITLE
fix: clean up warning for wildcard syntax usage

### DIFF
--- a/docs/content/concepts.mdx
+++ b/docs/content/concepts.mdx
@@ -556,7 +556,7 @@ For more information, please see [Contextual and Time-Based Authorization](./mod
 <details>
 <summary>
 
-## What Is A Type Bound Public Access?
+## What Is Type Bound Public Access?
 
 In <ProductName format={ProductNameFormat.LongForm}/>, type bound public access (represented by `<type>:*`) is a special <ProductName format={ProductNameFormat.ShortForm}/> syntax meaning **every object of that type** when used as a _user_ within a _relationship tuple_. For example, `user:*` represents every object of type `user` (including those not currently present in the system).
 

--- a/docs/content/concepts.mdx
+++ b/docs/content/concepts.mdx
@@ -556,9 +556,9 @@ For more information, please see [Contextual and Time-Based Authorization](./mod
 <details>
 <summary>
 
-## How Do I Represent "Everyone"?
+## What Is A Type Bound Public Access?
 
-In <ProductName format={ProductNameFormat.LongForm}/> the special syntax `*` means **everyone** when used as **user** in a relationship tuple. For example, `user:*` represents everyone with a user type.
+In <ProductName format={ProductNameFormat.LongForm}/>, type bound public access (represented by `<type>:*`) is a special <ProductName format={ProductNameFormat.ShortForm}/> syntax meaning **every object of that type** when used as a _user_ within a _relationship tuple_. For example, `user:*` represents everyone with a user type.
 
 </summary>
 
@@ -574,7 +574,7 @@ For example, in a case where you would like to indicate a certain document `docu
   ]}
 />
 
-Note that `*` has no special meaning when used in the `relation` or `object` properties. For example, `workspace:*` as an [object](#what-is-an-object) means a single object with the type `workspace` and identifier `*`.
+Note that you cannot use `<type>:*` in the `relation` or `object` properties. In addition, you cannot use `<type>:*` as part of a userset in the tuple's user field.
 For more information, please see [Modeling Public Access](./modeling/public-access.mdx) and [Advanced Modeling: Modeling Google Drive](./modeling/advanced/gdrive.mdx).
 
 </details>

--- a/docs/content/concepts.mdx
+++ b/docs/content/concepts.mdx
@@ -558,7 +558,7 @@ For more information, please see [Contextual and Time-Based Authorization](./mod
 
 ## What Is A Type Bound Public Access?
 
-In <ProductName format={ProductNameFormat.LongForm}/>, type bound public access (represented by `<type>:*`) is a special <ProductName format={ProductNameFormat.ShortForm}/> syntax meaning **every object of that type** when used as a _user_ within a _relationship tuple_. For example, `user:*` represents everyone with a user type.
+In <ProductName format={ProductNameFormat.LongForm}/>, type bound public access (represented by `<type>:*`) is a special <ProductName format={ProductNameFormat.ShortForm}/> syntax meaning **every object of that type** when used as a _user_ within a _relationship tuple_. For example, `user:*` represents every object of type `user` (including those not currently present in the system).
 
 </summary>
 

--- a/docs/content/modeling/advanced/gdrive.mdx
+++ b/docs/content/modeling/advanced/gdrive.mdx
@@ -32,7 +32,7 @@ This tutorial explains how to represent [Google Drive](https://www.google.com/in
   Used here is to indicate that writers are also commenters and viewers.
 - Using [**the union operator**](../../configuration-language.mdx#the-union-operator) condition to indicate that a user might have a certain relation with an object if they match any of the criteria indicated.<br />
   Used here to indicate that a user can be a viewer on a document, or can have the viewer relationship implied through commenter.
-- Using the **<ProductConcept section="what-is-a-type-bound-public-access" linkName="type bound public access" />** in a <ProductConcept section="what-is-a-relationship-tuple" linkName="relationship tuple's" /> user field to indicate that everyone has a certain relation with an object. See [Modeling Public Access](../public-access.mdx) for more.<br />
+- Using the **<ProductConcept section="what-is-type-bound-public-access" linkName="type bound public access" />** in a <ProductConcept section="what-is-a-relationship-tuple" linkName="relationship tuple's" /> user field to indicate that everyone has a certain relation with an object. See [Modeling Public Access](../public-access.mdx) for more.<br />
   Used here to [share documents publicly](#04-sharing-files-and-folders-publicly).
 - Model [**parent-child objects**](../parent-child.mdx) to indicate that a user having a relationship with a certain object implies having a relationship with another object in <ProductName format={ProductNameFormat.ShortForm}/>.<br />
   Used here is to indicate that a writer on a folder is a writer on all documents inside that folder.
@@ -776,7 +776,7 @@ Assume that `Anne` has created a new document: `2021-public-roadmap`, has shared
 
 ![Image showing requirements](./assets/gdrive-gdrive4.svg)
 
-Here's where another <ProductName format={ProductNameFormat.LongForm}/> feature, <ProductConcept section="what-is-a-type-bound-public-access" linkName="type bound public access" /> (as in everyone), would come in handy.
+Here's where another <ProductName format={ProductNameFormat.LongForm}/> feature, <ProductConcept section="what-is-type-bound-public-access" linkName="type bound public access" /> (as in everyone), would come in handy.
 
 First, we will need to update our model to allow for public access with type `user` for viewer relation.
 

--- a/docs/content/modeling/advanced/gdrive.mdx
+++ b/docs/content/modeling/advanced/gdrive.mdx
@@ -32,7 +32,7 @@ This tutorial explains how to represent [Google Drive](https://www.google.com/in
   Used here is to indicate that writers are also commenters and viewers.
 - Using [**the union operator**](../../configuration-language.mdx#the-union-operator) condition to indicate that a user might have a certain relation with an object if they match any of the criteria indicated.<br />
   Used here to indicate that a user can be a viewer on a document, or can have the viewer relationship implied through commenter.
-- Using the **<ProductConcept section="how-do-i-represent-everyone" linkName="`*` syntax" />** in a <ProductConcept section="what-is-a-relationship-tuple" linkName="relationship tuple's" /> user field to indicate that everyone has a certain relation with an object. See [Modeling Public Access](../public-access.mdx) for more.<br />
+- Using the **<ProductConcept section="what-is-a-type-bound-public-access" linkName="type bound public access" />** in a <ProductConcept section="what-is-a-relationship-tuple" linkName="relationship tuple's" /> user field to indicate that everyone has a certain relation with an object. See [Modeling Public Access](../public-access.mdx) for more.<br />
   Used here to [share documents publicly](#04-sharing-files-and-folders-publicly).
 - Model [**parent-child objects**](../parent-child.mdx) to indicate that a user having a relationship with a certain object implies having a relationship with another object in <ProductName format={ProductNameFormat.ShortForm}/>.<br />
   Used here is to indicate that a writer on a folder is a writer on all documents inside that folder.
@@ -776,7 +776,7 @@ Assume that `Anne` has created a new document: `2021-public-roadmap`, has shared
 
 ![Image showing requirements](./assets/gdrive-gdrive4.svg)
 
-Here's where another <ProductName format={ProductNameFormat.LongForm}/> feature, <ProductConcept section="how-do-i-represent-everyone" linkName="`*`" /> (as in everyone), would come in handy.
+Here's where another <ProductName format={ProductNameFormat.LongForm}/> feature, <ProductConcept section="what-is-a-type-bound-public-access" linkName="type bound public access" /> (as in everyone), would come in handy.
 
 First, we will need to update our model to allow for public access with type `user` for viewer relation.
 

--- a/docs/content/modeling/building-blocks/direct-relationships.mdx
+++ b/docs/content/modeling/building-blocks/direct-relationships.mdx
@@ -74,7 +74,7 @@ Direct relationships are relationships where a user has a relationship to an <Pr
 When checking for a relationship, a direct relationship exists if a _<ProductConcept section="what-is-a-relationship-tuple" linkName="relationship tuple" />_ is present in the system with the exact same object and relation that were in the query and where the user is one of:
 
 - the same user ID as that in the query
-- everyone (`*`)
+- type bound public access (`<type>:*`)
 - a set of users that contains the user ID present in the query
 
 ## Enable Or Disable Direct Relationships
@@ -247,9 +247,9 @@ This is because:
 
 </TabItem>
 
-<TabItem value='everyone' label='Everyone'>
+<TabItem value='everyone' label='Type Bound Public Access'>
 
-Assume you have a tuple that states that <ProductConcept section="how-do-i-represent-everyone" linkName="everyone" /> of type `user` is a `viewer` of `document:planning` (In other words, the document is public)
+Assume you have a <ProductConcept section="what-is-a-type-bound-public-access" linkName="type bound public access" /> tuple where everyone of type `user` is a `viewer` of `document:planning` (In other words, the document is public)
 
 <RelationshipTuplesViewer
   relationshipTuples={[

--- a/docs/content/modeling/building-blocks/direct-relationships.mdx
+++ b/docs/content/modeling/building-blocks/direct-relationships.mdx
@@ -249,7 +249,7 @@ This is because:
 
 <TabItem value='everyone' label='Type Bound Public Access'>
 
-Assume you have a <ProductConcept section="what-is-a-type-bound-public-access" linkName="type bound public access" /> tuple where everyone of type `user` is a `viewer` of `document:planning` (In other words, the document is public)
+Assume you have a <ProductConcept section="what-is-type-bound-public-access" linkName="type bound public access" /> tuple where everyone of type `user` is a `viewer` of `document:planning` (In other words, the document is public)
 
 <RelationshipTuplesViewer
   relationshipTuples={[

--- a/docs/content/modeling/public-access.mdx
+++ b/docs/content/modeling/public-access.mdx
@@ -115,17 +115,30 @@ Let us create a relationship tuple that states: **any user can view document:com
   ]}
 />
 
+:::caution Wildcard syntax usage
+Please note that `*` is a special <ProductName format={ProductNameFormat.ShortForm}/> syntax meaning **everyone** when used as a _user_ within a _relationship tuple_. It is not a wildcard or regex expression.
+
+**You cannot use the `*` syntax in the tuple's object field.**
+
+The following syntax is invalid:
+<WriteRequestViewer
+  relationshipTuples={[
+    {
+      _description: 'Not allow to specify * in the object field',
+      user: 'user:*',
+      relation: 'view',
+      object: 'document:*',
+    },
+  ]}
+/>
+
+:::
+
 ### 02. Check That The Relationship Exists
 
 Once the above _relationship tuple_ is added, we can <ProductConcept section="what-is-a-check-request" linkName="check" /> if **bob** cab `view` `document`:**company-psa.doc**. <ProductName format={ProductNameFormat.ShortForm}/> will return `{ "allowed": true }` even though no relationship tuple linking **bob** to the document was added. That is because the relationship tuple with `*` as the user made it so everyone can `view` the document, making it public.
 
 <CheckRequestViewer user={'user:bob'} relation={'view'} object={'document:company-psa.doc'} allowed={true} />
-
-:::caution Wildcard syntax usage
-Please note that `*` is a special <ProductName format={ProductNameFormat.ShortForm}/> syntax meaning **everyone** when used as a _user_ within a _relationship tuple_. It is not a wildcard or regex expression.
-
-**You cannot use it with a type to mean all objects in that type.** `workspace:*` does not mean all types; it means a single object with the type `workspace` and the `object_id` the string `*`.
-:::
 
 ## Related Sections
 

--- a/docs/content/modeling/public-access.mdx
+++ b/docs/content/modeling/public-access.mdx
@@ -85,7 +85,7 @@ You need to know how to create an authorization model and create a relationship 
 - A <ProductConcept section="what-is-a-relation" linkName="Relation" />: is a string defined in the type definition of an authorization model that defines the possibility of a relationship between an object of the same type as the type definition and a user in the system
 - An <ProductConcept section="what-is-an-object" linkName="Object" />: represents an entity in the system. Users' relationships to it can be define through relationship tuples and the authorization model
 - A <ProductConcept section="what-is-a-relationship-tuple" linkName="Relationship Tuple" />: a grouping consisting of a user, a relation and an object stored in <ProductName format={ProductNameFormat.ShortForm}/>
-- A <ProductConcept section="what-is-a-type-bound-public-access" linkName="Type Bound Public Access" />: is a special <ProductName format={ProductNameFormat.ShortForm}/> concept (represented by `<type>:*`) can be used in relationship tuples to represent every user
+- A <ProductConcept section="what-is-a-type-bound-public-access" linkName="Type Bound Public Access" />: is a special <ProductName format={ProductNameFormat.ShortForm}/> concept (represented by `<type>:*`) can be used in relationship tuples to represent every object of that type
 
 </details>
 
@@ -158,7 +158,7 @@ The following syntax is invalid:
 
 ### 02. Check That The Relationship Exists
 
-Once the above _relationship tuple_ is added, we can <ProductConcept section="what-is-a-check-request" linkName="check" /> if **bob** cab `view` `document`:**company-psa.doc**. <ProductName format={ProductNameFormat.ShortForm}/> will return `{ "allowed": true }` even though no relationship tuple linking **bob** to the document was added. That is because the relationship tuple with `*` as the user made it so everyone can `view` the document, making it public.
+Once the above _relationship tuple_ is added, we can <ProductConcept section="what-is-a-check-request" linkName="check" /> if **bob** cab `view` `document`:**company-psa.doc**. <ProductName format={ProductNameFormat.ShortForm}/> will return `{ "allowed": true }` even though no relationship tuple linking **bob** to the document was added. That is because the relationship tuple with `user:*` as the user made it so every object of type user (such as `user:bob`) can `view` the document, making it public.
 
 <CheckRequestViewer user={'user:bob'} relation={'view'} object={'document:company-psa.doc'} allowed={true} />
 

--- a/docs/content/modeling/public-access.mdx
+++ b/docs/content/modeling/public-access.mdx
@@ -116,7 +116,9 @@ Let us create a relationship tuple that states: **any user can view document:com
 />
 
 :::caution Wildcard syntax usage
-Please note that `*` is a special <ProductName format={ProductNameFormat.ShortForm}/> syntax meaning **everyone** when used as a _user_ within a _relationship tuple_. It is not a wildcard or regex expression.
+Please note that `<type>:*` is a special <ProductName format={ProductNameFormat.ShortForm}/> syntax meaning **every object of that type** when used as a _user_ within a _relationship tuple_.
+
+**It is not a wildcard or a regex expression.** `folder:plan*` does not mean all all folder starting with `plan`, and will not match either `plan` nor `planning`; `folder:plan*` means a single object with the type `folder` and the `object_id` the string `plan*`.
 
 **You cannot use the `*` syntax in the tuple's object field.**
 
@@ -124,8 +126,8 @@ The following syntax is invalid:
 <WriteRequestViewer
   relationshipTuples={[
     {
-      _description: 'Not allow to specify * in the object field',
-      user: 'user:*',
+      _description: 'It is invalid to use this syntax in the object field. The below relationship tuple is invalid and does not mean that Anne can view all documents.',
+      user: 'user:anne',
       relation: 'view',
       object: 'document:*',
     },

--- a/docs/content/modeling/public-access.mdx
+++ b/docs/content/modeling/public-access.mdx
@@ -13,6 +13,7 @@ import {
   ProductName,
   ProductNameFormat,
   RelatedSection,
+  RelationshipTuplesViewer,
   WriteRequestViewer,
 } from '@components/Docs';
 
@@ -20,11 +21,11 @@ import {
 
 <DocumentationNotice />
 
-In this guide you will learn how to grant public access to an <ProductConcept section="what-is-an-object" linkName="object" />, such as a certain document, using <ProductName format={ProductNameFormat.ProductLink}/>.
+In this guide you will learn how to grant public access to an <ProductConcept section="what-is-an-object" linkName="object" />, such as a certain document, using <ProductConcept section="what-is-a-type-bound-public-access" linkName="type bound public access" />.
 
 <CardBox title="When to use" appearance="filled" description=<div>
 
-Public access allows your application to grant every user in the system access to an object. You would add a relationship tuple with a user as `*` when:
+Public access allows your application to grant every user in the system access to an object. You would add a relationship tuple with type-bound public access when:
 
 - sharing a `document` publicly to indicate that everyone can `view` it
 - a public `poll` is created to indicate that anyone can `vote` on it
@@ -84,7 +85,7 @@ You need to know how to create an authorization model and create a relationship 
 - A <ProductConcept section="what-is-a-relation" linkName="Relation" />: is a string defined in the type definition of an authorization model that defines the possibility of a relationship between an object of the same type as the type definition and a user in the system
 - An <ProductConcept section="what-is-an-object" linkName="Object" />: represents an entity in the system. Users' relationships to it can be define through relationship tuples and the authorization model
 - A <ProductConcept section="what-is-a-relationship-tuple" linkName="Relationship Tuple" />: a grouping consisting of a user, a relation and an object stored in <ProductName format={ProductNameFormat.ShortForm}/>
-- With <ProductConcept section="how-do-i-represent-everyone" linkName="Everyone" />: a `*` can be used in relationship tuples to represent every user
+- A <ProductConcept section="what-is-a-type-bound-public-access" linkName="Type Bound Public Access" />: is a special <ProductName format={ProductNameFormat.ShortForm}/> concept (represented by `<type>:*`) can be used in relationship tuples to represent every user
 
 </details>
 
@@ -100,7 +101,7 @@ In previous guides, we have shown how to indicate that objects are related to us
 
 ### 01. Create A Relationship Tuple
 
-To do this we need to create a relationship tuple using the <ProductConcept section="how-do-i-represent-everyone" linkName="`*`" /> syntax. The `*` syntax is used to indicate that all users of a particular type have a relation to a specific object.
+To do this we need to create a relationship tuple using the <ProductConcept section="what-is-a-type-bound-public-access" linkName="type bound public access" />. The type bound public access syntax is used to indicate that all users of a particular type have a relation to a specific object.
 
 Let us create a relationship tuple that states: **any user can view document:company-psa.doc**
 
@@ -116,20 +117,39 @@ Let us create a relationship tuple that states: **any user can view document:com
 />
 
 :::caution Wildcard syntax usage
-Please note that `<type>:*` is a special <ProductName format={ProductNameFormat.ShortForm}/> syntax meaning **every object of that type** when used as a _user_ within a _relationship tuple_.
 
-**It is not a wildcard or a regex expression.** `folder:plan*` does not mean all all folder starting with `plan`, and will not match either `plan` nor `planning`; `folder:plan*` means a single object with the type `folder` and the `object_id` the string `plan*`.
+Please note that type-bound public access is not a wildcard or a regex expression.
 
-**You cannot use the `*` syntax in the tuple's object field.**
+**You cannot use the `<type>:*` syntax in the tuple's object field.**
 
 The following syntax is invalid:
-<WriteRequestViewer
+
+<RelationshipTuplesViewer
   relationshipTuples={[
     {
-      _description: 'It is invalid to use this syntax in the object field. The below relationship tuple is invalid and does not mean that Anne can view all documents.',
-      user: 'user:anne',
+      _description: 'It is invalid to use this syntax in the object field. The below relationship tuple is invalid and does not mean that Bob can view all documents.',
+      user: 'user:bob',
       relation: 'view',
       object: 'document:*',
+    },
+  ]}
+/>
+
+:::
+
+:::caution Wildcard syntax usage
+
+**You cannot use `<type>:*` as part of a userset in the tuple's user field.**
+
+The following syntax is invalid:
+
+<RelationshipTuplesViewer
+  relationshipTuples={[
+    {
+      _description: 'It is invalid to use this syntax as part of a userset. The below relationship tuple is invalid and does not mean that members of any org can view the company-psa document.',
+      user: 'org:*#member',
+      relation: 'view',
+      object: 'document:company-psa.doc',
     },
   ]}
 />

--- a/docs/content/modeling/public-access.mdx
+++ b/docs/content/modeling/public-access.mdx
@@ -21,7 +21,7 @@ import {
 
 <DocumentationNotice />
 
-In this guide you will learn how to grant public access to an <ProductConcept section="what-is-an-object" linkName="object" />, such as a certain document, using <ProductConcept section="what-is-a-type-bound-public-access" linkName="type bound public access" />.
+In this guide you will learn how to grant public access to an <ProductConcept section="what-is-an-object" linkName="object" />, such as a certain document, using <ProductConcept section="what-is-type-bound-public-access" linkName="type bound public access" />.
 
 <CardBox title="When to use" appearance="filled" description=<div>
 
@@ -85,7 +85,7 @@ You need to know how to create an authorization model and create a relationship 
 - A <ProductConcept section="what-is-a-relation" linkName="Relation" />: is a string defined in the type definition of an authorization model that defines the possibility of a relationship between an object of the same type as the type definition and a user in the system
 - An <ProductConcept section="what-is-an-object" linkName="Object" />: represents an entity in the system. Users' relationships to it can be define through relationship tuples and the authorization model
 - A <ProductConcept section="what-is-a-relationship-tuple" linkName="Relationship Tuple" />: a grouping consisting of a user, a relation and an object stored in <ProductName format={ProductNameFormat.ShortForm}/>
-- A <ProductConcept section="what-is-a-type-bound-public-access" linkName="Type Bound Public Access" />: is a special <ProductName format={ProductNameFormat.ShortForm}/> concept (represented by `<type>:*`) can be used in relationship tuples to represent every object of that type
+- A <ProductConcept section="what-is-type-bound-public-access" linkName="Type Bound Public Access" />: is a special <ProductName format={ProductNameFormat.ShortForm}/> concept (represented by `<type>:*`) can be used in relationship tuples to represent every object of that type
 
 </details>
 
@@ -101,7 +101,7 @@ In previous guides, we have shown how to indicate that objects are related to us
 
 ### 01. Create A Relationship Tuple
 
-To do this we need to create a relationship tuple using the <ProductConcept section="what-is-a-type-bound-public-access" linkName="type bound public access" />. The type bound public access syntax is used to indicate that all users of a particular type have a relation to a specific object.
+To do this we need to create a relationship tuple using the <ProductConcept section="what-is-type-bound-public-access" linkName="type bound public access" />. The type bound public access syntax is used to indicate that all users of a particular type have a relation to a specific object.
 
 Let us create a relationship tuple that states: **any user can view document:company-psa.doc**
 


### PR DESCRIPTION


## Description
Make it more clear that you cannot use type:* syntax in the object field.  Also, move the warning closer to the section where it is used.

<img width="2032" alt="Screen Shot 2023-01-05 at 3 50 42 PM" src="https://user-images.githubusercontent.com/10730463/210878182-40da5cb6-89e7-4f8c-b56c-2b0ad70fa703.png">


## References

Close https://github.com/openfga/openfga.dev/issues/328

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
