### PR TITLE
fix: correct CSP for github star

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -107,16 +107,16 @@ from openfga_sdk.api import open_fga_api`,
       block-all-mixed-content;
       child-src www.youtube-nocookie.com;
       prefetch-src 'self';
-      connect-src 'self' https://raw.githubusercontent.com https://s3.amazonaws.com https://cdn.cookielaw.org https://privacyportal.onetrust.com https://heapanalytics.com https://js.hs-scripts.com https://api.github.com ;
+      connect-src 'self' https://raw.githubusercontent.com https://s3.amazonaws.com https://cdn.cookielaw.org https://privacyportal.onetrust.com https://heapanalytics.com https://js.hs-scripts.com https://api.github.com https://js.hscollectedforms.net https://js.hs-analytics.net https://js.hs-banner.com https://forms.hscollectedforms.net ;
       font-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com;
       form-action 'none';
       frame-src www.youtube-nocookie.com;
-      img-src 'self' data: https://pbs.twimg.com https://docs.github.com https://heapanalytics.com;
+      img-src 'self' data: https://pbs.twimg.com https://docs.github.com https://heapanalytics.com https://forms.hsforms.com https://track.hubspot.com ;
       media-src 'self';
       object-src 'none';
       script-src 'self' ${
         process.env.NODE_ENV === 'development' ? `'unsafe-eval'` : ``
-      } 'unsafe-inline' https://cdn.cookielaw.org https://geolocation.onetrust.com https://cdn.heapanalytics.com https://js.hs-scripts.com https://api.github.com;
+      } 'unsafe-inline' https://cdn.cookielaw.org https://geolocation.onetrust.com https://cdn.heapanalytics.com https://js.hs-scripts.com https://api.github.com https://js.hscollectedforms.net https://js.hs-analytics.net https://js.hs-banner.com;
       style-src 'unsafe-inline' 'self' https://fonts.googleapis.com;`,
   },
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -107,7 +107,7 @@ from openfga_sdk.api import open_fga_api`,
       block-all-mixed-content;
       child-src www.youtube-nocookie.com;
       prefetch-src 'self';
-      connect-src 'self' https://raw.githubusercontent.com https://s3.amazonaws.com https://cdn.cookielaw.org https://privacyportal.onetrust.com https://heapanalytics.com https://js.hs-scripts.com;
+      connect-src 'self' https://raw.githubusercontent.com https://s3.amazonaws.com https://cdn.cookielaw.org https://privacyportal.onetrust.com https://heapanalytics.com https://js.hs-scripts.com https://api.github.com ;
       font-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com;
       form-action 'none';
       frame-src www.youtube-nocookie.com;


### PR DESCRIPTION
## Description
The CSP (Content Security Policy) for github is not correctly - preventing github star from being displayed properly.  Also update CSP for hubspot.

## References
https://community.hubspot.com/t5/HubSpot-Ideas/A-guide-to-Content-Security-Policy-CSP-settings/idi-p/314328

## Review Checklist
- [X] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [X] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
