### PR TITLE
fix: typo in configuration language documentation

### DIFF
--- a/docs/content/configuration-language.mdx
+++ b/docs/content/configuration-language.mdx
@@ -259,7 +259,7 @@ The _authorization model_ describes four _<ProductConcept section="what-is-a-typ
 
 The `domain` _<ProductConcept section="what-is-a-type-definition" linkName="type definition" />_ has a single _<ProductConcept section="what-is-a-relation" linkName="relation" />_ called `member` that only allows <ProductConcept section="what-are-direct-and-implied-relationships" linkName="direct relationships" />.
 
-The `folder` and `document` _type definitions_ each have five _relations_: `parent_folder`, `owner`, `editor`, `viewer` and `can_share`.
+The `folder` and `document` _type definitions_ each have five _relations_: `parent_folder`, `owner`, `writer`, `viewer` and `can_share`.
 
 :::
 


### PR DESCRIPTION
## Description

Fix reference to correct type `writer` instead of `editor`.

## References

https://openfga.dev/docs/configuration-language

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
