### PR TITLE
fix: correct .NET SDK check snippet bracket closing order

### DIFF
--- a/src/components/Docs/SnippetViewer/CheckRequestViewer.tsx
+++ b/src/components/Docs/SnippetViewer/CheckRequestViewer.tsx
@@ -139,7 +139,7 @@ TupleKey = new TupleKey() {
       .join(',\n    ')}
 }))`
           : ''
-      }, AuthorizationModelId = "${authorizationModelId ? authorizationModelId : DefaultAuthorizationModelId}")};
+      }, AuthorizationModelId = "${authorizationModelId ? authorizationModelId : DefaultAuthorizationModelId}"});
 
 // response.Allowed = ${allowed}`;
     case SupportedLanguage.PYTHON_SDK:


### PR DESCRIPTION

## Description
Correct bracket closing order

<img width="1833" alt="Screenshot 2023-04-18 at 11 48 00 AM" src="https://user-images.githubusercontent.com/10730463/232833436-914d303d-bbbf-4fbb-9866-afd4f42ca745.png">

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [X] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [X] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
