### PR TITLE
fix: `openfga-model-testing-action` example in docs

### DIFF
--- a/docs/content/modeling/testing-models.mdx
+++ b/docs/content/modeling/testing-models.mdx
@@ -186,7 +186,10 @@ jobs:
     name: Run test
     runs-on: ubuntu-latest
     steps:
-      - uses: openfga/action-openfga-test@v0.1.0
+      - name: Checkout Project
+        uses: actions/checkout@v4
+      - name: Run Test
+        uses: openfga/action-openfga-test@v0.1.0
         with:
           store-file-path: ./example/model.fga.yaml
 

--- a/docs/content/modeling/testing-models.mdx
+++ b/docs/content/modeling/testing-models.mdx
@@ -186,7 +186,7 @@ jobs:
     name: Run test
     runs-on: ubuntu-latest
     steps:
-      - uses: openfga/action-openfga-test@v0.1
+      - uses: openfga/action-openfga-test@v0.1.0
         with:
           store-file-path: ./example/model.fga.yaml
 


### PR DESCRIPTION
- Add `actions/checkout` to fetch the content of the repository.
- The version `v0.1` does not resolve. Changed it its used version to `v0.1.0`.

## Description
Error in the CI logs:
```console
Error: Unable to resolve action `openfga/action-openfga-test@v0.1`, unable to find version `v0.1`
```

See the action on the github marketplace: https://github.com/marketplace/actions/openfga-model-testing-action

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
