### PR TITLE
fix(docs): fix typo in "authorization and openfga" 

### DIFF
--- a/docs/content/authorization-and-openfga.mdx
+++ b/docs/content/authorization-and-openfga.mdx
@@ -11,7 +11,7 @@ import { DocumentationNotice, Playground, ProductName, ProductNameFormat } from 
 
 <DocumentationNotice />
 
-OpenFGA reies on several understandings of [authorization](#authentication-vs-authorization), including [fine-grained authorization](#what-is-fine-grained-authorization-fga), [role-based access control](#what-are-role-based-access-control-rbac-and-attribute-based-access-control-abac), [attribute-based access control](#what-are-role-based-access-control-rbac-and-attribute-based-access-control-abac), and [relationship-based access control](#what-is-relationship-based-access-control-rebac).
+OpenFGA relies on several understandings of [authorization](#authentication-vs-authorization), including [fine-grained authorization](#what-is-fine-grained-authorization-fga), [role-based access control](#what-are-role-based-access-control-rbac-and-attribute-based-access-control-abac), [attribute-based access control](#what-are-role-based-access-control-rbac-and-attribute-based-access-control-abac), and [relationship-based access control](#what-is-relationship-based-access-control-rebac).
 
 ## What Is OpenFGA?
 
@@ -33,7 +33,7 @@ For example, when you log in to Google, Authentication verifies that your userna
 
 In [**Role-Based Access Control**](https://en.wikipedia.org/wiki/Role-based_access_control) (RBAC), permissions are assigned to users based on their role in a system. For example, a user needs the `editor` role to edit content. [For more information about RBAC, click here.](https://auth0.com/docs/manage-users/access-control/rbac)
 
-In [**Attribute-Based Access Control**](https://en.wikipedia.org/wiki/Attribute-based_access_control) (ABAC), permissions are granted based on a set of attributes that a user or resource possess. For example, a user assigned both `marketing` and `manager` attributes is entitled to publish and delete posts that have a `marketing` attribute. [For more information about ABAC, click here.](https://www.okta.com/blog/2020/09/attribute-based-access-control-abac/)
+In [**Attribute-Based Access Control**](https://en.wikipedia.org/wiki/Attribute-based_access_control) (ABAC), permissions are granted based on a set of attributes that a user or resource possesses. For example, a user assigned both `marketing` and `manager` attributes is entitled to publish and delete posts that have a `marketing` attribute. [For more information about ABAC, click here.](https://www.okta.com/blog/2020/09/attribute-based-access-control-abac/)
 
 ## What Is Relationship-Based Access Control?
 


### PR DESCRIPTION
Correcting a few typos noticed in the authorization and Openfga page.

## Description
Two small spelling/grammatical fixes.
