### PR TITLE
fix: use correct configuration for python openfga client

### DIFF
--- a/docs/content/getting-started/create-store.mdx
+++ b/docs/content/getting-started/create-store.mdx
@@ -106,7 +106,7 @@ from openfga_sdk.client import OpenFgaClient
 from openfga_sdk.models.create_store_request import CreateStoreRequest
 
 async def main():
-    configuration = openfga_sdk.Configuration(
+    configuration = openfga_sdk.ClientConfiguration(
         api_scheme = os.environ.get('FGA_API_SCHEME'),
         api_host = os.environ.get('FGA_API_HOST'),
     )

--- a/docs/content/getting-started/setup-sdk-client.mdx
+++ b/docs/content/getting-started/setup-sdk-client.mdx
@@ -97,11 +97,11 @@ import openfga_sdk
 from openfga_sdk.client import OpenFgaClient
 
 async def main():
-    configuration = openfga_sdk.Configuration(
+    configuration = openfga_sdk.ClientConfiguration(
         api_scheme = os.environ.get('FGA_API_SCHEME'), # optional. Can be "http" or "https". Defaults to "https"
         api_host = os.environ.get('FGA_API_HOST'), # required, define without the scheme (e.g. api.fga.example instead of https://api.fga.example)
         store_id = os.environ.get('FGA_STORE_ID'), # optional, not needed for \`CreateStore\` and \`ListStores\`, required before calling for all other methods
-        model_id = os.environ.get('FGA_MODEL_ID'), # optional, can be overridden per request
+        authorization_model_id = os.environ.get('FGA_MODEL_ID'), # optional, can be overridden per request
     )
 
     async with OpenFgaClient(configuration) as fga_client:
@@ -251,11 +251,11 @@ async def main():
             api_token=os.environ.get('FGA_API_TOKEN')
         )
     )
-    configuration = openfga_sdk.Configuration(
+    configuration = openfga_sdk.ClientConfiguration(
         api_scheme = os.environ.get('FGA_API_SCHEME'), # optional. Can be "http" or "https". Defaults to "https"
         api_host = os.environ.get('FGA_API_HOST'), # required, define without the scheme (e.g. api.fga.example instead of https://api.fga.example)
         store_id = os.environ.get('FGA_STORE_ID'), # optional, not needed for \`CreateStore\` and \`ListStores\`, required before calling for all other methods
-        model_id = os.environ.get('FGA_MODEL_ID'), # optional, can be overridden per request
+        authorization_model_id = os.environ.get('FGA_MODEL_ID'), # optional, can be overridden per request
         credentials = credentials,
     )
 
@@ -418,11 +418,11 @@ async def main():
             client_secret= os.environ.get('FGA_CLIENT_SECRET'),
         )
     )
-    configuration = openfga_sdk.Configuration(
+    configuration = openfga_sdk.ClientConfiguration(
         api_scheme = os.environ.get('FGA_API_SCHEME'), # optional. Can be "http" or "https". Defaults to "https"
         api_host = os.environ.get('FGA_API_HOST'), # required, define without the scheme (e.g. api.fga.example instead of https://api.fga.example)
         store_id = os.environ.get('FGA_STORE_ID'), # optional, not needed for \`CreateStore\` and \`ListStores\`, required before calling for all other methods
-        model_id = os.environ.get('FGA_MODEL_ID'), # optional, can be overridden per request
+        authorization_model_id = os.environ.get('FGA_MODEL_ID'), # optional, can be overridden per request
         credentials = credentials,
     )
 


### PR DESCRIPTION
## Description

Corrects to use `ClientConfiguration` for the configuration in python and changes the model_id parameter to be correct

## References


## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
