### PR TITLE
docs(cli): document usage of context/condition and continuation token

### DIFF
--- a/docs/content/modeling/conditions.mdx
+++ b/docs/content/modeling/conditions.mdx
@@ -134,6 +134,7 @@ For example, we can give `user:anne` viewer access to `document:1` for 10 minute
   allowedLanguages={[
     SupportedLanguage.JS_SDK,
     SupportedLanguage.GO_SDK,
+    SupportedLanguage.CLI,
     SupportedLanguage.CURL,
   ]}
 />
@@ -151,6 +152,7 @@ Now that we have written a [Conditional Relationship Tuple](../concepts.mdx#what
   allowedLanguages={[
     SupportedLanguage.JS_SDK,
     SupportedLanguage.GO_SDK,
+    SupportedLanguage.CLI,
     SupportedLanguage.CURL,
   ]}
 />
@@ -167,6 +169,7 @@ but if the current time is outside the grant window then you get a deny decision
   allowedLanguages={[
     SupportedLanguage.JS_SDK,
     SupportedLanguage.GO_SDK,
+    SupportedLanguage.CLI,
     SupportedLanguage.CURL,
   ]}
 />
@@ -183,6 +186,7 @@ Similarly, we can use the [ListObjects API](https://openfga.dev/api/service#/Rel
   allowedLanguages={[
     SupportedLanguage.JS_SDK,
     SupportedLanguage.GO_SDK,
+    SupportedLanguage.CLI,
     SupportedLanguage.CURL,
   ]}
 />
@@ -199,6 +203,7 @@ but if the current time is outside the grant window then we don't get the object
   allowedLanguages={[
     SupportedLanguage.JS_SDK,
     SupportedLanguage.GO_SDK,
+    SupportedLanguage.CLI,
     SupportedLanguage.CURL,
   ]}
 />

--- a/docs/content/modeling/contextual-time-based-authorization.mdx
+++ b/docs/content/modeling/contextual-time-based-authorization.mdx
@@ -470,7 +470,7 @@ On the "transaction" type:
 
 Now that we have updated our authorization model to take time and ip address into consideration, you will notice that Anne has lost access because nothing indicates that Anne is connecting from an approved ip address and time. You can verify that by issuing the following check:
 
-<CheckRequestViewer user={'anne'} relation={'can_view'} object={'transaction:A'} allowed={false} />
+<CheckRequestViewer user={'user:anne'} relation={'can_view'} object={'transaction:A'} allowed={false} />
 
 We need to add relationship tuples to mark some approved timeslots and ip address ranges:
 

--- a/src/components/Docs/SnippetViewer/CheckRequestViewer.tsx
+++ b/src/components/Docs/SnippetViewer/CheckRequestViewer.tsx
@@ -41,10 +41,8 @@ ${
           ? `${contextualTuples
               .map((tuple) => ` --contextual-tuple "${tuple.user} ${tuple.relation} ${tuple.object}"`)
               .join(' ')}`
-          : ''}${
-            context ? ` --context='${JSON.stringify(context)}'`
-            : ''
-          }
+          : ''
+      }${context ? ` --context='${JSON.stringify(context)}'` : ''}
 
 # Response: {"allowed":${allowed}}`;
     case SupportedLanguage.CURL:

--- a/src/components/Docs/SnippetViewer/CheckRequestViewer.tsx
+++ b/src/components/Docs/SnippetViewer/CheckRequestViewer.tsx
@@ -41,8 +41,10 @@ ${
           ? ` --contextual_tuples ${contextualTuples
               .map((tuple) => `"${tuple.user} ${tuple.relation} ${tuple.object}"`)
               .join(' ')}`
-          : ''
-      }
+          : ''}${
+            context ? ` --context='${JSON.stringify(context)}'`
+            : ''
+          }
 
 # Response: {"allowed":${allowed}}`;
     case SupportedLanguage.CURL:

--- a/src/components/Docs/SnippetViewer/CheckRequestViewer.tsx
+++ b/src/components/Docs/SnippetViewer/CheckRequestViewer.tsx
@@ -38,8 +38,8 @@ ${
     case SupportedLanguage.CLI:
       return `fga query check --store-id=$FGA_STORE_ID --model-id=${modelId} ${user} ${relation} ${object}${
         contextualTuples
-          ? ` --contextual_tuples ${contextualTuples
-              .map((tuple) => `"${tuple.user} ${tuple.relation} ${tuple.object}"`)
+          ? `${contextualTuples
+              .map((tuple) => ` --contextual-tuple "${tuple.user} ${tuple.relation} ${tuple.object}"`)
               .join(' ')}`
           : ''}${
             context ? ` --context='${JSON.stringify(context)}'`

--- a/src/components/Docs/SnippetViewer/ListObjectsRequestViewer.tsx
+++ b/src/components/Docs/SnippetViewer/ListObjectsRequestViewer.tsx
@@ -31,10 +31,7 @@ function listObjectsRequestViewer(lang: SupportedLanguage, opts: ListObjectsRequ
               .map((tuple) => ` --contextual-tuple "${tuple.user} ${tuple.relation} ${tuple.object}"`)
               .join(' ')}`
           : ''
-      }${
-        context ? ` --context='${JSON.stringify(context)}'`
-        : ''
-      }
+      }${context ? ` --context='${JSON.stringify(context)}'` : ''}
 
 # Response: {"objects": [${expectedResults.map((r) => `"${r}"`).join(', ')}]}`;
     case SupportedLanguage.CURL:

--- a/src/components/Docs/SnippetViewer/ListObjectsRequestViewer.tsx
+++ b/src/components/Docs/SnippetViewer/ListObjectsRequestViewer.tsx
@@ -31,6 +31,9 @@ function listObjectsRequestViewer(lang: SupportedLanguage, opts: ListObjectsRequ
               .map((tuple) => `"${tuple.user} ${tuple.relation} ${tuple.object}"`)
               .join(' ')}`
           : ''
+      }${
+        context ? ` --context='${JSON.stringify(context)}'`
+        : ''
       }
 
 # Response: {"objects": [${expectedResults.map((r) => `"${r}"`).join(', ')}]}`;

--- a/src/components/Docs/SnippetViewer/ListObjectsRequestViewer.tsx
+++ b/src/components/Docs/SnippetViewer/ListObjectsRequestViewer.tsx
@@ -27,8 +27,8 @@ function listObjectsRequestViewer(lang: SupportedLanguage, opts: ListObjectsRequ
     case SupportedLanguage.CLI:
       return `fga query list-objects --store-id=\${FGA_STORE_ID} --model-id=${modelId} ${user} ${relation} ${objectType}${
         contextualTuples
-          ? ` --contextual_tuples ${contextualTuples
-              .map((tuple) => `"${tuple.user} ${tuple.relation} ${tuple.object}"`)
+          ? `${contextualTuples
+              .map((tuple) => ` --contextual-tuple "${tuple.user} ${tuple.relation} ${tuple.object}"`)
               .join(' ')}`
           : ''
       }${

--- a/src/components/Docs/SnippetViewer/ReadChangesRequestViewer.tsx
+++ b/src/components/Docs/SnippetViewer/ReadChangesRequestViewer.tsx
@@ -12,7 +12,9 @@ interface ReadChangesRequestViewerOpts {
 function readChangesRequestViewer(lang: SupportedLanguage, opts: ReadChangesRequestViewerOpts) {
   switch (lang) {
     case SupportedLanguage.CLI: {
-      return `fga tuple changes --store-id=\${FGA_STORE_ID}${opts.type ? ` --type ${opts.type}` : ''}${opts.continuationToken ? ` --continuation-token ${opts.continuationToken}` : ''}`;
+      return `fga tuple changes --store-id=\${FGA_STORE_ID}${opts.type ? ` --type ${opts.type}` : ''}${
+        opts.continuationToken ? ` --continuation-token ${opts.continuationToken}` : ''
+      }`;
     }
     case SupportedLanguage.CURL: {
       const typeString = `${opts.type ? '"type": ' + opts.type + '", ' : ''}`;

--- a/src/components/Docs/SnippetViewer/ReadChangesRequestViewer.tsx
+++ b/src/components/Docs/SnippetViewer/ReadChangesRequestViewer.tsx
@@ -12,7 +12,7 @@ interface ReadChangesRequestViewerOpts {
 function readChangesRequestViewer(lang: SupportedLanguage, opts: ReadChangesRequestViewerOpts) {
   switch (lang) {
     case SupportedLanguage.CLI: {
-      return `fga tuple changes --store-id=\${FGA_STORE_ID}${opts.type ? ` --type ${opts.type}` : ''}`;
+      return `fga tuple changes --store-id=\${FGA_STORE_ID}${opts.type ? ` --type ${opts.type}` : ''}${opts.continuationToken ? ` --continuation-token ${opts.continuationToken}` : ''}`;
     }
     case SupportedLanguage.CURL: {
       const typeString = `${opts.type ? '"type": ' + opts.type + '", ' : ''}`;

--- a/src/components/Docs/SnippetViewer/WriteRequestViewer.tsx
+++ b/src/components/Docs/SnippetViewer/WriteRequestViewer.tsx
@@ -36,7 +36,7 @@ function writeRequestViewer(lang: SupportedLanguage, opts: WriteRequestViewerOpt
           ? opts.relationshipTuples
               .map(
                 (tuple) =>
-                  `fga tuple write --store-id=\${FGA_STORE_ID} --model-id=${modelId} ${tuple.user} ${tuple.relation} ${tuple.object}`,
+                  `fga tuple write --store-id=\${FGA_STORE_ID} --model-id=${modelId} ${tuple.user} ${tuple.relation} ${tuple.object} ${tuple.condition ? `--condition-name ${tuple.condition.name} --condition-context '${JSON.stringify(tuple.condition.context)}'` : ''}`,
               )
               .join('\n')
           : ''

--- a/src/components/Docs/SnippetViewer/WriteRequestViewer.tsx
+++ b/src/components/Docs/SnippetViewer/WriteRequestViewer.tsx
@@ -36,7 +36,15 @@ function writeRequestViewer(lang: SupportedLanguage, opts: WriteRequestViewerOpt
           ? opts.relationshipTuples
               .map(
                 (tuple) =>
-                  `fga tuple write --store-id=\${FGA_STORE_ID} --model-id=${modelId} ${tuple.user} ${tuple.relation} ${tuple.object} ${tuple.condition ? `--condition-name ${tuple.condition.name} --condition-context '${JSON.stringify(tuple.condition.context)}'` : ''}`,
+                  `fga tuple write --store-id=\${FGA_STORE_ID} --model-id=${modelId} ${tuple.user} ${tuple.relation} ${
+                    tuple.object
+                  } ${
+                    tuple.condition
+                      ? `--condition-name ${tuple.condition.name} --condition-context '${JSON.stringify(
+                          tuple.condition.context,
+                        )}'`
+                      : ''
+                  }`,
               )
               .join('\n')
           : ''


### PR DESCRIPTION
## Description

Adds support for context/condition, continuation token and corrects the contextual tuples logic within the CLI snippets

## References

Part of #603

Draft until context/condition and continuation token support is released in the CLI

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
