### PR TITLE
fix: list objects concept should refer to proper endpoint

### DIFF
--- a/docs/content/concepts.mdx
+++ b/docs/content/concepts.mdx
@@ -534,7 +534,7 @@ For more information, please see the [Relationship Queries page](./interacting/r
 
 ## What Is A List Objects Request?
 
-A **list objects request** is a call to the <ProductName format={ProductNameFormat.LongForm}/> check endpoint that returns all the objects of a given type that a user has a specified relationship with.
+A **list objects request** is a call to the <ProductName format={ProductNameFormat.LongForm}/> list objects endpoint that returns all the objects of a given type that a user has a specified relationship with.
 
 </summary>
 


### PR DESCRIPTION


## Description
Typo fix for concept page.  List objects should use its own endpoint instead of check endpoint

## References
N/A

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
