### PR TITLE
fix: correct caution box in list object explanation

### DIFF
--- a/docs/content/interacting/relationship-queries.mdx
+++ b/docs/content/interacting/relationship-queries.mdx
@@ -286,7 +286,7 @@ The [ListObjects API](/api/service#/Relationship%20Queries/ListObjects) is an AP
 
 It provides a solution to the [Search with Permissions (Option 3)](./search-with-permissions.mdx#option-3-build-a-list-of-ids-then-search) use case for access-aware filtering on small object collections.
 
-:::
+:::caution Warning
 Make sure to read the [caveats](./relationship-queries.mdx#caveats-and-when-not-to-use-it-3) when using ListObjects.
 :::
 


### PR DESCRIPTION
## Description

Add proper caution box in list object explanation

<img width="2032" alt="Screenshot 2023-04-20 at 6 05 16 PM" src="https://user-images.githubusercontent.com/10730463/233497380-333e76c9-5b08-4b74-a567-62f3e7cb16f0.png">


## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [X] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [X] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [X] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
