### PR TITLE
fix: CLI output-format example

### DIFF
--- a/docs/content/getting-started/cli.mdx
+++ b/docs/content/getting-started/cli.mdx
@@ -331,7 +331,7 @@ Delete all tuples from a store by reading all the tuples first and then deleting
 ```bash
 # Reads all the tuples and outputs them in a json format that can be used by 'fga tuple delete' and 'fga tuple write'.
 
-$ fga tuple read --simple-output --max-pages 0    > tuples.json
+$ fga tuple read --output-format=simple-json --max-pages 0    > tuples.json
 $ fga tuple delete --file  tuples.json
 ```
 


### PR DESCRIPTION
## Description

`--simple-output` seems to be deprecated in the CLI, replaced by `--output-format=simple-json`

The example has been updated to reflect that change.

> Note: Sorry for many small PRs, but I find these as I go in my learning :)

## References

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
