### PR TITLE
fix: github and migration examples specified directly assignable relationship

### DIFF
--- a/docs/content/getting-started/create-store.mdx
+++ b/docs/content/getting-started/create-store.mdx
@@ -108,7 +108,7 @@ from openfga_sdk.client import OpenFgaClient
 from openfga_sdk.models.create_store_request import CreateStoreRequest
 
 configuration = openfga_sdk.Configuration(
-    scheme = os.environ.get('FGA_API_SCHEME')
+    scheme = os.environ.get('FGA_API_SCHEME'),
     api_host = os.environ.get('FGA_API_HOST'),
 )
 

--- a/docs/content/modeling/advanced/github.mdx
+++ b/docs/content/modeling/advanced/github.mdx
@@ -731,32 +731,47 @@ We express it like this:
     schema_version: '1.1',
     type_definitions: [
       {
-        admin: {
-          union: {
-            child: [
-              {
-                this: {},
-              },
-              {
-                tupleToUserset: {
-                  // read all tuples related to tooling as owner
-                  // which returns [{ "user": "organization:contoso", "relation": "owner", "object": "repo:contoso/tooling" }]
-                  tupleset: {
-                    relation: 'owner',
-                  },
-                  // and for each tuple return all usersets that match the following, replacing $TUPLE_USERSET_OBJECT with organization:contoso
-                  // this will return tuples of shape { object: "organization:contoso", "repo_admin", "user": ??? }
-                  computedUserset: {
-                    relation: 'repo_admin',
+        type: 'repo',
+        relations: {
+          admin: {
+            union: {
+              child: [
+                {
+                  this: {},
+                },
+                {
+                  tupleToUserset: {
+                    // read all tuples related to tooling as owner
+                    // which returns [{ "user": "organization:contoso", "relation": "owner", "object": "repo:contoso/tooling" }]
+                    tupleset: {
+                      relation: 'owner',
+                    },
+                    // and for each tuple return all usersets that match the following, replacing $TUPLE_USERSET_OBJECT with organization:contoso
+                    // this will return tuples of shape { object: "organization:contoso", "repo_admin", "user": ??? }
+                    computedUserset: {
+                      relation: 'repo_admin',
+                    },
                   },
                 },
-              },
-            ],
+              ],
+            },
+          },
+        },
+        metadata: {
+          relations: {
+            admin: {
+              directly_related_user_types: [
+                { type: 'user' },
+                { type: 'team', relation: 'member' },
+                { type: 'organization', relation: 'member' },
+              ],
+            },
           },
         },
       },
     ],
-  }} skipVersion={true}
+}}
+skipVersion={true}
 />
 
 :::info

--- a/docs/content/modeling/migrating/migrating-relations.mdx
+++ b/docs/content/modeling/migrating/migrating-relations.mdx
@@ -58,6 +58,11 @@ In this scenario, you will migrate the following model:
             },
           },
         },
+        metadata: {
+          relations: {
+            editor: { directly_related_user_types: [{ type: 'user' }] },
+          },
+        },
       },
       {
         type: 'user',
@@ -100,6 +105,11 @@ This is the authorization model that you will want to migrate to:
               object: '',
               relation: 'writer',
             },
+          },
+        },
+        metadata: {
+          relations: {
+            writer: { directly_related_user_types: [{ type: 'user' }] },
           },
         },
       },
@@ -153,6 +163,12 @@ In the example below, `user:Anne` still has write privileges to the `document:ro
               object: '',
               relation: 'writer',
             },
+          },
+        },
+        metadata: {
+          relations: {
+            editor: { directly_related_user_types: [{ type: 'user' }] },
+            writer: { directly_related_user_types: [{ type: 'user' }] },
           },
         },
       },
@@ -275,6 +291,11 @@ After you remove the previous relationship tuples, update your authorization mod
               object: '',
               relation: 'writer',
             },
+          },
+        },
+        metadata: {
+          relations: {
+            writer: { directly_related_user_types: [{ type: 'user' }] },
           },
         },
       },


### PR DESCRIPTION

## Description
Add directly assignable relationships to example so that DSL is rendered correctly
<img width="1016" alt="Screenshot 2023-08-29 at 11 54 15 AM" src="https://github.com/openfga/openfga.dev/assets/10730463/c33cc25f-9b56-4087-a503-d710b73de746">
<img width="1016" alt="Screenshot 2023-08-29 at 11 54 48 AM" src="https://github.com/openfga/openfga.dev/assets/10730463/052cb39f-dab9-4aee-a673-08f26e320afb">



## References
Close https://github.com/openfga/openfga.dev/issues/477

## Review Checklist
- [X] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [X] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
