### PR TITLE
fix(snippets/js): correct casing for contextual tuples in check and list objects

### DIFF
--- a/src/components/Docs/SnippetViewer/CheckRequestViewer.tsx
+++ b/src/components/Docs/SnippetViewer/CheckRequestViewer.tsx
@@ -70,7 +70,7 @@ const { allowed } = await fgaClient.check({
       !contextualTuples
         ? ``
         : `
-    contextual_tuples: [\n      ${contextualTuples.map((tuple) => `${JSON.stringify(tuple)}`).join(',')}
+    contextualTuples: [\n      ${contextualTuples.map((tuple) => `${JSON.stringify(tuple)}`).join(',')}
     ],`
     }${!context ? `\n  }` : `\n    context: ${JSON.stringify(context)}\n  }`}, {
   authorization_model_id: '${modelId}',

--- a/src/components/Docs/SnippetViewer/ListObjectsRequestViewer.tsx
+++ b/src/components/Docs/SnippetViewer/ListObjectsRequestViewer.tsx
@@ -74,7 +74,7 @@ function listObjectsRequestViewer(lang: SupportedLanguage, opts: ListObjectsRequ
   type: "${objectType}",${
     contextualTuples?.length
       ? `
-  contextual_tuples: {
+      contextualTuples: {
     tuple_keys: [${contextualTuples
       .map(
         (tupleKey) => `{


### PR DESCRIPTION
## Description

Fixes the casing for providing contextual tuples in code snippets for check and list objects.

## References

https://github.com/openfga/sdk-generator/issues/346

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
