### PR TITLE
fix: jq expression in create store shell example

### DIFF
--- a/docs/content/getting-started/create-store.mdx
+++ b/docs/content/getting-started/create-store.mdx
@@ -148,7 +148,7 @@ public class Example {
 fga store create --name "FGA Demo Store"
 
 # To create the store and directly put the Store ID into an env variable:
-# export FGA_STORE_ID=$(fga store create --name "FGA Demo Store" | jq -r .id)
+# export FGA_STORE_ID=$(fga store create --name "FGA Demo Store" | jq -r .store.id)
 ```
 
 </TabItem>


### PR DESCRIPTION
## Description

The change updates the `jq` example for exporting FGA_STORE_ID. The new API response does not work with the example jq.

Example response of the new FGA API:

```json
{
  "store": {
    "created_at":"2024-04-09T05:52:22.078257Z",
    "id":"01HV0PM8HY355M5G4GTW3VQ4E5",
    "name":"FGA Demo Store",
    "updated_at":"2024-04-09T05:52:22.078257Z"
  }
}

```

- `jq -r .id` - 🚫
- `jq -r .store.id` - ✅ 

I don't mean to be nit-picking, but as I start to learn OpenFGA and read through the wonderful docs, I try to help fix any problems (however small they may be)

## References
N/A

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
