### PR TITLE
fix: remove as self from document

### DIFF
--- a/docs/content/concepts.mdx
+++ b/docs/content/concepts.mdx
@@ -59,6 +59,7 @@ Code snippet below is an example of a type definition:
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type: 'document',
     relations: {
       viewer: {
@@ -347,7 +348,7 @@ For the following model, only [relationship tuple](#what-is-a-relationship-tuple
 
 Relationship tuple with user `user:anne` or `user:3f7768e0-4fa7-4e93-8417-4da68ce1846c` may be written for objects with type `document` and relation `viewer`, so writing `{"user": "user:anne","relation":"viewer","object":"document:roadmap"}` will succeed.
 Relationship tuple writes with user type that is not allowed for the `viewer` relation on objects of type `document`, for example `workspace:auth0` or `folder:planning#editor` will be rejected, so writing `{"user": "folder:product","relation":"viewer","object":"document:roadmap"}` will fail.
-This will affect only relations that are [directly related](#what-are-direct-and-implied-relationships) and have [the direct relationship keyword ("this")](./configuration-language.mdx#the-direct-relationship-keyword) in their relation definition.
+This will affect only relations that are [directly related](#what-are-direct-and-implied-relationships) and have [the direct relationship type restrictions](./configuration-language.mdx#the-direct-relationship-type-restrictions) in their relation definition.
 
 </details>
 
@@ -402,13 +403,13 @@ An [authorization model](#what-is-an-authorization-model), together with [relati
 
 ## What Are Direct And Implied Relationships?
 
-A **direct relationship** R between user X and object Y means the relationship tuple (user=X, relation=R, object=Y) exists, and the <ProductName format={ProductNameFormat.ShortForm}/> authorization model for that relation allows this direct relationship (by use of `self`).
+A **direct relationship** R between user X and object Y means the relationship tuple (user=X, relation=R, object=Y) exists, and the <ProductName format={ProductNameFormat.ShortForm}/> authorization model for that relation allows this direct relationship (by use of [direct relationship type restrictions](./configuration-language.mdx#the-direct-relationship-type-restrictions)).
 
 An **implied (or computed) relationship** R exists between user X and object Y if user X is related to an object Z that is in a direct or implied relationship with object Y, and the <ProductName format={ProductNameFormat.ShortForm}/> authorization model allows it.
 
 </summary>
 
-- `user:anne` has a **direct relationship** with `document:new-roadmap` as `viewer` if the [type definition](#what-is-a-type-definition) allows it (allows [`self`](./configuration-language.mdx#the-direct-relationship-keyword)), and one of the following [relationship tuples](#what-is-a-relationship-tuple) exist:
+- `user:anne` has a **direct relationship** with `document:new-roadmap` as `viewer` if the [type definition](#what-is-a-type-definition) allows it (allows [`direct relationship type restrictions`](./configuration-language.mdx#the-direct-relationship-type-restrictions)), and one of the following [relationship tuples](#what-is-a-relationship-tuple) exist:
 
   - <RelationshipTuplesViewer
       relationshipTuples={[

--- a/docs/content/configuration-language.mdx
+++ b/docs/content/configuration-language.mdx
@@ -261,13 +261,13 @@ The `folder` and `document` _type definitions_ each have five _relations_: `pare
 
 :::
 
-### The Direct Relationship Keyword
+### The Direct Relationship Type Restrictions
 
-`self`, when used in the context of the <ProductConcept section="what-is-a-relation-definition" linkName="relation definition" /> allows <ProductConcept section="what-are-direct-and-implied-relationships" linkName="direct relationships" /> to the objects of this type. The absence of `self` disallows these direct relationships.
+`[<type1>,<type2>]`, when used in the context of the <ProductConcept section="what-is-a-relation-definition" linkName="relation definition" /> allows <ProductConcept section="what-are-direct-and-implied-relationships" linkName="direct relationships" /> to the objects of these specified types. The absence of `[]` disallows these direct relationships.
 
 :::info
 
-`self` in the <ProductName format={ProductNameFormat.ShortForm}/> DSL translates to `this` in the <ProductName format={ProductNameFormat.ShortForm}/> API syntax.
+`[]` in the <ProductName format={ProductNameFormat.ShortForm}/> DSL translates to `this` in the <ProductName format={ProductNameFormat.ShortForm}/> API syntax.
 
 :::
 
@@ -275,6 +275,7 @@ For example, let's take a closer look at the `team` type.
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type: 'team',
     relations: {
       member: {
@@ -283,15 +284,18 @@ For example, let's take a closer look at the `team` type.
     },
     metadata: {
       relations: {
-        member: { directly_related_user_types: [{ type: 'user' }, { type: 'team', relation: 'member' }] },
+        member: { directly_related_user_types: [{ type: 'user' }, { type: 'user:*'}, { type: 'team', relation: 'member' }] },
       },
     },
-  }}
+  }} skipVersion={true}
 />
 
 This `team` _<ProductConcept section="what-is-a-type-definition" linkName="type definition" />_ defines all the _<ProductConcept section="what-is-a-relation" linkName="relations" />_ that _<ProductConcept section="what-is-a-user" linkName="users" />_ can have with an _<ProductConcept section="what-is-an-object" linkName="object" />_ of _type_ `team`. In this case the _relation_ is: `member`.
 
-Due to the direct relationship keyword (`self`) being used, a user in the system can have a **<ProductConcept section="what-are-direct-and-implied-relationships" linkName="direct relationship" />** with the `team` type as a `member`.
+Due to the direct relationship type restrictions (`[user, team#member]`) being used, a user in the system can have a **<ProductConcept section="what-are-direct-and-implied-relationships" linkName="direct relationship" />** with the `team` type as a `member` for users of 
+- type `user`
+- <ProductConcept section="what-is-type-bound-public-access" linkName="type bound public access" /> of type `user`
+- [usersets](./modeling/building-blocks/usersets.mdx) of type `team`
 
 In the type definition snippet above, `anne` is a `member` of `team:product` if _any one of_ the following relationship tuple sets exist:
 
@@ -342,6 +346,7 @@ You can also reference other relations on the same object. Let us look at a simp
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type: 'document',
     relations: {
       editor: {
@@ -371,7 +376,7 @@ You can also reference other relations on the same object. Let us look at a simp
         viewer: { directly_related_user_types: [{ type: 'user' }] },
       },
     },
-  }}
+  }} skipVersion={true}
 />
 
 The above `document` _<ProductConcept section="what-is-a-type-definition" linkName="type definition" />_ defines all the _<ProductConcept section="what-is-a-relation" linkName="relations" />_ that _<ProductConcept section="what-is-a-user" linkName="users" />_ can have with an _<ProductConcept section="what-is-an-object" linkName="object" />_ of _type_ `document`. In this case the _relations_ are: `editor`, `viewer` and `can_rename`.
@@ -380,7 +385,7 @@ The `viewer` and `can_rename` _relation definitions_ are both referencing `edito
 
 :::info
 
-Notice how `can_rename` does not reference the [_direct relationship keyword_](#the-direct-relationship-keyword) (`self`), indicating that a direct relationship is not possible (as in a user cannot be directly assigned this relation, it has to be inherited through an assignment of the `editor` relation). The `viewer` relation on the other hand allows both _direct and indirect relationships_ using the [Union Operator](#the-union-operator).
+Notice how `can_rename` does not reference the [_direct relationship type restrictions_](#the-direct-relationship-type-restrictions), indicating that a direct relationship is not possible (as in a user cannot be directly assigned this relation, it has to be inherited through an assignment of the `editor` relation). The `viewer` relation on the other hand allows both _direct and indirect relationships_ using the [Union Operator](#the-union-operator).
 
 :::
 
@@ -532,7 +537,7 @@ The snippet below taken from the authorization model above is stating that viewe
         },
       },
     ],
-  }}
+  }} skipVersion={true}
 />
 
 In the _authorization model_ above, `user:anne` is a `viewer` of `document:new-roadmap` if any one of the following relationship tuple sets exists:
@@ -607,7 +612,7 @@ The _union operator_ (`or` in the DSL, `union` in the JSON syntax) is used to in
         },
       },
     ],
-  }}
+  }} skipVersion={true}
 />
 
 In the <ProductConcept section="what-is-a-type-definition" linkName="type definition" /> snippet above, `user:anne` is a `viewer` of `document:new-roadmap` if _any of_ the following conditions are satisfied:
@@ -685,7 +690,7 @@ The _intersection operator_ (`and` in the DSL, `intersection` in the JSON syntax
         },
       },
     ],
-  }}
+  }} skipVersion={true}
 />
 
 In the <ProductConcept section="what-is-a-type-definition" linkName="type definition" /> snippet above, `user:anne` is a `viewer` of `document:new-roadmap` if **all of** the following conditions are satisfied:
@@ -762,7 +767,7 @@ The _exclusion operator_ (`but not` in the DSL, `difference` in the JSON syntax)
         },
       },
     ],
-  }}
+  }} skipVersion={true}
 />
 
 In the _type definition_ snippet above, `user:anne` is a `viewer` of `document:new-roadmap` if:
@@ -818,7 +823,7 @@ The JSON syntax accepted by the <ProductName format={ProductNameFormat.ShortForm
 
 | Zanzibar           | <ProductName format={ProductNameFormat.ShortForm}/> JSON | <ProductName format={ProductNameFormat.ShortForm}/> DSL |
 | :----------------- | :------------------------------------------------------- | :------------------------------------------------------ |
-| `this`             | `this`                                                   | `self`                                                  |
+| `this`             | `this`                                                   | `[]`                                                  |
 | `union`            | `union`                                                  | `or`                                                    |
 | `intersection`     | `intersection`                                           | `and`                                                   |
 | `exclusion`        | `difference`                                             | `but not`                                               |

--- a/docs/content/modeling/advanced/entitlements.mdx
+++ b/docs/content/modeling/advanced/entitlements.mdx
@@ -325,6 +325,7 @@ Add it now. Like so:
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type: 'feature',
     relations: {
       associated_plan: {
@@ -340,7 +341,7 @@ Add it now. Like so:
         access: { directly_related_user_types: [{ type: 'user' }] },
       },
     },
-  }}
+  }} skipVersion={true}
 />
 
 :::info
@@ -353,7 +354,7 @@ Add it now. Like so:
 
 In this tutorial, you will find the phrases <ProductConcept section="what-are-direct-and-implied-relationships" linkName="direct relationship and implied relationship" />.
 
-A _direct relationship_ R between user X and object Y means the relationship tuple (user=X, relation=R, object=Y) exists, and the <ProductName format={ProductNameFormat.ShortForm}/> authorization model for that relation allows this direct relationship (by use of `self`).
+A _direct relationship_ R between user X and object Y means the relationship tuple (user=X, relation=R, object=Y) exists, and the <ProductName format={ProductNameFormat.ShortForm}/> authorization model for that relation allows this direct relationship (by use of [direct relationship type restriction](../../configuration-language.mdx#the-direct-relationship-type-restrictions)).
 
 An _implied relationship_ R exists between user X and object Y if user X is related to an object Z that is in direct or implied relationship with object Y, and the <ProductName format={ProductNameFormat.ShortForm}/> authorization model allows it.
 
@@ -431,6 +432,7 @@ If you have already completed some of the other tutorials you might have encount
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     viewer: {
       tupleToUserset: {
         tupleset: {
@@ -441,7 +443,7 @@ If you have already completed some of the other tutorials you might have encount
         },
       },
     },
-  }}
+  }} skipVersion={true}
 />
 
 :::info
@@ -451,12 +453,13 @@ With this, when asked to check a user's `viewer` relationship with the object, <
 2. For each relationship tuple, return all _usersets_ that have `all_objects_viewer` relation to the objects in those relationship tuples
 3. If the user is in any of those _usersets_, return yes, as the user is a `viewer` on this object.
    In other words, users related as `all_objects_viewer` to any of this object's `parents` are related as `viewer` to this object.
-   :::
+:::
 
 If you want to give all subscribers on a plan access to a feature, you can do it like so:
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type: 'feature',
     relations: {
       associated_plan: {
@@ -490,7 +493,7 @@ If you want to give all subscribers on a plan access to a feature, you can do it
         },
       },
     },
-  }}
+  }} skipVersion={true}
 />
 
 :::info
@@ -708,10 +711,11 @@ So far, with just a <ProductName format={ProductNameFormat.ShortForm}/> authoriz
 
 Earlier on, the idea of not allowing a direct `access` relation between a user and a `feature` was discussed, e.g. adding a relationship tuple like `{ "user": "user:anne", "relation": "access", "object": "feature:y" }`. You will remove it now.
 
-To disallow a direct relationship, you need to remove `self`. The following snippet:
+To disallow a direct relationship, you need to remove direct relationship type restriction. The following snippet:
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type: 'feature',
     relations: {
       associated_plan: {
@@ -745,13 +749,14 @@ To disallow a direct relationship, you need to remove `self`. The following snip
         },
       },
     },
-  }}
+  }} skipVersion={true}
 />
 
 becomes
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type: 'feature',
     relations: {
       associated_plan: {
@@ -773,7 +778,7 @@ becomes
         associated_plan: { directly_related_user_types: [{ type: 'plan' }] },
       },
     },
-  }}
+  }} skipVersion={true}
 />
 
 With this change, even if your app layer added the following relationship tuple:
@@ -896,7 +901,7 @@ In this tutorial, you learned:
 - how to start with a set of requirements and scenarios and iterate on the <ProductName format={ProductNameFormat.ShortForm}/> authorization model until the checks match the expected scenarios
 - how to model [**parent-child relationships**](../parent-child.mdx) to indicate that a user having a relationship with a certain object implies having a relationship with another object in <ProductName format={ProductNameFormat.ShortForm}/>
 - how to use [**the union operator**](../../configuration-language.mdx#the-union-operator) condition to indicate multiple possible paths for a relationship between two objects to be computed
-- using the [**direct relationship keyword**](../../configuration-language.mdx#the-direct-relationship-keyword) (`self`) in a <ProductName format={ProductNameFormat.ShortForm}/> authorization model, and how to block direct relationships by removing it
+- using the [**direct relationship type restrictions**](../../configuration-language.mdx#the-direct-relationship-type-restrictions) in a <ProductName format={ProductNameFormat.ShortForm}/> authorization model, and how to block direct relationships by removing it
 
 <Playground title="Entitlements" preset="entitlements" example="Entitlements" store="entitlements" />
 

--- a/docs/content/modeling/advanced/gdrive.mdx
+++ b/docs/content/modeling/advanced/gdrive.mdx
@@ -164,6 +164,7 @@ The <ProductName format={ProductNameFormat.LongForm}/> service determines if a <
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type: 'document', // objects of type document
     relations: {
       // have users related to them as...
@@ -177,7 +178,7 @@ The <ProductName format={ProductNameFormat.LongForm}/> service determines if a <
         viewer: { directly_related_user_types: [{ type: 'user' }] },
       },
     },
-  }}
+  }} skipVersion={true}
 />
 
 :::info
@@ -580,6 +581,7 @@ We express it like this:
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     viewer: {
       union: {
         child: [
@@ -609,7 +611,7 @@ We express it like this:
         ],
       },
     },
-  }}
+  }} skipVersion={true}
 />
 
 :::info

--- a/docs/content/modeling/advanced/github.mdx
+++ b/docs/content/modeling/advanced/github.mdx
@@ -324,6 +324,7 @@ Let us examine one of those relations in detail:
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type: 'repo', // objects of type "repo"
     relations: {
       // have users related to them as
@@ -351,6 +352,7 @@ Let us examine one of those relations in detail:
       },
     },
   }}
+  skipVersion={true}
 />
 
 :::info
@@ -726,30 +728,35 @@ We express it like this:
 
 <AuthzModelSnippetViewer
   configuration={{
-    admin: {
-      union: {
-        child: [
-          {
-            this: {},
-          },
-          {
-            tupleToUserset: {
-              // read all tuples related to tooling as owner
-              // which returns [{ "user": "organization:contoso", "relation": "owner", "object": "repo:contoso/tooling" }]
-              tupleset: {
-                relation: 'owner',
+    schema_version: '1.1',
+    type_definitions: [
+      {
+        admin: {
+          union: {
+            child: [
+              {
+                this: {},
               },
-              // and for each tuple return all usersets that match the following, replacing $TUPLE_USERSET_OBJECT with organization:contoso
-              // this will return tuples of shape { object: "organization:contoso", "repo_admin", "user": ??? }
-              computedUserset: {
-                relation: 'repo_admin',
+              {
+                tupleToUserset: {
+                  // read all tuples related to tooling as owner
+                  // which returns [{ "user": "organization:contoso", "relation": "owner", "object": "repo:contoso/tooling" }]
+                  tupleset: {
+                    relation: 'owner',
+                  },
+                  // and for each tuple return all usersets that match the following, replacing $TUPLE_USERSET_OBJECT with organization:contoso
+                  // this will return tuples of shape { object: "organization:contoso", "repo_admin", "user": ??? }
+                  computedUserset: {
+                    relation: 'repo_admin',
+                  },
+                },
               },
-            },
+            ],
           },
-        ],
+        },
       },
-    },
-  }}
+    ],
+  }} skipVersion={true}
 />
 
 :::info

--- a/docs/content/modeling/advanced/iot.mdx
+++ b/docs/content/modeling/advanced/iot.mdx
@@ -415,6 +415,7 @@ The <ProductConcept section="what-is-a-type-definition" linkName="type definitio
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type: 'device_group',
     relations: {
       it_admin: {
@@ -430,7 +431,7 @@ The <ProductConcept section="what-is-a-type-definition" linkName="type definitio
         security_guard: { directly_related_user_types: [{ type: 'user' }] },
       },
     },
-  }}
+  }} skipVersion={true}
 />
 
 With this change, the full <ProductConcept section="what-is-an-authorization-model" linkName="authorization model" /> becomes:
@@ -620,7 +621,7 @@ Notice that despite following **[Step 03](./iot.mdx#03-updating-our-authorizatio
 
 `anne` is a `live_video_viewer` by both her position as `security_guard` as well as her _<ProductConcept section="what-are-direct-and-implied-relationships" linkName="direct relationship" />_ assignment. This is undesirable. Imagine `anne` left her position of `security_guard` and she will still have `live_video_viewer` access to `device:1`.
 
-To remedy this, remove `self` from `live_video_viewer`, `recorded_video_viewer` and `device_renamer`. This denies direct relations to `live_video_viewer`, `recorded_video_viewer` and `device_renamer` from having an effect. To do this:
+To remedy this, remove `[user]` from `live_video_viewer`, `recorded_video_viewer` and `device_renamer`. This denies direct relations to `live_video_viewer`, `recorded_video_viewer` and `device_renamer` from having an effect. To do this:
 
 <AuthzModelSnippetViewer
   configuration={{
@@ -716,7 +717,7 @@ To remedy this, remove `self` from `live_video_viewer`, `recorded_video_viewer` 
 
 :::info
 
-Notice that any reference to the [**direct relationship keyword**](../../configuration-language.mdx#the-direct-relationship-keyword) (`self` in the friendly Syntax - or `this` in the api syntax) has been removed. That indicates that a user cannot have a <ProductConcept section="what-are-direct-and-implied-relationships" linkName="direct relationship" /> with an object in this type.
+Notice that any reference to the [**direct relationship type restrictions**](../../configuration-language.mdx#the-direct-relationship-type-restrictions) has been removed. That indicates that a user cannot have a <ProductConcept section="what-are-direct-and-implied-relationships" linkName="direct relationship" /> with an object in this type.
 
 With this change, `anne` can no longer have a `live_video_viewer` permission for `device:1` except through having a `security_guard` or `it_admin` role first, and when she loses access to that role, she will automatically lose access to the `live_video_viewer` permission.
 
@@ -748,7 +749,7 @@ To test this, we can add a new user `emily`. Emily is **not** a `security_guard`
   ]}
 />
 
-Now try to query `is emily related to device:1 as live_video_viewer?`. The returned result should be `emily is not related to device:1 as live_video_viewer`. This confirms that direct relations have no effect on the `live_video_viewer` relations, and that is because the [**direct relationship keyword**](../../configuration-language.mdx#the-direct-relationship-keyword) (`self`) was removed from the relation configuration.
+Now try to query `is emily related to device:1 as live_video_viewer?`. The returned result should be `emily is not related to device:1 as live_video_viewer`. This confirms that direct relations have no effect on the `live_video_viewer` relations, and that is because the [**direct relationship type restrictions**](../../configuration-language.mdx#the-direct-relationship-type-restrictions) was removed from the relation configuration.
 
 <CheckRequestViewer user={'user:emily'} relation={'live_video_viewer'} object={'device:1'} allowed={false} />
 

--- a/docs/content/modeling/advanced/slack.mdx
+++ b/docs/content/modeling/advanced/slack.mdx
@@ -150,10 +150,11 @@ The requirements stated:
 - **Catherine** and **Emily** are a normal **members** of the **Sandcastle workspace**
 - **David** is a **guest** user
 
-Here is how you would express than in <ProductName format={ProductNameFormat.ShortForm}/>'s<ProductConcept section="what-is-an-authorization-model" linkName="authorization model" />: You have a <ProductConcept section="what-is-a-type" linkName="type" /> called "workspace", and users can be related to it as a legacy_admin, channels_admin, member and guest
+Here is how you would express than in <ProductName format={ProductNameFormat.ShortForm}/>'s <ProductConcept section="what-is-an-authorization-model" linkName="authorization model" />: You have a <ProductConcept section="what-is-a-type" linkName="type" /> called "workspace", and users can be related to it as a legacy_admin, channels_admin, member and guest
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
     {
       type: 'user',
@@ -200,7 +201,7 @@ Here is how you would express than in <ProductName format={ProductNameFormat.Sho
 - Member (`member`)
 - Guest (`guest`)
 
-`self` (or `this` in the API Syntax) is the [direct relationship keyword](../../configuration-language.mdx#the-direct-relationship-keyword) and indicates that a user can have a <ProductConcept section="what-are-direct-and-implied-relationships" linkName="direct relationship" /> with an object of the type the relation specifies.
+[Direct relationship type restrictions](../../configuration-language.mdx#the-direct-relationship-type-restrictions) indicates that a user can have a <ProductConcept section="what-are-direct-and-implied-relationships" linkName="direct relationship" /> with an object of the type the relation specifies.
 
 :::
 
@@ -260,6 +261,7 @@ The <ProductName format={ProductNameFormat.LongForm}/> service determines if a <
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type: 'workspace', // objects of type workspace
     relations: {
       // have users related to them as...
@@ -273,7 +275,7 @@ The <ProductName format={ProductNameFormat.LongForm}/> service determines if a <
         member: { directly_related_user_types: [{ type: 'user' }] },
       },
     },
-  }}
+  }} skipVersion={true}
 />
 
 :::info
@@ -510,6 +512,7 @@ The authorization model already has a section describing the workspace, what rem
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type: 'channel', // A channel can have the following relations:
     relations: {
       parent_workspace: {
@@ -548,7 +551,7 @@ The authorization model already has a section describing the workspace, what rem
         },
       },
     },
-  }}
+  }} skipVersion={true}
 />
 
 :::info
@@ -567,6 +570,7 @@ There is an <ProductConcept section="what-are-direct-and-implied-relationships" 
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type: 'channel',
     relations: {
       parent_workspace: {
@@ -616,7 +620,7 @@ There is an <ProductConcept section="what-are-direct-and-implied-relationships" 
         },
       },
     },
-  }}
+  }} skipVersion={true}
 />
 
 :::info

--- a/docs/content/modeling/building-blocks/direct-relationships.mdx
+++ b/docs/content/modeling/building-blocks/direct-relationships.mdx
@@ -61,7 +61,7 @@ You need to know how to create an authorization model and create a relationship 
 - A <ProductConcept section="what-is-a-relation" linkName="Relation" />: is a string defined in the type definition of an authorization model that defines the possibility of a relationship between an object of the same type as the type definition and a user in the system
 - An <ProductConcept section="what-is-an-object" linkName="Object" />: represents an entity in the system. Users' relationships to it can be define through relationship tuples and the authorization model
 - A <ProductConcept section="what-is-a-relationship-tuple" linkName="Relationship Tuple" />: a grouping consisting of a user, a relation and an object stored in <ProductName format={ProductNameFormat.ShortForm}/>
-- [Direct Relationship Keyword](../../configuration-language.mdx#the-direct-relationship-keyword): `self` used in the context of the relation definition can be used to allow direct relationships to the objects of this type
+- [Direct Relationship Type Restrictions](../../configuration-language.mdx#the-direct-relationship-type-restrictions): used in the context of the relation definition can be used to allow direct relationships to the objects of this type
 
 </details>
 
@@ -79,7 +79,7 @@ When checking for a relationship, a direct relationship exists if a _<ProductCon
 
 ## Enable Or Disable Direct Relationships
 
-Direct relationships can be enabled for a specific relation on an _<ProductConcept section="what-is-a-type" linkName="object type" />_ by adding the [direct relationship keyword](../../configuration-language.mdx#the-direct-relationship-keyword) from that <ProductConcept section="what-is-a-relation-definition" linkName="relation's definition" />. Likewise, they can be disabled by removing that keyword.
+Direct relationships can be enabled for a specific relation on an _<ProductConcept section="what-is-a-type" linkName="object type" />_ by adding [direct relationship type restrictions](../../configuration-language.mdx#the-direct-relationship-type-restrictions) from that <ProductConcept section="what-is-a-relation-definition" linkName="relation's definition" />. Likewise, they can be disabled by removing the direct relationship type restrictions.
 
 <AuthzModelSnippetViewer
   configuration={{

--- a/docs/content/modeling/building-blocks/object-to-object-relationships.mdx
+++ b/docs/content/modeling/building-blocks/object-to-object-relationships.mdx
@@ -250,7 +250,7 @@ To do this, the authorization model will have two <ProductConcept section="what-
 
 Type `feature` has two relations, associated_plan and access. Relation `associated_plan` allows associating plans with features while `access` defines who can access the feature. In our case, the access can be achieved either from
 
-- <ProductConcept section="what-are-direct-and-implied-relationships" linkName="direct relationship" /> via the keyword `self`
+- <ProductConcept section="what-are-direct-and-implied-relationships" linkName="direct relationship" /> via  [direct relationship type restrictions](../../configuration-language.mdx#the-direct-relationship-type-restrictions).
   or `this`
 - object to object relationship where a user can access because it is a subscriber_member of a particular plan AND that plan is associated with the feature.
 

--- a/docs/content/modeling/contextual-time-based-authorization.mdx
+++ b/docs/content/modeling/contextual-time-based-authorization.mdx
@@ -272,6 +272,7 @@ In order to add time and ip address to our authorization model, we will add appr
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type: 'timeslot',
     relations: {
       user: {
@@ -283,11 +284,12 @@ In order to add time and ip address to our authorization model, we will add appr
         user: { directly_related_user_types: [{ type: 'user' }] },
       },
     },
-  }}
+  }} skipVersion={true}
 />
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type: 'ip-address-range',
     relations: {
       user: {
@@ -299,7 +301,7 @@ In order to add time and ip address to our authorization model, we will add appr
         user: { directly_related_user_types: [{ type: 'user' }] },
       },
     },
-  }}
+  }} skipVersion={true}
 />
 
 We'll also need to introduce some new relations, and modify some others.
@@ -314,6 +316,7 @@ The branch type definition then becomes:
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type: 'branch',
     relations: {
       account_manager: {
@@ -363,7 +366,7 @@ The branch type definition then becomes:
         approved_timeslot: { directly_related_user_types: [{ type: 'timeslot' }] },
       },
     },
-  }}
+  }} skipVersion={true}
 />
 
 2. On the "account" type:
@@ -375,6 +378,7 @@ The account type definition then becomes:
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type: 'account',
     relations: {
       branch: {
@@ -450,7 +454,7 @@ The account type definition then becomes:
         customer: { directly_related_user_types: [{ type: 'user' }] },
       },
     },
-  }}
+  }} skipVersion={true}
 />
 
 :::note

--- a/docs/content/modeling/getting-started.mdx
+++ b/docs/content/modeling/getting-started.mdx
@@ -612,7 +612,7 @@ Why? This relation definition states:
   `{ user: {user-id}, relation: "member", object: "organization:{id}" }`
 
 :::info Important
-Relation definitions of the form “define {relation} as self" are fairly common. They are used to express that relationships "to the object with that relation" (e.g. "member of organization") can be assigned by your system and that only the users that have that relation are those with a [direct relationship](./building-blocks/direct-relationships.mdx).
+Relation definitions of the form “define {relation}: [user, organization#member]" are fairly common. They are used to express that relationships "to the object with that relation" (e.g. "users" of type user or "member of organization") can be assigned by your system and that only the users that have that relation are those with a [direct relationship](./building-blocks/direct-relationships.mdx).
 :::
 
 You can read more about group membership and types in [Modeling User Groups](./user-groups.mdx).
@@ -842,43 +842,49 @@ We can achieve that with the following definition using <UpdateProductNameInLink
 
 <AuthzModelSnippetViewer
   onlyShow={SyntaxFormat.Friendly2}
+  skipVersion={true}
   configuration={{
-    can_share: {
-      union: {
-        child: [
-          {
-            computedUserset: {
-              object: '',
-              relation: 'owner',
-            },
-          },
-          {
-            computedUserset: {
-              object: '',
-              relation: 'editor',
-            },
-          },
-          {
-            tupleToUserset: {
-              computedUserset: {
-                object: '',
-                relation: 'owner',
+    schema_version: '1.1',
+    type_definitions: [
+      {
+        can_share: {
+          union: {
+            child: [
+              {
+                computedUserset: {
+                  object: '',
+                  relation: 'owner',
+                },
               },
-              tupleset: {
-                object: '',
-                relation: 'parent',
+              {
+                computedUserset: {
+                  object: '',
+                  relation: 'editor',
+                },
               },
-            },
+              {
+                tupleToUserset: {
+                  computedUserset: {
+                    object: '',
+                    relation: 'owner',
+                  },
+                  tupleset: {
+                    object: '',
+                    relation: 'parent',
+                  },
+                },
+              },
+            ],
           },
-        ],
+        },
       },
-    },
+    ],
   }}
 />
 
 There are a few key things here:
 
-- **We don't use self as part of the definition.** can_share is a common example of representing a permission that is defined in terms of other relations but is not directly assignable by the system.
+- **We don't use [direct relationship type restriction](../configuration-language.mdx#the-direct-relationship-type-restrictions) as part of the definition.** can_share is a common example of representing a permission that is defined in terms of other relations but is not directly assignable by the system.
 - The relation definition contains a [union operator](../configuration-language.mdx#the-union-operator) separating a list of relations that the user must have with the object in order to "be able to share the document". It is any of:
   - Being an owner of the document
   - Being an editor of the document
@@ -896,49 +902,55 @@ Similar to the [can_share relation](#relation-can_share), we can achieve that wi
 
 <AuthzModelSnippetViewer
   onlyShow={SyntaxFormat.Friendly2}
+  skipVersion={true}
   configuration={{
-    can_view: {
-      union: {
-        child: [
-          {
-            computedUserset: {
-              object: '',
-              relation: 'viewer',
-            },
-          },
-          {
-            computedUserset: {
-              object: '',
-              relation: 'editor',
-            },
-          },
-          {
-            tupleToUserset: {
-              computedUserset: {
-                object: '',
-                relation: 'viewer',
+    schema_version: '1.1',
+    type_definitions: [
+      {
+        can_view: {
+          union: {
+            child: [
+              {
+                computedUserset: {
+                  object: '',
+                  relation: 'viewer',
+                },
               },
-              tupleset: {
-                object: '',
-                relation: 'parent',
+              {
+                computedUserset: {
+                  object: '',
+                  relation: 'editor',
+                },
               },
-            },
+              {
+                tupleToUserset: {
+                  computedUserset: {
+                    object: '',
+                    relation: 'viewer',
+                  },
+                  tupleset: {
+                    object: '',
+                    relation: 'parent',
+                  },
+                },
+              },
+              {
+                tupleToUserset: {
+                  computedUserset: {
+                    object: '',
+                    relation: 'owner',
+                  },
+                  tupleset: {
+                    object: '',
+                    relation: 'parent',
+                  },
+                },
+              },
+            ],
           },
-          {
-            tupleToUserset: {
-              computedUserset: {
-                object: '',
-                relation: 'owner',
-              },
-              tupleset: {
-                object: '',
-                relation: 'parent',
-              },
-            },
-          },
-        ],
+        },
       },
-    },
+    ],
   }}
 />
 
@@ -952,37 +964,43 @@ Similar to the [can_share relation](#relation-can_share), we can achieve that wi
 
 <AuthzModelSnippetViewer
   onlyShow={SyntaxFormat.Friendly2}
+  skipVersion={true}
   configuration={{
-    can_write: {
-      union: {
-        child: [
-          {
-            computedUserset: {
-              object: '',
-              relation: 'editor',
-            },
-          },
-          {
-            computedUserset: {
-              object: '',
-              relation: 'owner',
-            },
-          },
-          {
-            tupleToUserset: {
-              computedUserset: {
-                object: '',
-                relation: 'owner',
+    schema_version: '1.1',
+    type_definitions: [
+      {
+        can_write: {
+          union: {
+            child: [
+              {
+                computedUserset: {
+                  object: '',
+                  relation: 'editor',
+                },
               },
-              tupleset: {
-                object: '',
-                relation: 'parent',
+              {
+                computedUserset: {
+                  object: '',
+                  relation: 'owner',
+                },
               },
-            },
+              {
+                tupleToUserset: {
+                  computedUserset: {
+                    object: '',
+                    relation: 'owner',
+                  },
+                  tupleset: {
+                    object: '',
+                    relation: 'parent',
+                  },
+                },
+              },
+            ],
           },
-        ],
+        },
       },
-    },
+    ],
   }}
 />
 
@@ -996,13 +1014,19 @@ Similar to the [can_share relation](#relation-can_share), we can achieve that wi
 
 <AuthzModelSnippetViewer
   onlyShow={SyntaxFormat.Friendly2}
+  skipVersion={true}
   configuration={{
-    can_change_owner: {
-      computedUserset: {
-        object: '',
-        relation: 'owner',
+    schema_version: '1.1',
+    type_definitions: [
+      {
+        can_change_owner: {
+          computedUserset: {
+            object: '',
+            relation: 'owner',
+          },
+        },
       },
-    },
+    ],
   }}
 />
 

--- a/docs/content/modeling/migrating/migrating-relations.mdx
+++ b/docs/content/modeling/migrating/migrating-relations.mdx
@@ -43,6 +43,7 @@ In this scenario, you will migrate the following model:
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'document',
@@ -86,6 +87,7 @@ This is the authorization model that you will want to migrate to:
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'document',
@@ -118,6 +120,7 @@ In the example below, `user:Anne` still has write privileges to the `document:ro
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'document',
@@ -261,6 +264,7 @@ After you remove the previous relationship tuples, update your authorization mod
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type_definitions: [
       {
         type: 'document',

--- a/docs/content/modeling/organization-context-authorization.mdx
+++ b/docs/content/modeling/organization-context-authorization.mdx
@@ -320,13 +320,14 @@ We can do that by introducing some new relations and updating existing relation 
 - Add "user_in_context" relation to mark that a user's access is being evaluated within that particular context
 - Update the "project_manager" relation to require that the user be in the correct context (by adding `and user_in_context` to the relation definition)
 - Considering that <ProductName format={ProductNameFormat.ShortForm}/> does not yet support multiple logical operations within the same definition, we will split "project_editor" into two:
-  - "base_project_editor" editor which will contain the original relation definition (`self or project_manager`)
+  - "base_project_editor" editor which will contain the original relation definition (`[user] or project_manager`)
   - "project_editor" which will require that a user has both the "base_project_editor" and the "user_in_context" relations
 
 The "organization" type definition then becomes:
 
 <AuthzModelSnippetViewer
   configuration={{
+    schema_version: '1.1',
     type: 'organization',
     relations: {
       member: {
@@ -392,7 +393,7 @@ The "organization" type definition then becomes:
         user_in_context: { directly_related_user_types: [{ type: 'user' }] },
       },
     },
-  }}
+  }} skipVersion={true}
 />
 
 2. On the "project" type

--- a/docs/content/modeling/roles-and-permissions.mdx
+++ b/docs/content/modeling/roles-and-permissions.mdx
@@ -104,7 +104,7 @@ You need to know how to create an authorization model and create a relationship 
 - An <ProductConcept section="what-is-an-object" linkName="Object" />: represents an entity in the system. Users' relationships to it can be define through relationship tuples and the authorization model
 - A <ProductConcept section="what-is-a-relationship-tuple" linkName="Relationship Tuple" />: a grouping consisting of a user, a relation and an object stored in Auth <ProductName format={ProductNameFormat.ShortForm}/>
 - A <ProductConcept section="what-is-a-relationship" linkName="Relationship" />: <ProductName format={ProductNameFormat.ShortForm}/> will be called to check if there is a relationship between a user and an object, indicating that the access is allowed
-- [Direct Relationship Keyword](../configuration-language.mdx#the-direct-relationship-keyword): The `self` keyword can be used to indicate direct relationships between users and objects
+- [Direct Relationship Type Restriction](../configuration-language.mdx#the-direct-relationship-type-restrictions): can be used to indicate direct relationships between users and objects
 - A <ProductConcept section="what-is-a-check-request" linkName="Check API Request" /> the Check API Request is used to check for relationships between users and objects
 
 </details>
@@ -158,7 +158,7 @@ Relating roles within <ProductName format={ProductNameFormat.ShortForm}/> can be
 
 ### 02. Adding Permissions For Bookings
 
-Permissions within <ProductName format={ProductNameFormat.LongForm}/> can be best described as the following: **Permissions are relations that users get only through other relations.** To represent permissions, we avoid adding the [**direct relationship keyword**](../configuration-language.mdx#the-direct-relationship-keyword) (`self`) to the relation in the authorization model. Instead, we define the relation from other relations to indicate that it is a permission granted to and implied from a different relation.
+Permissions within <ProductName format={ProductNameFormat.LongForm}/> can be best described as the following: **Permissions are relations that users get only through other relations.** To represent permissions, we avoid adding [**direct relationship type restriction**](../configuration-language.mdx#the-direct-relationship-type-restrictions) to the relation in the authorization model. Instead, we define the relation from other relations to indicate that it is a permission granted to and implied from a different relation.
 
 To add permissions related to bookings, we can add new relations to the `trip` _object_ type denoting the various actions a user can take on `trips` (view, edit, delete, rename, etc...)
 
@@ -219,11 +219,11 @@ To allow `viewers` of a `trip` to have **permissions to view bookings** and `own
   }}
 />
 
-> Note: notice how both `booking_viewer` and `booking_adder` don't have the `self` syntax, this is to ensure that the relation can only be assigned through the **role** and not directly.
+> Note: notice how both `booking_viewer` and `booking_adder` don't have the [direct relationship type restrictions](../configuration-language.mdx#the-direct-relationship-type-restrictions), this is to ensure that the relation can only be assigned through the **role** and not directly.
 
 ### 03. Checking User Roles And Their Permissions
 
-Now that our type definitions reflects the roles and permissions on how bookings can be viewed/added. Let's create _<ProductConcept section="what-is-a-relationship-tuple" linkName="relationship tuples" />_ to assign roles to _users_ and then *<ProductConcept section="what-is-a-check-request" linkName="check" />*if _users_ have the proper permissions.
+Now that our type definitions reflects the roles and permissions on how bookings can be viewed/added. Let's create _<ProductConcept section="what-is-a-relationship-tuple" linkName="relationship tuples" />_ to assign roles to _users_ and then *<ProductConcept section="what-is-a-check-request" linkName="check" />* if _users_ have the proper permissions.
 
 Let us create two relationship tuples:
 

--- a/src/components/Docs/AuthorizationModel/AuthzModelCodeBlock.tsx
+++ b/src/components/Docs/AuthorizationModel/AuthzModelCodeBlock.tsx
@@ -7,16 +7,17 @@ import { WriteAuthorizationModelRequest } from '@openfga/sdk';
 type AuthzModelCodeBlockProps = {
   configuration: WriteAuthorizationModelRequest;
   syntaxFormat: SyntaxFormat;
+  skipVersion?: boolean;
 };
 
-const AuthzModelCodeBlock: React.FC<AuthzModelCodeBlockProps> = ({ configuration, syntaxFormat }) => {
+const AuthzModelCodeBlock: React.FC<AuthzModelCodeBlockProps> = ({ configuration, syntaxFormat, skipVersion }) => {
   return (
     <CodeBlock
       className={`language-${
         syntaxFormat === SyntaxFormat.Api ? 'json' : syntaxHighlighters.PrismExtensions.LANGUAGE_NAME
       }`}
     >
-      {loadSyntax(configuration, syntaxFormat)}
+      {loadSyntax(configuration, syntaxFormat, skipVersion)}
     </CodeBlock>
   );
 };

--- a/src/components/Docs/AuthorizationModel/AuthzModelSnippetViewer.tsx
+++ b/src/components/Docs/AuthorizationModel/AuthzModelSnippetViewer.tsx
@@ -16,21 +16,36 @@ type AuthzModelSnippetViewerProps = {
   description?: string;
   onlyShow?: SyntaxFormat;
   showWrite?: boolean;
+  // do not display the model schema in DSL
+  skipVersion?: boolean;
 };
 
-const AuthzModelSnippetViewer: React.FC<AuthzModelSnippetViewerProps> = ({ configuration, onlyShow, showWrite }) => {
+const AuthzModelSnippetViewer: React.FC<AuthzModelSnippetViewerProps> = ({
+  configuration,
+  onlyShow,
+  showWrite,
+  skipVersion,
+}) => {
   if (onlyShow) {
-    return <AuthzModelCodeBlock configuration={configuration} syntaxFormat={onlyShow} />;
+    return <AuthzModelCodeBlock configuration={configuration} syntaxFormat={onlyShow} skipVersion={skipVersion} />;
   }
 
   return (
     <>
       <Tabs groupId="dsl">
         <TabItem value="dsl" label="DSL">
-          <AuthzModelCodeBlock configuration={configuration} syntaxFormat={SyntaxFormat.Friendly2} />
+          <AuthzModelCodeBlock
+            configuration={configuration}
+            syntaxFormat={SyntaxFormat.Friendly2}
+            skipVersion={skipVersion}
+          />
         </TabItem>
         <TabItem value="json" label="JSON">
-          <AuthzModelCodeBlock configuration={configuration} syntaxFormat={SyntaxFormat.Api} />
+          <AuthzModelCodeBlock
+            configuration={configuration}
+            syntaxFormat={SyntaxFormat.Api}
+            skipVersion={skipVersion}
+          />
         </TabItem>
       </Tabs>
       {showWrite ? (

--- a/src/components/Docs/AuthorizationModel/SyntaxTransformer.ts
+++ b/src/components/Docs/AuthorizationModel/SyntaxTransformer.ts
@@ -8,12 +8,21 @@ export enum SyntaxFormat {
   Friendly2 = 'friendly_v2',
 }
 
-export const loadSyntax = (configuration: WriteAuthorizationModelRequest, format: SyntaxFormat = SyntaxFormat.Api) => {
+export const loadSyntax = (
+  configuration: WriteAuthorizationModelRequest,
+  format: SyntaxFormat = SyntaxFormat.Api,
+  skipVersion?: boolean,
+) => {
   switch (format) {
     case SyntaxFormat.Friendly2:
-      return apiSyntaxToFriendlySyntax(configuration);
+      return skipVersion
+        ? apiSyntaxToFriendlySyntax(configuration).replace('model\n  schema 1.1\n', '')
+        : apiSyntaxToFriendlySyntax(configuration);
     case SyntaxFormat.Api:
-    default:
-      return JSON.stringify(configuration, null, '  ');
+    default: {
+      return skipVersion
+        ? JSON.stringify(configuration, null, '  ').replace('  "schema_version": "1.1",\n', '')
+        : JSON.stringify(configuration, null, '  ');
+    }
   }
 };


### PR DESCRIPTION

## Description
1. Remove `as self` from docs
2. Add in parameter in auth model component to remove schema version number.  This simplifies if we only want to show snippet.
3. Update auth model to be schema version 1.1

## References
Close https://github.com/openfga/openfga.dev/issues/330

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
