### PR TITLE
fix: update docker-compose file to be similar to openfga github

### DIFF
--- a/docs/content/getting-started/setup-openfga.mdx
+++ b/docs/content/getting-started/setup-openfga.mdx
@@ -108,52 +108,41 @@ networks:
   openfga:
 
 services:
-  db:
+  postgres:
     image: postgres:14
+    container_name: postgres
     networks:
       - openfga
+    ports:
+      - "5432:5432"
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=password
-      - POSTGRES_DB=openfga
     healthcheck:
       test: [ "CMD-SHELL", "pg_isready -U postgres" ]
       interval: 5s
       timeout: 5s
       retries: 5
 
-  pause:
-    image: ubuntu
-    command: sleep 5
-    depends_on:
-      db:
-        condition: service_started
-
   migrate:
-    image: openfga/openfga
     depends_on:
-      pause:
-        condition: service_completed_successfully
-    command: |
-      migrate
-    environment: 
-      - OPENFGA_DATASTORE_ENGINE=postgres
-      - OPENFGA_DATASTORE_URI=postgres://postgres:password@db:5432/openfga
+      postgres:
+        condition: service_healthy
+    image: openfga/openfga:latest
+    container_name: migrate
+    command: migrate --datastore-engine postgres --datastore-uri 'postgres://postgres:password@postgres:5432/postgres?sslmode=disable'
     networks:
       - openfga
 
   openfga:
-    image: openfga/openfga
-    environment:
-      - OPENFGA_DATASTORE_ENGINE=postgres
-      - OPENFGA_DATASTORE_URI=postgres://postgres:password@db:5432/openfga
-      - OPENFGA_LOG_FORMAT=json
-    command: run
     depends_on:
-      db:
-        condition: service_started
       migrate:
         condition: service_completed_successfully
+    image: openfga/openfga:latest
+    container_name: openfga
+    environment:
+      - OPENFGA_LOG_FORMAT=json
+    command: run --datastore-engine postgres --datastore-uri 'postgres://postgres:password@postgres:5432/postgres?sslmode=disable'
     networks:
       - openfga
     ports:

--- a/docs/content/getting-started/setup-openfga.mdx
+++ b/docs/content/getting-started/setup-openfga.mdx
@@ -130,7 +130,10 @@ services:
         condition: service_healthy
     image: openfga/openfga:latest
     container_name: migrate
-    command: migrate --datastore-engine postgres --datastore-uri 'postgres://postgres:password@postgres:5432/postgres?sslmode=disable'
+    command: migrate
+    environment:
+      - OPENFGA_DATASTORE_ENGINE=postgres
+      - OPENFGA_DATASTORE_URI=postgres://postgres:password@postgres:5432/postgres?sslmode=disable
     networks:
       - openfga
 
@@ -141,8 +144,10 @@ services:
     image: openfga/openfga:latest
     container_name: openfga
     environment:
+      - OPENFGA_DATASTORE_ENGINE=postgres
+      - OPENFGA_DATASTORE_URI=postgres://postgres:password@postgres:5432/postgres?sslmode=disable
       - OPENFGA_LOG_FORMAT=json
-    command: run --datastore-engine postgres --datastore-uri 'postgres://postgres:password@postgres:5432/postgres?sslmode=disable'
+    command: run
     networks:
       - openfga
     ports:


### PR DESCRIPTION


## Description
Remove reference to pause.  In addition, reformat to be similar to https://github.com/openfga/openfga/blob/main/docker-compose.yaml.

<img width="2032" alt="Screen Shot 2023-02-09 at 4 17 25 PM" src="https://user-images.githubusercontent.com/10730463/217941533-a3ed1f96-57e4-406d-b353-ddecd0c47866.png">


## References
Close https://github.com/openfga/openfga.dev/issues/359


## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
