### PR TITLE
feat: add explanation of feature vs plan when used in entitlement

### DIFF
--- a/docs/content/modeling/building-blocks/object-to-object-relationships.mdx
+++ b/docs/content/modeling/building-blocks/object-to-object-relationships.mdx
@@ -254,6 +254,16 @@ Type `feature` has two relations, associated_plan and access. Relation `associat
   or `this`
 - object to object relationship where a user can access because it is a subscriber_member of a particular plan AND that plan is associated with the feature.
 
+Here, we define `plan` as the user of object `feature` with relationship `associated_plan` rather than defining `feature` as the user of object `plan` with relationship `feature`. The reason we choose the former is that we want to describe our system in the following [plain language](../getting-started.mdx#write-it-in-plain-language):
+
+<CardBox monoFontChildren appearance='filled'>
+
+- A user can access a feature in a plan if they are a subscriber member of a plan that is the associated plan of a feature.
+
+</CardBox>
+
+This will give us a flow of user->organization->plan->feature and allows us to answer the question of whether user can access a feature rather than whether user is subscriber of a plan.
+
 ### 02. Adding Relationship Tuples
 
 To realize the relationship, we will need to add the following relationship tuples.


### PR DESCRIPTION
## Description
Explain how to choose user vs. object with entitlement's feature vs. plan as example

<img width="2032" alt="Screenshot 2023-04-20 at 6 30 31 PM" src="https://user-images.githubusercontent.com/10730463/233647263-a14111d0-011b-492e-8799-9043635704c5.png">

 
## References
Based off of Discord message https://discord.com/channels/759188666072825867/1098436392595501066/1098600845790154772

## Review Checklist
- [X] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [X] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [X] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
