### PR TITLE
fix: correct migration relations read tuples

### DIFF
--- a/docs/content/modeling/migrating/migrating-relations.mdx
+++ b/docs/content/modeling/migrating/migrating-relations.mdx
@@ -193,11 +193,9 @@ Run a check in the API for Bethany to ensure correct access.
 
 Next, migrate the existing relationship tuples. The new relation makes this definition obsolete.
 
-Use the `read` API to lookup all relationship tuples with the `editor` name in your model.
+Use the `read` API to lookup all relationship tuples.
 
 <ReadRequestViewer
-  relation={'editor'}
-  object={'document:'}
   tuples={[
     {
       user: 'user:anne',

--- a/docs/content/modeling/migrating/migrating-relations.mdx
+++ b/docs/content/modeling/migrating/migrating-relations.mdx
@@ -210,7 +210,7 @@ Use the `read` API to lookup all relationship tuples.
   ]}
 />
 
-Update the new tuples with the `write` relationship.
+We will then filter out the tuples that do not match the object type or relations. Update the new tuples with the `write` relationship.
 
 <WriteRequestViewer
   relationshipTuples={[

--- a/docs/content/modeling/migrating/migrating-relations.mdx
+++ b/docs/content/modeling/migrating/migrating-relations.mdx
@@ -210,7 +210,7 @@ Use the `read` API to lookup all relationship tuples.
   ]}
 />
 
-We will then filter out the tuples that do not match the object type or relations. Update the new tuples with the `write` relationship.
+Then filter out the tuples that do not match the object type or relation (in this case, `document` and `editor` respectively), then update the new tuples with the `write` relationship.
 
 <WriteRequestViewer
   relationshipTuples={[

--- a/docs/content/modeling/migrating/migrating-relations.mdx
+++ b/docs/content/modeling/migrating/migrating-relations.mdx
@@ -210,7 +210,7 @@ Use the `read` API to lookup all relationship tuples.
   ]}
 />
 
-Then filter out the tuples that do not match the object type or relation (in this case, `document` and `editor` respectively), then update the new tuples with the `write` relationship.
+Then filter out the tuples that do not match the object type or relation (in this case, `document` and `editor` respectively), and update the new tuples with the `write` relationship.
 
 <WriteRequestViewer
   relationshipTuples={[

--- a/src/components/Docs/SnippetViewer/ReadRequestViewer.tsx
+++ b/src/components/Docs/SnippetViewer/ReadRequestViewer.tsx
@@ -37,11 +37,10 @@ function readRequestViewer(lang: SupportedLanguage, opts: ReadRequestViewerOpts,
           `"object":"${opts.object}"`
         : '';
 
-      const requestTuplePayload =
-        requestTuples != ''
-          ? `\\
+      const requestTuplePayload = requestTuples
+        ? `\\
   -d '{"tuple_key":{${requestTuples}}}`
-          : '';
+        : '';
 
       // eslint-disable-next-line max-len
       return `curl -X POST $FGA_API_URL/stores/$FGA_STORE_ID/read \\
@@ -57,14 +56,13 @@ function readRequestViewer(lang: SupportedLanguage, opts: ReadRequestViewerOpts,
           (opts.relation ? `    relation:'${opts.relation}',\n` : '') +
           `    object:'${opts.object}',`
         : '';
-      const requestTuplesPayload =
-        requestTuples != ''
-          ? `
+      const requestTuplesPayload = requestTuples
+        ? `
   tuple_key: {
 ${requestTuples}
   },
 `
-          : '';
+        : '';
       return `
 // Execute a read
 const { tuples } = await fgaClient.read({${requestTuplesPayload}});
@@ -79,14 +77,13 @@ const { tuples } = await fgaClient.read({${requestTuplesPayload}});
           (opts.relation ? `\t\tRelation: fgaSdk.PtrString("${opts.relation}"),\n` : '') +
           `\t\tObject: fgaSdk.PtrString("${opts.object}"),\n`
         : '';
-      const requestTuplePayload =
-        requestTuples != ''
-          ? `
+      const requestTuplePayload = requestTuples
+        ? `
   TupleKey: fgaSdk.TupleKey{
 ${requestTuples}
   },
 `
-          : '';
+        : '';
 
       /* eslint-disable no-tabs */
       return `
@@ -103,12 +100,11 @@ data, response, err := fgaClient.${languageMappings['go'].apiName}.Read(context.
           `  Object = "${opts.object}",`
         : '';
 
-      const requestTuplePayload =
-        requestTuples != ''
-          ? `new TupleKey() {
+      const requestTuplePayload = requestTuples
+        ? `new TupleKey() {
 ${requestTuples}
 }`
-          : '';
+        : '';
 
       /* eslint-disable no-tabs */
       return `
@@ -123,14 +119,13 @@ var response = fgaClient.Read(new ReadRequest(${requestTuplePayload}));
           `            object="${opts.object}",\n`
         : '';
 
-      const requestTuplePayload =
-        requestTuples != ''
-          ? `
+      const requestTuplePayload = requestTuples
+        ? `
         tuple_key=TupleKey(
 ${requestTuples}
         ),
     `
-          : '';
+        : '';
       return `
 # from openfga_sdk.models.read_request import ReadRequest
 # from openfga_sdk.models.read_response import ReadResponse

--- a/src/components/Docs/SnippetViewer/ReadRequestViewer.tsx
+++ b/src/components/Docs/SnippetViewer/ReadRequestViewer.tsx
@@ -12,7 +12,7 @@ interface ReadRequestViewerOpts {
   ModelId?: string;
   user?: string;
   relation?: string;
-  object: string;
+  object?: string;
   tuples?: ReadTuples[];
   skipSetup?: boolean;
   allowedLanguages?: SupportedLanguage[];
@@ -31,97 +31,125 @@ function readRequestViewer(lang: SupportedLanguage, opts: ReadRequestViewerOpts,
 
   switch (lang) {
     case SupportedLanguage.CURL: {
-      const requestTuples =
-        (opts.user ? `"user":"${opts.user}",` : '') +
-        (opts.relation ? `"relation":"${opts.relation}",` : '') +
-        `"object":"${opts.object}"`;
+      const requestTuples = opts.object
+        ? (opts.user ? `"user":"${opts.user}",` : '') +
+          (opts.relation ? `"relation":"${opts.relation}",` : '') +
+          `"object":"${opts.object}"`
+        : '';
+
+      const requestTuplePayload =
+        requestTuples != ''
+          ? `\\
+  -d '{"tuple_key":{${requestTuples}}}`
+          : '';
 
       // eslint-disable-next-line max-len
       return `curl -X POST $FGA_API_URL/stores/$FGA_STORE_ID/read \\
   -H "Authorization: Bearer $FGA_BEARER_TOKEN" \\ # Not needed if service does not require authorization
-  -H "content-type: application/json" \\
-  -d '{"tuple_key":{${requestTuples}}}'
+  -H "content-type: application/json" ${requestTuplePayload}'
 
 # Response: "tuples": {[${readTuples}]}`;
     }
 
     case SupportedLanguage.JS_SDK: {
-      const requestTuples =
-        (opts.user ? `    user:'${opts.user}',\n` : '') +
-        (opts.relation ? `    relation:'${opts.relation}',\n` : '') +
-        `    object:'${opts.object}',`;
-      return `
-// Execute a read
-const { tuples } = await fgaClient.read({
+      const requestTuples = opts.object
+        ? (opts.user ? `    user:'${opts.user}',\n` : '') +
+          (opts.relation ? `    relation:'${opts.relation}',\n` : '') +
+          `    object:'${opts.object}',`
+        : '';
+      const requestTuplesPayload =
+        requestTuples != ''
+          ? `
   tuple_key: {
 ${requestTuples}
   },
-});
+`
+          : '';
+      return `
+// Execute a read
+const { tuples } = await fgaClient.read({${requestTuplesPayload}});
 
 // tuples = [${readTuples}]
 `;
     }
 
     case SupportedLanguage.GO_SDK: {
-      const requestTuples =
-        (opts.user ? `\t\tUser: fgaSdk.PtrString("${opts.user}"),\n` : '') +
-        (opts.relation ? `\t\tRelation: fgaSdk.PtrString("${opts.relation}"),\n` : '') +
-        `\t\tObject: fgaSdk.PtrString("${opts.object}"),\n`;
+      const requestTuples = opts.object
+        ? (opts.user ? `\t\tUser: fgaSdk.PtrString("${opts.user}"),\n` : '') +
+          (opts.relation ? `\t\tRelation: fgaSdk.PtrString("${opts.relation}"),\n` : '') +
+          `\t\tObject: fgaSdk.PtrString("${opts.object}"),\n`
+        : '';
+      const requestTuplePayload =
+        requestTuples != ''
+          ? `
+  TupleKey: fgaSdk.TupleKey{
+${requestTuples}
+  },
+`
+          : '';
 
       /* eslint-disable no-tabs */
       return `
-body := fgaSdk.ReadRequest{
-	TupleKey: fgaSdk.TupleKey{
-${requestTuples}
-	},
-}
+body := fgaSdk.ReadRequest{${requestTuplePayload}}
 data, response, err := fgaClient.${languageMappings['go'].apiName}.Read(context.Background()).Body(body).Execute()
 
 // data = { "tuples": [${readTuples}] }`;
     }
 
     case SupportedLanguage.DOTNET_SDK: {
-      const requestTuples =
-        (opts.user ? `  User = "${opts.user}",\n` : '') +
-        (opts.relation ? `  Relation = "${opts.relation}",\n` : '') +
-        `  Object = "${opts.object}",`;
+      const requestTuples = opts.object
+        ? (opts.user ? `  User = "${opts.user}",\n` : '') +
+          (opts.relation ? `  Relation = "${opts.relation}",\n` : '') +
+          `  Object = "${opts.object}",`
+        : '';
+
+      const requestTuplePayload =
+        requestTuples != ''
+          ? `new TupleKey() {
+${requestTuples}
+}`
+          : '';
 
       /* eslint-disable no-tabs */
       return `
-var response = fgaClient.Read(new ReadRequest(new TupleKey() {
-${requestTuples}
-}));
+var response = fgaClient.Read(new ReadRequest(${requestTuplePayload}));
 
 // data = { "tuples": [${readTuples}] }`;
     }
     case SupportedLanguage.PYTHON_SDK: {
-      const requestTuples =
-        (opts.user ? `            user="${opts.user}",\n` : '') +
-        (opts.relation ? `            relation="${opts.relation}",\n` : '') +
-        `            object="${opts.object}",\n`;
+      const requestTuples = opts.object
+        ? (opts.user ? `            user="${opts.user}",\n` : '') +
+          (opts.relation ? `            relation="${opts.relation}",\n` : '') +
+          `            object="${opts.object}",\n`
+        : '';
 
+      const requestTuplePayload =
+        requestTuples != ''
+          ? `
+        tuple_key=TupleKey(
+${requestTuples}
+        ),
+    `
+          : '';
       return `
 # from openfga_sdk.models.read_request import ReadRequest
 # from openfga_sdk.models.read_response import ReadResponse
 # from openfga_sdk.models.tuple_key import TupleKey
 
 async def read():
-    body = ReadRequest(
-        tuple_key=TupleKey(
-${requestTuples}
-        ),
-    )
+    body = ReadRequest(${requestTuplePayload})
     response = await fga_client_instance.read(body)
     # response = ReadResponse({"tuples":[${readTuples}]})`;
     }
     case SupportedLanguage.RPC: {
-      const objectOrType = opts.object.slice(-1) === ':' ? 'type' : 'object';
-      const requestTuples =
-        (opts.user
-          ? `  "${opts.user}", // where user \`${opts.user}\` has $(opts.relation ? '': 'any ' )relation\n`
-          : `  // for users who have relation\n`) +
-        (opts.relation ? `  "${opts.relation}", // \`${opts.relation}\`\n` : '') +
-        `  "${opts.object}", // with the ${objectOrType} \`${opts.object}\``;
+      const objectOrType = opts.object ? (opts.object.slice(-1) === ':' ? 'type' : 'object') : '';
+      const requestTuples = opts.object
+        ? (opts.user
+            ? `  "${opts.user}", // where user \`${opts.user}\` has $(opts.relation ? '': 'any ' )relation\n`
+            : `  // for users who have relation\n`) +
+          (opts.relation ? `  "${opts.relation}", // \`${opts.relation}\`\n` : '') +
+          `  "${opts.object}", // with the ${objectOrType} \`${opts.object}\``
+        : '';
 
       const readTuples = opts.tuples
         ? opts.tuples


### PR DESCRIPTION
## Description

If only type is specified for read tuples, we must also provide the username. For migration, it is better to read all tuples instead of per relation/object type.

https://user-images.githubusercontent.com/10730463/223235832-d90eadd7-f0f9-4584-8aea-5bdde7247649.mov


## References

Close https://github.com/openfga/openfga.dev/issues/381


## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
