### PR TITLE
fix: write and delete references on docs

### DIFF
--- a/src/components/Docs/SnippetViewer/WriteRequestViewer.tsx
+++ b/src/components/Docs/SnippetViewer/WriteRequestViewer.tsx
@@ -27,7 +27,7 @@ function writeRequestViewer(lang: SupportedLanguage, opts: WriteRequestViewerOpt
           ? opts.relationshipTuples
               .map(
                 (tuple) =>
-                  `fga write --store-id=\${FGA_STORE_ID} --model-id=${modelId} ${tuple.user} ${tuple.relation} ${tuple.object}`,
+                  `fga tuple write --store-id=\${FGA_STORE_ID} --model-id=${modelId} ${tuple.user} ${tuple.relation} ${tuple.object}`,
               )
               .join('\n')
           : ''
@@ -36,10 +36,7 @@ function writeRequestViewer(lang: SupportedLanguage, opts: WriteRequestViewerOpt
 ${
   opts.deleteRelationshipTuples?.length
     ? opts.deleteRelationshipTuples
-        .map(
-          (tuple) =>
-            `fga delete --store-id=\${FGA_STORE_ID} --model-id=${modelId} ${tuple.user} ${tuple.relation} ${tuple.object}`,
-        )
+        .map((tuple) => `fga tuple delete --store-id=\${FGA_STORE_ID} ${tuple.user} ${tuple.relation} ${tuple.object}`)
         .join('\n')
     : ''
 }`;


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

Aims to close #512  by fixing the commands used on the docs to write and delete tuples

## Description
<!-- Provide a detailed description of the changes -->

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
