### PR TITLE
chore: downgrade swagger-ui

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "react-dom": "18.2.0",
         "react-feather": "2.0.10",
         "sanitize-html": "2.11.0",
-        "swagger-ui-react": "5.10.3"
+        "swagger-ui-react": "5.9.3"
       },
       "devDependencies": {
         "@docusaurus/module-type-aliases": "3.0.1",
@@ -17164,9 +17164,9 @@
       }
     },
     "node_modules/swagger-ui-react": {
-      "version": "5.10.3",
-      "resolved": "https://registry.npmjs.org/swagger-ui-react/-/swagger-ui-react-5.10.3.tgz",
-      "integrity": "sha512-AB/ko3xD76wyCFbfb5zihy8Gacg7Lz62umzcmBLC/+VN8twib4ayWNZ48lTRh6Kb9vitvEQCDM/4VS2uTwwy0w==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/swagger-ui-react/-/swagger-ui-react-5.9.3.tgz",
+      "integrity": "sha512-4jVjVpbhn3EgAgOkKUiQcwZAlUsvX+2NXSY8c15MQ7iiBkwep0pC9i3I/4yw1DSmX5FSrqJZ4e0l7TI6ePdDiw==",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.23.2",
         "@braintree/sanitize-url": "=6.0.4",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "react-dom": "18.2.0",
     "react-feather": "2.0.10",
     "sanitize-html": "2.11.0",
-    "swagger-ui-react": "5.10.3"
+    "swagger-ui-react": "5.9.3"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "3.0.1",


### PR DESCRIPTION

## Description
Styling changes in https://github.com/swagger-api/swagger-ui/compare/v5.9.3...v5.9.4 causes weirdness in styling.  Temporary downgrade swagger-ui while working out the new styling config.
![Screenshot 2023-12-04 at 3 49 15 PM](https://github.com/openfga/openfga.dev/assets/10730463/225b3d88-1faa-45f5-ab48-d89cebb5a48a)

## References
Workaround for https://github.com/openfga/openfga.dev/issues/578


## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
