### PR TITLE
fix: cache number of star gazers locally

### DIFF
--- a/src/theme/NavbarItem/NavbarNavLink.tsx
+++ b/src/theme/NavbarItem/NavbarNavLink.tsx
@@ -6,6 +6,8 @@ import { isRegexpStringMatch } from '@docusaurus/theme-common';
 import IconExternalLink from '@theme/Icon/ExternalLink';
 import type { Props } from '@theme/NavbarItem/NavbarNavLink';
 
+const github_stars = 'openfga_github_stars';
+
 export default function NavbarNavLink({
   activeBasePath,
   activeBaseRegex,
@@ -29,17 +31,26 @@ export default function NavbarNavLink({
   useEffect(() => {
     const getData = async () => {
       try {
+        const cached_github_stars = sessionStorage.getItem(github_stars);
+        if (cached_github_stars) {
+          setData(cached_github_stars);
+          return;
+        }
+
         const response = await fetch(`https://api.github.com/repos/openfga/openfga`);
         if (!response.ok) {
           throw new Error(`This is an HTTP error: The status is ${response.status}`);
         }
         const actualData = await response.json();
         setData(actualData.stargazers_count);
+        sessionStorage.setItem(cached_github_stars, actualData.stargazers_count);
       } catch (err) {
         setData(null);
       }
     };
-    getData();
+    if (!data) {
+      getData();
+    }
   }, []);
 
   const newLabel = label === 'GitHub' && data ? `GitHub | ${data}` : label;


### PR DESCRIPTION
## Description
Cache the number of github star gazers locally to avoid running into rate limiting by github 

## References
Close https://github.com/openfga/openfga.dev/issues/419


## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
