### PR TITLE
Fix the assertion within the 'Get Started with Modeling' page.

### DIFF
--- a/docs/content/modeling/getting-started.mdx
+++ b/docs/content/modeling/getting-started.mdx
@@ -1445,7 +1445,7 @@ Because anne is the owner of document:1:
 
 Because beth is a member of organization:fabrikam and members of organization:fabrikam are writer of document:1:
 
-- user **beth** does not have relation **can_share** with document:1
+- user **beth** has relation **can_share** with document:1
 - user **beth** has relation **can_write** with document:1
 - user **beth** has relation **can_view** with document:1
 - user **beth** does not have relation **can_change_owner** with document:1


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
This change corrects the assertion that Beth does not have the **can_share** relationship with `document:1`, even though she is an editor of it.

![image](https://github.com/openfga/openfga.dev/assets/57375055/3640b859-5340-4108-b997-f4654aaa42f1)
_The relationship definition._

![image](https://github.com/openfga/openfga.dev/assets/57375055/c16decf4-e59b-4c35-abc3-5a182feb4c2f)
_Relationship tuples._

![image](https://github.com/openfga/openfga.dev/assets/57375055/567d5d21-3d3e-4c83-889f-63daf713df6a)
_Old assertion._

![image](https://github.com/openfga/openfga.dev/assets/57375055/c288f88b-4e3e-4446-b2e5-4b6af5677d86)
_Fixed assertion._

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
