### PR TITLE
changing reference to organization#repo_admin from admin to repo_admin

### DIFF
--- a/docs/content/modeling/advanced/github.mdx
+++ b/docs/content/modeling/advanced/github.mdx
@@ -833,7 +833,7 @@ The updated authorization model looks like this:
                 {
                   tupleToUserset: {
                     computedUserset: {
-                      relation: 'admin',
+                      relation: 'repo_admin',
                     },
                     tupleset: {
                       relation: 'owner',


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->
Fix for a model snippet in the Github example where a relation was referenced with the wrong name.

## Description
<!-- Provide a detailed description of the changes -->
For this example, there's a relation where a `repo` can have an `organization` as owner. Admins rights on the `repo` are gained through an indirect relationship. The relation on the repo references the relation on the `organization` by the wrong name.

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
