### PR TITLE
chore: adjust some remaining css properties from new swagger-ui version

### DIFF
--- a/src/components/SwaggerUI/swagger-ui-override.css
+++ b/src/components/SwaggerUI/swagger-ui-override.css
@@ -7597,6 +7597,7 @@
   padding: 10px 0;
 }
 .swagger-ui .body-param-options label {
+  color: var(--ifm-color-primary-contrast-foreground);
   padding: 8px 0;
 }
 .swagger-ui .body-param-options label select {
@@ -7648,7 +7649,7 @@
 }
 .swagger-ui .opblock-body pre.microlight {
   word-wrap: break-word;
-  background: #333;
+  background: var(--ofga-neutral-black) !important;
   border-radius: 4px;
   color: #fff;
   font-family: monospace;
@@ -7707,7 +7708,7 @@
   align-items: flex-end;
   display: flex;
 }
-.swagger-ui .scheme-container .schemes > label {
+.swagger-ui .scheme-container .schemes label {
   color: var(--ifm-color-primary-contrast-foreground);
 
   display: flex;
@@ -7716,7 +7717,7 @@
   font-weight: 700;
   margin: -20px 15px 0 0;
 }
-.swagger-ui .scheme-container .schemes > label select {
+.swagger-ui .scheme-container .schemes label select {
   min-width: 130px;
   text-transform: uppercase;
 }
@@ -8796,7 +8797,7 @@
 }
 
 .swagger-ui .description p {
-  font-size: 18px;
+  font-size: 18px !important;
 }
 
 .swagger-ui .info .description {


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
This PR resolves remaining style problems following the update to the new swagger-ui version (#579, #580) by implementing some adjustments in CSS.

### 1. Background color from response
![old_response](https://github.com/openfga/openfga.dev/assets/41171734/e1d44b3a-29fe-443a-82ea-4cd552c4002b)
![new_response](https://github.com/openfga/openfga.dev/assets/41171734/4008108e-26a1-455a-bf04-ca1179d4c471)

### 2. Scheme selector
![old_schemes](https://github.com/openfga/openfga.dev/assets/41171734/db5ad80f-c43b-47c7-a745-3be672783202)
![new_schemes](https://github.com/openfga/openfga.dev/assets/41171734/9a2535b7-5d45-4df0-a90e-96bd71104333)


## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->
- #580 
- #579 

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
