### PR TITLE
fix: member access image in github guide

### DIFF
--- a/docs/content/modeling/advanced/assets/github-org-base-permissions-drop-down.png
+++ b/docs/content/modeling/advanced/assets/github-org-base-permissions-drop-down.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6dc7e4ef47b014ba9f31d9311c62d90f591ade1fb2133171ed03780f0ebd1c3d
+size 473595

--- a/docs/content/modeling/advanced/github.mdx
+++ b/docs/content/modeling/advanced/github.mdx
@@ -784,7 +784,7 @@ What should the **users** in those relationship tuples with **???** be?
   - If the base permission for org contoso is repo_admin then it should be **organization:contoso#member**.
   - If the base permission for org contoso is NOT repo_admin, then it should be empty (no relationship tuple).
 - Whenever the value of this dropdown changes:
-  ![Selecting new permission level from base permissions drop-down](https://docs.github.com/assets/images/help/organizations/base-permissions-drop-down.png)
+  ![Selecting new permission level from base permissions drop-down](./assets/github-org-base-permissions-drop-down.png)
   - Delete the previous relationship tuple and create a new one:
     <WriteRequestViewer
       relationshipTuples={[


### PR DESCRIPTION

<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

GitHub deleted the file from their docs - replaced it with a manual screenshot
<img width="1257" alt="github-org-base-permissions-drop-down" src="https://user-images.githubusercontent.com/536147/229867875-238c4584-fe4d-4c0a-9dca-9671071a3a8a.png">



## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
