### PR TITLE
fix: missing double quotes

### DIFF
--- a/src/components/Docs/SnippetViewer/WriteRequestViewer.tsx
+++ b/src/components/Docs/SnippetViewer/WriteRequestViewer.tsx
@@ -44,7 +44,7 @@ function writeRequestViewer(lang: SupportedLanguage, opts: WriteRequestViewerOpt
   -H "content-type: application/json" \\
   -d '{${opts.relationshipTuples ? writes : ''}${separator}${
         opts.deleteRelationshipTuples ? deletes : ''
-      }, authorization_model_id: "${
+      }, "authorization_model_id": "${
         opts.authorizationModelId ? opts.authorizationModelId : DefaultAuthorizationModelId
       }"}'`;
     }


### PR DESCRIPTION
## Description
The `authorization_model_id` key in [Update Relationship Tuples](https://openfga.dev/docs/getting-started/update-tuples) is not enclosed in double quotes, making it difficult to copy and paste for use.

<img width="600" alt="image" src="https://user-images.githubusercontent.com/38530610/236808518-b6e5cfa2-4260-4729-b81f-43b0dc03d916.png">



## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
