### PR TITLE
fix: add owner to can_view relation definition in getting started

### DIFF
--- a/docs/content/modeling/getting-started.mdx
+++ b/docs/content/modeling/getting-started.mdx
@@ -929,6 +929,12 @@ Similar to the [can_share relation](#relation-can_share), we can achieve that wi
                 },
               },
               {
+                computedUserset: {
+                  object: '',
+                  relation: 'owner',
+                },
+              },
+              {
                 tupleToUserset: {
                   computedUserset: {
                     object: '',


### PR DESCRIPTION
## Description
Small tweak to the [getting started doc](https://openfga.dev/docs/modeling/getting-started). When describing how to create a definition for the "can_view" relation, the sentence states 
>"A user can view a document if they are an owner, viewer or editor of a document or if they are a viewer, owner of the folder/drive that is the parent of the document."

But the actual definition is as follows
>    define can_view: viewer or editor or viewer from parent or owner from parent

Which is missing a direct owner relation. This is fixed in the final auth model.

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
