### PR TITLE
chore: remove migrating schema 1.1 document

### DIFF
--- a/docs/content/modeling/migrating/migrating-schema-1-1.mdx
+++ b/docs/content/modeling/migrating/migrating-schema-1-1.mdx
@@ -22,6 +22,10 @@ import {
 
 <DocumentationNotice />
 
+:::info
+The model schema v1.0 has been deprecated. Migrate to schema v1.1 in order to be able to write tuples and run queries on your store.
+:::
+
 A new DSL schema version has been introduced with several changes that we
 believe will make models easier to read and write, enable better tuple and model validations, and provide more options for
 optimizing the performance of different <ProductName format={ProductNameFormat.ShortForm} /> APIs.<br/><br/>

--- a/docs/content/modeling/migrating/migrating-schema-1-1.mdx
+++ b/docs/content/modeling/migrating/migrating-schema-1-1.mdx
@@ -22,10 +22,6 @@ import {
 
 <DocumentationNotice />
 
-:::caution
-The <ProductName format={ProductNameFormat.ShortForm} /> model schema v1.0 is being deprecated. Read about when support will be dropped in the [deprecation timeline](#deprecation-timeline).
-:::
-
 A new DSL schema version has been introduced with several changes that we
 believe will make models easier to read and write, enable better tuple and model validations, and provide more options for
 optimizing the performance of different <ProductName format={ProductNameFormat.ShortForm} /> APIs.<br/><br/>

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -211,11 +211,6 @@ from openfga_sdk.api import open_fga_api`,
         defaultMode: 'dark',
         disableSwitch: true,
       },
-      announcementBar: {
-        id: 'announcementBar.4', // Increment on change
-        // eslint-disable-next-line max-len
-        content: `OpenFGA is deprecating model schema v1.0. Read about when support will be dropped and how to migrate in the <a href="/docs/modeling/migrating/migrating-schema-1-1#deprecation-timeline">deprecation timeline</a>.`,
-      },
       navbar: {
         // style: "primary",
         // title: "OpenFGA",


### PR DESCRIPTION
## Description
Remove migrating schema 1.1 document's note about deprecation
<img width="2032" alt="Screenshot 2023-06-09 at 8 21 26 PM" src="https://github.com/openfga/openfga.dev/assets/10730463/a007a5f4-67fd-44c1-bde0-9a56d0d92e13">


## References
Close https://github.com/openfga/openfga.dev/issues/450


## Review Checklist
- [X] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [X] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [X] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
