### PR TITLE
fix(docs): AuthZ mentioned instead of AuthN

### DIFF
--- a/docs/content/authorization-and-openfga.mdx
+++ b/docs/content/authorization-and-openfga.mdx
@@ -23,7 +23,7 @@ OpenFGA reies on several understandings of [authorization](#authentication-vs-au
 
 [**Authentication**](https://auth0.com/intro-to-iam/what-is-authentication/) (or **AuthN**) ensures a user's identity. [**Authorization**](https://en.wikipedia.org/wiki/Authorization) (or **AuthZ**) determines if a user can perform a certain action on a particular resource.
 
-For example, when you log in to Google, Authorization verifies that your username and password are correct. Authorization checks if you can access a given Google service. [For more information about AuthN vs AuthZ, click here.](https://www.okta.com/identity-101/authentication-vs-authorization/).
+For example, when you log in to Google, Authentication verifies that your username and password are correct. Authorization checks if you can access a given Google service. [For more information about AuthN vs AuthZ, click here.](https://www.okta.com/identity-101/authentication-vs-authorization/).
 
 ## What Is Fine-Grained Authorization?
 


### PR DESCRIPTION
<!-- Provide a brief summary of the changes -->

Fix typo (?) reference to AuthZ instead of AuthN

## Description
<!-- Provide a detailed description of the changes -->

This commit fixes a reference that should have been to AuthN made in the AuthN-vs-AuthZ description section which might be confusing for beginners.

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

[Documentation on AuthN vs AuthZ](https://openfga.dev/docs/authorization-and-openfga#authentication-vs-authorization)

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [-] I have added tests to validate that the change in functionality is working as expected
