### PR TITLE
Add list users snippet, concept and testing

### DIFF
--- a/docs/content/concepts.mdx
+++ b/docs/content/concepts.mdx
@@ -604,9 +604,9 @@ A **list users request** is a call to the <ProductName format={ProductNameFormat
 
 </summary>
 
-List object requests are completed using the `listUsers` methods in the <ProductName format={ProductNameFormat.ShortForm}/> SDKs ([JavaScript SDK](https://www.npmjs.com/package/@openfga/sdk)/[Go SDK](https://github.com/openfga/go-sdk)/[.NET SDK](https://www.nuget.org/packages/OpenFga.Sdk)) by manually calling the [list users endpoint](/api/service#Relationship%20Queries/ListUsers) using curl or in your code.
+List users requests are completed using the `listUsers` methods in the <ProductName format={ProductNameFormat.ShortForm}/> SDKs ([JavaScript SDK](https://www.npmjs.com/package/@openfga/sdk)/[Go SDK](https://github.com/openfga/go-sdk)/[.NET SDK](https://www.nuget.org/packages/OpenFga.Sdk)) by manually calling the [list users endpoint](/api/service#Relationship%20Queries/ListUsers) using curl or in your code.
 
-The list users endpoint responds with a list of users and excluded users for a given type that have the specificed relationship with an Object.
+The list users endpoint responds with a list of users and excluded users for a given type that have the specificed relationship with an object.
 
 For example, the following returns all the users of type `user` that have the `viewer` relationship for `document:planning`:
 

--- a/docs/content/concepts.mdx
+++ b/docs/content/concepts.mdx
@@ -592,7 +592,7 @@ For example, the following returns all the objects with document type for which 
   expectedResults={['document:otherdoc', 'document:planning']}
 />
 
-For more information, see the [Relationship Queries page](./interacting/relationship-queries.mdx) and the official [List Objects API Reference](/api/service#Relationship%20Queries/ListObjects).
+For more information, see the [Relationship Queries page](./interacting/relationship-queries.mdx) and the [List Objects API Reference](/api/service#Relationship%20Queries/ListObjects).
 
 </details>
 <details>
@@ -604,7 +604,7 @@ A **list users request** is a call to the <ProductName format={ProductNameFormat
 
 </summary>
 
-List users requests are completed using the `listUsers` methods in the <ProductName format={ProductNameFormat.ShortForm}/> SDKs ([JavaScript SDK](https://www.npmjs.com/package/@openfga/sdk)/[Go SDK](https://github.com/openfga/go-sdk)/[.NET SDK](https://www.nuget.org/packages/OpenFga.Sdk)) by manually calling the [list users endpoint](/api/service#Relationship%20Queries/ListUsers) using curl or in your code.
+List users requests are completed using the relevant `ListUsers` method in SDKs, the `fga query list-users` command in the CLI, or by manually calling the [ListUsers endpoint](/api/service#Relationship%20Queries/ListUsers) using curl or in your code.
 
 The list users endpoint responds with a list of users and excluded users for a given type that have the specificed relationship with an object.
 
@@ -622,7 +622,7 @@ For example, the following returns all the users of type `user` that have the `v
   }}
 />
 
-For more information, see the the official [List Users API Reference](/api/service#Relationship%20Queries/ListUsers).
+For more information, see the the [ListUsers API Reference](/api/service#Relationship%20Queries/ListUsers).
 
 </details>
 <details>

--- a/docs/content/concepts.mdx
+++ b/docs/content/concepts.mdx
@@ -17,6 +17,7 @@ import {
   RelatedSection,
   RelationshipTuplesViewer,
   UpdateProductNameInLinks,
+  ListUsersRequestViewer
 } from '@components/Docs';
 
 # Concepts
@@ -591,7 +592,37 @@ For example, the following returns all the objects with document type for which 
   expectedResults={['document:otherdoc', 'document:planning']}
 />
 
-For more information, see the [Relationship Queries page](./interacting/relationship-queries.mdx) and the official [Check API Reference](/api/service#Relationship%20Queries/ListObjects).
+For more information, see the [Relationship Queries page](./interacting/relationship-queries.mdx) and the official [List Objects API Reference](/api/service#Relationship%20Queries/ListObjects).
+
+</details>
+<details>
+<summary>
+
+## What Is A List Users Request?
+
+A **list users request** is a call to the <ProductName format={ProductNameFormat.LongForm}/> list users endpoint that returns all users of a given type that have a specified relationship with an object.
+
+</summary>
+
+List object requests are completed using the `listUsers` methods in the <ProductName format={ProductNameFormat.ShortForm}/> SDKs ([JavaScript SDK](https://www.npmjs.com/package/@openfga/sdk)/[Go SDK](https://github.com/openfga/go-sdk)/[.NET SDK](https://www.nuget.org/packages/OpenFga.Sdk)) by manually calling the [list users endpoint](/api/service#Relationship%20Queries/ListUsers) using curl or in your code.
+
+The list users endpoint responds with a list of users and excluded users for a given type that have the specificed relationship with an Object.
+
+For example, the following returns all the users of type `user` that have the `viewer` relationship for `document:planning`:
+
+<ListUsersRequestViewer
+  authorizationModelId="01HVMMBCMGZNT3SED4Z17ECXCA"
+  objectType="document"
+  objectId="planning"
+  relation="viewer"
+  userFilterType="user"
+  expectedResults={{
+    users: [{ object: { type: "user:anne" } }],
+    excluded_users: [{ object: { type: "user:beth" } }]
+  }}
+/>
+
+For more information, see the the official [List Users API Reference](/api/service#Relationship%20Queries/ListUsers).
 
 </details>
 <details>

--- a/docs/content/getting-started/perform-list-users.mdx
+++ b/docs/content/getting-started/perform-list-users.mdx
@@ -98,7 +98,7 @@ This section will illustrate how to perform a <ProductConcept section="what-is-a
 
 ## Step By Step
 
-Assume that you want to list all objects of type document that  user `anne` has `reader` relationship with:
+Assume that you want to list all users of type `user` that have a `reader` relationship with `document:planning`:
 
 ### 01. Configure the <ProductName format={ProductNameFormat.ShortForm}/> API Client
 

--- a/docs/content/getting-started/perform-list-users.mdx
+++ b/docs/content/getting-started/perform-list-users.mdx
@@ -171,6 +171,10 @@ To return all users of type `user` that have have the `reader` relationship with
 
 The result `user:anne` and `user:beth` are the `user` objects that have the `reader` relationship with `document:planning`.
 
+:::caution Warning
+The performance characteristics of the ListUsers endpoint vary drastically depending on the model complexity, number of tuples, and the relations it needs to evaluate. Relations with 'and' or 'but not' are particularly expensive to evaluate.
+:::
+
 ## Related Sections
 
 <RelatedSection

--- a/docs/content/getting-started/perform-list-users.mdx
+++ b/docs/content/getting-started/perform-list-users.mdx
@@ -1,0 +1,190 @@
+---
+title: Perform a List Users call
+sidebar_position: 4
+slug: /getting-started/perform-list-users
+description: List all users that have a certain relation with a particular object
+---
+
+import {
+  SupportedLanguage,
+  languageLabelMap,
+  ListUsersRequestViewer,
+  DocumentationNotice,
+  ProductConcept,
+  ProductName,
+  ProductNameFormat,
+  RelatedSection,
+  SdkSetupHeader,
+  SdkSetupPrerequisite,
+} from '@components/Docs';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Perform a List Users call
+
+:::caution Warning
+ListUsers is currently in an experimental release. Read [the announcement](https://openfga.dev/blog/list-users-announcement) for more information.
+:::
+
+<DocumentationNotice />
+
+This section will illustrate how to perform a <ProductConcept section="what-is-a-list-users-request" linkName="list users" /> request to determine all the <ProductConcept section="what-is-a-user" linkName="users" /> of a given <ProductConcept section="what-is-a-type" linkName="type" /> that have a specified <ProductConcept section="what-is-a-relationship" linkName="relationship" /> with a given <ProductConcept section="what-is-an-object" linkName="objects" />.
+
+## Before You Start
+
+<Tabs groupId="languages">
+
+<TabItem value={SupportedLanguage.JS_SDK} label={languageLabelMap.get(SupportedLanguage.JS_SDK)}>
+
+1. <SdkSetupPrerequisite />
+2. You have [installed the SDK](./install-sdk.mdx).
+3. You have [configured the _authorization model_](./configure-model.mdx) and [updated the _relationship tuples_](./update-tuples.mdx).
+4. You have loaded `FGA_STORE_ID` and `FGA_API_URL` as environment variables.
+
+</TabItem>
+
+<TabItem value={SupportedLanguage.GO_SDK} label={languageLabelMap.get(SupportedLanguage.GO_SDK)}>
+
+1. <SdkSetupPrerequisite />
+2. You have [installed the SDK](./install-sdk.mdx).
+3. You have [configured the _authorization model_](./configure-model.mdx) and [updated the _relationship tuples_](./update-tuples.mdx).
+4. You have loaded `FGA_STORE_ID` and `FGA_API_URL` as environment variables.
+
+</TabItem>
+
+<TabItem value={SupportedLanguage.DOTNET_SDK} label={languageLabelMap.get(SupportedLanguage.DOTNET_SDK)}>
+
+1. <SdkSetupPrerequisite />
+2. You have [installed the SDK](./install-sdk.mdx).
+3. You have [configured the _authorization model_](./configure-model.mdx) and [updated the _relationship tuples_](./update-tuples.mdx).
+4. You have loaded `FGA_STORE_ID` and `FGA_API_URL` as environment variables.
+
+</TabItem>
+
+<TabItem value={SupportedLanguage.PYTHON_SDK} label={languageLabelMap.get(SupportedLanguage.PYTHON_SDK)}>
+
+1. <SdkSetupPrerequisite />
+2. You have [installed the SDK](./install-sdk.mdx).
+3. You have [configured the _authorization model_](./configure-model.mdx) and [updated the _relationship tuples_](./update-tuples.mdx).
+4. You have loaded `FGA_STORE_ID` and `FGA_API_URL` as environment variables.
+
+</TabItem>
+
+<TabItem value={SupportedLanguage.JAVA_SDK} label={languageLabelMap.get(SupportedLanguage.JAVA_SDK)}>
+
+1. <SdkSetupPrerequisite />
+2. You have [installed the SDK](./install-sdk.mdx).
+3. You have [configured the _authorization model_](./configure-model.mdx) and [updated the _relationship tuples_](./update-tuples.mdx).
+4. You have loaded `FGA_STORE_ID` and `FGA_API_URL` as environment variables.
+
+</TabItem>
+
+<TabItem value={SupportedLanguage.CLI} label={languageLabelMap.get(SupportedLanguage.CLI)}>
+
+1. <SdkSetupPrerequisite />
+2. You have [configured the _authorization model_](./configure-model.mdx).
+3. You have loaded `FGA_STORE_ID` and `FGA_API_URL` as environment variables.
+
+</TabItem>
+
+<TabItem value={SupportedLanguage.CURL} label={languageLabelMap.get(SupportedLanguage.CURL)}>
+
+1. <SdkSetupPrerequisite />
+2. You have [configured the _authorization model_](./configure-model.mdx) and [updated the _relationship tuples_](./update-tuples.mdx).
+3. You have loaded `FGA_STORE_ID` and `FGA_API_URL` as environment variables.
+
+</TabItem>
+</Tabs>
+
+## Step By Step
+
+Assume that you want to list all objects of type document that  user `anne` has `reader` relationship with:
+
+### 01. Configure the <ProductName format={ProductNameFormat.ShortForm}/> API Client
+
+Before calling the check API, you will need to configure the API client.
+
+<Tabs groupId="languages">
+<TabItem value={SupportedLanguage.JS_SDK} label={languageLabelMap.get(SupportedLanguage.JS_SDK)}>
+
+<SdkSetupHeader lang={SupportedLanguage.JS_SDK} />
+
+</TabItem>
+<TabItem value={SupportedLanguage.GO_SDK} label={languageLabelMap.get(SupportedLanguage.GO_SDK)}>
+
+<SdkSetupHeader lang={SupportedLanguage.GO_SDK} />
+
+</TabItem>
+<TabItem value={SupportedLanguage.DOTNET_SDK} label={languageLabelMap.get(SupportedLanguage.DOTNET_SDK)}>
+
+<SdkSetupHeader lang={SupportedLanguage.DOTNET_SDK} />
+
+</TabItem>
+<TabItem value={SupportedLanguage.PYTHON_SDK} label={languageLabelMap.get(SupportedLanguage.PYTHON_SDK)}>
+
+<SdkSetupHeader lang={SupportedLanguage.PYTHON_SDK} />
+
+</TabItem>
+<TabItem value={SupportedLanguage.JAVA_SDK} label={languageLabelMap.get(SupportedLanguage.JAVA_SDK)}>
+
+<SdkSetupHeader lang={SupportedLanguage.JAVA_SDK} />
+
+</TabItem>
+<TabItem value={SupportedLanguage.CLI} label={languageLabelMap.get(SupportedLanguage.CLI)}>
+
+<SdkSetupHeader lang={SupportedLanguage.CLI} />
+
+</TabItem>
+<TabItem value={SupportedLanguage.CURL} label={languageLabelMap.get(SupportedLanguage.CURL)}>
+
+To obtain the [access token](https://auth0.com/docs/get-started/authentication-and-authorization-flow/call-your-api-using-the-client-credentials-flow):
+
+<SdkSetupHeader lang={SupportedLanguage.CURL} />
+
+</TabItem>
+</Tabs>
+
+### 02. Calling List Objects API
+
+To return all documents that user `user:anne` has relationship `reader` with:
+
+<ListUsersRequestViewer
+  authorizationModelId="01HVMMBCMGZNT3SED4Z17ECXCA"
+  objectType="document"
+  objectId="planning"
+  relation="reader"
+  userFilterType="user"
+  expectedResults={{
+    users: [{ object: { type: "user:anne" } }],
+    excluded_users: [{ object: { type: "user:beth" } }]
+  }}
+  skipSetup={true}
+  allowedLanguages={[
+    SupportedLanguage.JS_SDK,
+    SupportedLanguage.GO_SDK,
+    SupportedLanguage.DOTNET_SDK,
+    SupportedLanguage.PYTHON_SDK,
+    SupportedLanguage.JAVA_SDK,
+    SupportedLanguage.CLI,
+    SupportedLanguage.CURL,
+  ]}
+/>
+
+The result `document:otherdoc` and `document:planning` are the document objects that `user:anne` has `reader` relationship with.
+
+:::caution Warning
+The performance characteristics of the ListUsers endpoint vary drastically depending on the model complexity, number of tuples, and the relations it needs to evaluate. Relations with 'and' or 'but not' are more expensive to evaluate than relations with 'or'.
+:::
+
+## Related Sections
+
+<RelatedSection
+  description="Take a look at the following section for more on how to perform list users in your system"
+  relatedLinks={[
+    {
+      title: '{ProductName} List Users API',
+      description: 'Read the List Users API documentation and see how it works.',
+      link: '/api/service#Relationship%20Queries/ListUsers',
+    },
+  ]}
+/>

--- a/docs/content/getting-started/perform-list-users.mdx
+++ b/docs/content/getting-started/perform-list-users.mdx
@@ -61,14 +61,14 @@ This section will illustrate how to perform a <ProductConcept section="what-is-a
 
 </TabItem>
 
-<TabItem value={SupportedLanguage.PYTHON_SDK} label={languageLabelMap.get(SupportedLanguage.PYTHON_SDK)}>
+{/* <TabItem value={SupportedLanguage.PYTHON_SDK} label={languageLabelMap.get(SupportedLanguage.PYTHON_SDK)}>
 
 1. <SdkSetupPrerequisite />
 2. You have [installed the SDK](./install-sdk.mdx).
 3. You have [configured the _authorization model_](./configure-model.mdx) and [updated the _relationship tuples_](./update-tuples.mdx).
 4. You have loaded `FGA_STORE_ID` and `FGA_API_URL` as environment variables.
 
-</TabItem>
+</TabItem> */}
 
 <TabItem value={SupportedLanguage.JAVA_SDK} label={languageLabelMap.get(SupportedLanguage.JAVA_SDK)}>
 
@@ -120,11 +120,11 @@ Before calling the ListUsers API, you will need to configure the API client.
 <SdkSetupHeader lang={SupportedLanguage.DOTNET_SDK} />
 
 </TabItem>
-<TabItem value={SupportedLanguage.PYTHON_SDK} label={languageLabelMap.get(SupportedLanguage.PYTHON_SDK)}>
+{/* <TabItem value={SupportedLanguage.PYTHON_SDK} label={languageLabelMap.get(SupportedLanguage.PYTHON_SDK)}>
 
 <SdkSetupHeader lang={SupportedLanguage.PYTHON_SDK} />
 
-</TabItem>
+</TabItem> */}
 <TabItem value={SupportedLanguage.JAVA_SDK} label={languageLabelMap.get(SupportedLanguage.JAVA_SDK)}>
 
 <SdkSetupHeader lang={SupportedLanguage.JAVA_SDK} />
@@ -163,7 +163,6 @@ To return all users of type `user` that have have the `reader` relationship with
     SupportedLanguage.JS_SDK,
     SupportedLanguage.GO_SDK,
     SupportedLanguage.DOTNET_SDK,
-    SupportedLanguage.PYTHON_SDK,
     SupportedLanguage.JAVA_SDK,
     SupportedLanguage.CLI,
     SupportedLanguage.CURL,

--- a/docs/content/getting-started/perform-list-users.mdx
+++ b/docs/content/getting-started/perform-list-users.mdx
@@ -144,9 +144,9 @@ To obtain the [access token](https://auth0.com/docs/get-started/authentication-a
 </TabItem>
 </Tabs>
 
-### 02. Calling List Objects API
+### 02. Calling List Users API
 
-To return all documents that user `user:anne` has relationship `reader` with:
+To return all users of type `users` that have have the `reader` relationship with `document:planning`:
 
 <ListUsersRequestViewer
   authorizationModelId="01HVMMBCMGZNT3SED4Z17ECXCA"
@@ -155,8 +155,8 @@ To return all documents that user `user:anne` has relationship `reader` with:
   relation="reader"
   userFilterType="user"
   expectedResults={{
-    users: [{ object: { type: "user:anne" } }],
-    excluded_users: [{ object: { type: "user:beth" } }]
+    users: [{ object: { type: "user:anne" } }, { object: { type: "user:beth" } }],
+    excluded_users: []
   }}
   skipSetup={true}
   allowedLanguages={[
@@ -170,11 +170,7 @@ To return all documents that user `user:anne` has relationship `reader` with:
   ]}
 />
 
-The result `document:otherdoc` and `document:planning` are the document objects that `user:anne` has `reader` relationship with.
-
-:::caution Warning
-The performance characteristics of the ListUsers endpoint vary drastically depending on the model complexity, number of tuples, and the relations it needs to evaluate. Relations with 'and' or 'but not' are more expensive to evaluate than relations with 'or'.
-:::
+The result `user:anne` and `user:beth` are the `user` objects that have the `reader` relationship with `document:planning`.
 
 ## Related Sections
 

--- a/docs/content/getting-started/perform-list-users.mdx
+++ b/docs/content/getting-started/perform-list-users.mdx
@@ -102,7 +102,7 @@ Assume that you want to list all users of type `user` that have a `reader` relat
 
 ### 01. Configure the <ProductName format={ProductNameFormat.ShortForm}/> API Client
 
-Before calling the check API, you will need to configure the API client.
+Before calling the ListUsers API, you will need to configure the API client.
 
 <Tabs groupId="languages">
 <TabItem value={SupportedLanguage.JS_SDK} label={languageLabelMap.get(SupportedLanguage.JS_SDK)}>
@@ -146,7 +146,7 @@ To obtain the [access token](https://auth0.com/docs/get-started/authentication-a
 
 ### 02. Calling List Users API
 
-To return all users of type `users` that have have the `reader` relationship with `document:planning`:
+To return all users of type `user` that have have the `reader` relationship with `document:planning`:
 
 <ListUsersRequestViewer
   authorizationModelId="01HVMMBCMGZNT3SED4Z17ECXCA"

--- a/docs/content/modeling/testing-models.mdx
+++ b/docs/content/modeling/testing-models.mdx
@@ -165,7 +165,7 @@ Each list users verification has the following structure:
 |`assertions` | A list of assertions to make |
 |`<relation>` | The name of the relation you want to verify |
 |`<relation>.users` | The users who should have the stated relation to the object |
-|`<relation>.excluded_users` | The users who should have explicitly not have access to the object due to evaluations of typed wildcards and negation |
+|`<relation>.excluded_users` | The users who should have explicitly not have access to the object due to evaluations of type bound public access and negation (e.g. "all users except anne") |
 
 In order to simplify test writing, the following syntax is supported for the various object types included in `users` and `excluded_users` from the API response:
 

--- a/docs/content/modeling/testing-models.mdx
+++ b/docs/content/modeling/testing-models.mdx
@@ -82,6 +82,7 @@ Tests have the following structure:
 |`tuples` | A set of tuples that are only considered for the test | 
 |`check` | A set of tests for Check calls, each with a user/object and a set of assertions |
 |`list_objects` | A set of tests for ListObjects calls, each one with a user/type and a set of assertions for any number of relations|
+|`list_users` | A set of tests for ListUsers calls, each one with an object and user filter and a set of assertions for the users and excluded_users for any number of relations |
 
 ## Write Check tests
 
@@ -143,6 +144,68 @@ The following verifies the expected results using the `list_objects` option in <
 
 ```
 The example above checks that `user:anne` has access to the `organization:acme` as a member and is not an admin of any organization. It also checks that `user:peter`, given the current time is February 1st 2024, 0:10 AM, is not related to any organization as a member, but is related to `organization:acme` as an admin.
+
+## Write List Users tests
+
+:::caution Warning
+ListUsers is currently in an experimental release. Read [the announcement](https://openfga.dev/blog/list-users-announcement) for more information.
+:::
+
+List users tests verify the results of the [list-users API](../getting-started/perform-list-users.mdx) to validate the users who or do not have access to an object
+
+Each list users verification has the following structure:
+
+| Object  | Description |
+| -------- | -------- | 
+|`object` | The object to list users for |
+|`user_filter` | Specifies the type or userset to filter with |
+|`user_filter.type` | The specific type to filter with |
+|`user_filter.relation` | The specific relation to filter with (optional) |
+|`context` | A set of tests for contextual parameters used to evaluate [conditions](./conditions.mdx)|
+|`assertions` | A list of assertions to make |
+|`<relation>` | The name of the relation you want to verify |
+|`<relation>.users` | The users who should have the stated relation to the object |
+|`<relation>.excluded_users` | The users who should have explicitly not have access to the object due to negation in the model |
+
+In order to simplify test writing, the following syntax is supported for the various object types included in `users` and `excluded_users` from the API response:
+
+* `<type>:<id>` to represent a userset that is a user
+* `<type>:<id>#<relation>` to represent a userset that is a relation on a type
+* `<type>:*` to represent a userset that is a wildcard for a type
+
+The following is an example of using the `list_users` option in <ProductName format={ProductNameFormat.ShortForm}/> tests:
+
+```yaml
+    list_users:
+      - object: organization:acme
+        user_filter:
+          - type: user
+        assertions:
+            member:
+              users:
+                - user:anne
+              excluded_users: []
+            admin:
+              users: []
+              excluded_users: []
+              
+      - object: organization:acme
+        user_filter:
+          - type: user
+        context: 
+          current_time : "2024-02-01T00:10:00Z"
+        assertions:
+            member:
+              users: []
+              excluded_users: []
+            admin:
+              users:
+                - user_peter
+              excluded_users: []
+
+```
+The example above checks that `user:anne` has access to the `organization:acme` as a member and is not an admin of any organization. It also checks that `user:peter`, given the current time is February 1st 2024, 0:10 AM, is not related to any organization as a member, but is related to `organization:acme` as an admin.
+
 
 ## Running tests
 

--- a/docs/content/modeling/testing-models.mdx
+++ b/docs/content/modeling/testing-models.mdx
@@ -171,7 +171,7 @@ In order to simplify test writing, the following syntax is supported for the var
 
 * `<type>:<id>` to represent a userset that is a user
 * `<type>:<id>#<relation>` to represent a userset that is a relation on a type
-* `<type>:*` to represent a userset that is a wildcard for a type
+* `<type>:*` to represent a userset that is a type bound public access for a type
 
 The following is an example of using the `list_users` option in <ProductName format={ProductNameFormat.ShortForm}/> tests:
 
@@ -191,7 +191,7 @@ The following is an example of using the `list_users` option in <ProductName for
               
       - object: organization:acme
         user_filter:
-          - type: user
+          - type: employee
         context: 
           current_time : "2024-02-01T00:10:00Z"
         assertions:
@@ -200,11 +200,11 @@ The following is an example of using the `list_users` option in <ProductName for
               excluded_users: []
             admin:
               users:
-                - user_peter
+                - employee:peter
               excluded_users: []
 
 ```
-The example above checks that `user:anne` has access to the `organization:acme` as a member and is not an admin of any organization. It also checks that `user:peter`, given the current time is February 1st 2024, 0:10 AM, is not related to any organization as a member, but is related to `organization:acme` as an admin.
+The example above checks that `user:anne` has access to the `organization:acme` as a member and is not an admin of any organization. It also checks that `employee:peter`, given the current time is February 1st 2024, 0:10 AM, is not related to any organization as a member, but is related to `organization:acme` as an admin.
 
 
 ## Running tests

--- a/docs/content/modeling/testing-models.mdx
+++ b/docs/content/modeling/testing-models.mdx
@@ -158,14 +158,14 @@ Each list users verification has the following structure:
 | Object  | Description |
 | -------- | -------- | 
 |`object` | The object to list users for |
-|`user_filter` | Specifies the type or userset to filter with |
-|`user_filter.type` | The specific type to filter with |
-|`user_filter.relation` | The specific relation to filter with (optional) |
+|`user_filter` | Specifies the type or userset to filter with, this must only contain one entry |
+|`user_filter.type` | The specific type of results to return with response |
+|`user_filter.relation` | The specific relation of results to return with response. Specify to return usersets (optional) |
 |`context` | A set of tests for contextual parameters used to evaluate [conditions](./conditions.mdx)|
 |`assertions` | A list of assertions to make |
 |`<relation>` | The name of the relation you want to verify |
 |`<relation>.users` | The users who should have the stated relation to the object |
-|`<relation>.excluded_users` | The users who should have explicitly not have access to the object due to negation in the model |
+|`<relation>.excluded_users` | The users who should have explicitly not have access to the object due to evaluations of typed wildcards and negation |
 
 In order to simplify test writing, the following syntax is supported for the various object types included in `users` and `excluded_users` from the API response:
 

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -100,6 +100,11 @@ const sidebars = {
         },
         {
           type: 'doc',
+          label: 'Perform a List Users Request',
+          id: 'content/getting-started/perform-list-users',
+        },
+        {
+          type: 'doc',
           label: 'Use the FGA CLI',
           id: 'content/getting-started/cli',
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@easyops-cn/docusaurus-search-local": "0.40.1",
         "@lottiefiles/react-lottie-player": "3.5.3",
         "@openfga/frontend-utils": "^0.2.0-beta.9",
-        "@openfga/sdk": "^0.3.5",
+        "@openfga/sdk": "^0.4.0",
         "@openfga/syntax-transformer": "^0.2.0-beta.17",
         "assert-never": "1.2.1",
         "clsx": "2.1.1",
@@ -3404,11 +3404,11 @@
       }
     },
     "node_modules/@openfga/sdk": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@openfga/sdk/-/sdk-0.3.5.tgz",
-      "integrity": "sha512-ChS/D9khwiy2nqffxTjUMwd9wkNvY34nHgk6BWjLfEaceahBZVEMCkvcPW1N/oCoA5CbhI1+AJ1/LgHZrZc93g==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@openfga/sdk/-/sdk-0.4.0.tgz",
+      "integrity": "sha512-1UnAcBdwCqLVAg8nuX72KMbJxBg3qsg3m2qf7FLZFwVAK6YHvzHYZ+gATCjZe4mMhr3qmZsb3dZRqE8hTbz9ng==",
       "dependencies": {
-        "axios": "^1.6.7",
+        "axios": "^1.6.8",
         "tiny-async-pool": "^2.1.0"
       },
       "engines": {
@@ -21083,11 +21083,11 @@
       }
     },
     "@openfga/sdk": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@openfga/sdk/-/sdk-0.3.5.tgz",
-      "integrity": "sha512-ChS/D9khwiy2nqffxTjUMwd9wkNvY34nHgk6BWjLfEaceahBZVEMCkvcPW1N/oCoA5CbhI1+AJ1/LgHZrZc93g==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@openfga/sdk/-/sdk-0.4.0.tgz",
+      "integrity": "sha512-1UnAcBdwCqLVAg8nuX72KMbJxBg3qsg3m2qf7FLZFwVAK6YHvzHYZ+gATCjZe4mMhr3qmZsb3dZRqE8hTbz9ng==",
       "requires": {
-        "axios": "^1.6.7",
+        "axios": "^1.6.8",
         "tiny-async-pool": "^2.1.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@easyops-cn/docusaurus-search-local": "0.40.1",
     "@lottiefiles/react-lottie-player": "3.5.3",
     "@openfga/frontend-utils": "^0.2.0-beta.9",
-    "@openfga/sdk": "^0.3.5",
+    "@openfga/sdk": "^0.4.0",
     "@openfga/syntax-transformer": "^0.2.0-beta.17",
     "assert-never": "1.2.1",
     "clsx": "2.1.1",

--- a/src/components/Docs/SnippetViewer/ListUsersRequestViewer.tsx
+++ b/src/components/Docs/SnippetViewer/ListUsersRequestViewer.tsx
@@ -228,45 +228,45 @@ var response = await fgaClient.ListUsers(body, options);
 // response.ExcludedUsers = [${expectedResults.excluded_users.map((u) => JSON.stringify(u)).join(',')}]`;
     case SupportedLanguage.PYTHON_SDK:
       return '';
-//       return `
-// options = {
-//     "authorization_model_id": "${modelId}"
-// }
+    //       return `
+    // options = {
+    //     "authorization_model_id": "${modelId}"
+    // }
 
-// userFilters=[UserTypeFilter(type="${userFilterType}"${userFilterRelation ? `, relation="${userFilterRelation}"` : ''})]
+    // userFilters=[UserTypeFilter(type="${userFilterType}"${userFilterRelation ? `, relation="${userFilterRelation}"` : ''})]
 
-// body = ClientListUsersRequest(
-//     object=FgaObject(type="${objectId}, id="${objectId}"),
-//     relation="${relation}",
-//     userFilters=userFilters,${
-//       contextualTuples
-//         ? `
-//     contextual_tuples=[
-//         ${contextualTuples
-//           .map(
-//             (tuple) => `ClientTupleKey(user="${tuple.user}", relation="${tuple.relation}", object="${tuple.object}")`,
-//           )
-//           .join(',\n                ')}
-//     ],`
-//         : ``
-//     }${
-//       context
-//         ? `
-//     context=dict(${Object.entries(context)
-//       .map(
-//         ([k, v]) => `
-//         ${k}="${v}"`,
-//       )
-//       .join(',')}
-//     )`
-//         : ''
-//     }
-// )
+    // body = ClientListUsersRequest(
+    //     object=FgaObject(type="${objectId}, id="${objectId}"),
+    //     relation="${relation}",
+    //     userFilters=userFilters,${
+    //       contextualTuples
+    //         ? `
+    //     contextual_tuples=[
+    //         ${contextualTuples
+    //           .map(
+    //             (tuple) => `ClientTupleKey(user="${tuple.user}", relation="${tuple.relation}", object="${tuple.object}")`,
+    //           )
+    //           .join(',\n                ')}
+    //     ],`
+    //         : ``
+    //     }${
+    //       context
+    //         ? `
+    //     context=dict(${Object.entries(context)
+    //       .map(
+    //         ([k, v]) => `
+    //         ${k}="${v}"`,
+    //       )
+    //       .join(',')}
+    //     )`
+    //         : ''
+    //     }
+    // )
 
-// response = await fga_client.list_users(body, options)
+    // response = await fga_client.list_users(body, options)
 
-// # response.users = [${expectedResults.users.map((u) => JSON.stringify(u)).join(',')}]
-// # response.excludedUsers = [${expectedResults.excluded_users.map((u) => JSON.stringify(u)).join(',')}]`;
+    // # response.users = [${expectedResults.users.map((u) => JSON.stringify(u)).join(',')}]
+    // # response.excludedUsers = [${expectedResults.excluded_users.map((u) => JSON.stringify(u)).join(',')}]`;
     case SupportedLanguage.RPC:
       return `listUsers(
   "${objectId}", // list the objects that the user \`${objectId}\`

--- a/src/components/Docs/SnippetViewer/ListUsersRequestViewer.tsx
+++ b/src/components/Docs/SnippetViewer/ListUsersRequestViewer.tsx
@@ -64,6 +64,7 @@ function listUsersRequestViewer(lang: SupportedLanguage, opts: ListUsersRequestV
             "type": "${userFilterType}"${
               userFilterRelation
                 ? `,
+,
             "relation": "${userFilterRelation}"`
                 : ''
             }
@@ -99,7 +100,7 @@ function listUsersRequestViewer(lang: SupportedLanguage, opts: ListUsersRequestV
     id: "${objectId}"
   },
   user_filters: [{
-    type: "${userFilterType}"${
+    type: "${userFilterType}",${
       userFilterRelation
         ? `,
     relation: "${userFilterRelation}"`
@@ -130,8 +131,8 @@ function listUsersRequestViewer(lang: SupportedLanguage, opts: ListUsersRequestV
 }, {
   authorization_model_id: "${modelId}",
 });
-// response.getUsers() = [${expectedResults.users.map((u) => JSON.stringify(u)).join(',')}]
-// response.getExcludedUsers() = p${expectedResults.excluded_users.map((u) => JSON.stringify(u)).join(',')}]`;
+// response.users = [${expectedResults.users.map((u) => JSON.stringify(u)).join(',')}]
+// response.excluded_users = p${expectedResults.excluded_users.map((u) => JSON.stringify(u)).join(',')}]`;
     case SupportedLanguage.GO_SDK:
       /* eslint-disable no-tabs */
       return `options := ClientListUsersOptions{
@@ -146,7 +147,7 @@ body := ClientListUsersRequest{
         Id:      "${objectId}",
     },
     Relation:     "${relation}",
-    UserFilter:   userFilters,${
+    UserFilters:   userFilters,${
       !contextualTuples
         ? ''
         : `
@@ -261,7 +262,7 @@ body = ClientListUsersRequest(
     }
 )
 
-response = await fga_client.list_objects(body, options)
+response = await fga_client.list_users(body, options)
 
 # response.users = [${expectedResults.users.map((u) => JSON.stringify(u)).join(',')}]
 # response.excludedUsers = [${expectedResults.excluded_users.map((u) => JSON.stringify(u)).join(',')}]`;

--- a/src/components/Docs/SnippetViewer/ListUsersRequestViewer.tsx
+++ b/src/components/Docs/SnippetViewer/ListUsersRequestViewer.tsx
@@ -227,45 +227,46 @@ var response = await fgaClient.ListUsers(body, options);
 // response.Users = [${expectedResults.users.map((u) => JSON.stringify(u)).join(',')}]
 // response.ExcludedUsers = [${expectedResults.excluded_users.map((u) => JSON.stringify(u)).join(',')}]`;
     case SupportedLanguage.PYTHON_SDK:
-      return `
-options = {
-    "authorization_model_id": "${modelId}"
-}
+      return '';
+//       return `
+// options = {
+//     "authorization_model_id": "${modelId}"
+// }
 
-userFilters=[UserTypeFilter(type="${userFilterType}"${userFilterRelation ? `, relation="${userFilterRelation}"` : ''})]
+// userFilters=[UserTypeFilter(type="${userFilterType}"${userFilterRelation ? `, relation="${userFilterRelation}"` : ''})]
 
-body = ClientListUsersRequest(
-    object=FgaObject(type="${objectId}, id="${objectId}"),
-    relation="${relation}",
-    userFilters=userFilters,${
-      contextualTuples
-        ? `
-    contextual_tuples=[
-        ${contextualTuples
-          .map(
-            (tuple) => `ClientTupleKey(user="${tuple.user}", relation="${tuple.relation}", object="${tuple.object}")`,
-          )
-          .join(',\n                ')}
-    ],`
-        : ``
-    }${
-      context
-        ? `
-    context=dict(${Object.entries(context)
-      .map(
-        ([k, v]) => `
-        ${k}="${v}"`,
-      )
-      .join(',')}
-    )`
-        : ''
-    }
-)
+// body = ClientListUsersRequest(
+//     object=FgaObject(type="${objectId}, id="${objectId}"),
+//     relation="${relation}",
+//     userFilters=userFilters,${
+//       contextualTuples
+//         ? `
+//     contextual_tuples=[
+//         ${contextualTuples
+//           .map(
+//             (tuple) => `ClientTupleKey(user="${tuple.user}", relation="${tuple.relation}", object="${tuple.object}")`,
+//           )
+//           .join(',\n                ')}
+//     ],`
+//         : ``
+//     }${
+//       context
+//         ? `
+//     context=dict(${Object.entries(context)
+//       .map(
+//         ([k, v]) => `
+//         ${k}="${v}"`,
+//       )
+//       .join(',')}
+//     )`
+//         : ''
+//     }
+// )
 
-response = await fga_client.list_users(body, options)
+// response = await fga_client.list_users(body, options)
 
-# response.users = [${expectedResults.users.map((u) => JSON.stringify(u)).join(',')}]
-# response.excludedUsers = [${expectedResults.excluded_users.map((u) => JSON.stringify(u)).join(',')}]`;
+// # response.users = [${expectedResults.users.map((u) => JSON.stringify(u)).join(',')}]
+// # response.excludedUsers = [${expectedResults.excluded_users.map((u) => JSON.stringify(u)).join(',')}]`;
     case SupportedLanguage.RPC:
       return `listUsers(
   "${objectId}", // list the objects that the user \`${objectId}\`
@@ -334,7 +335,7 @@ export function ListUsersRequestViewer(opts: ListUsersRequestViewerOpts): JSX.El
     SupportedLanguage.JS_SDK,
     SupportedLanguage.GO_SDK,
     SupportedLanguage.DOTNET_SDK,
-    SupportedLanguage.PYTHON_SDK,
+    // SupportedLanguage.PYTHON_SDK,
     SupportedLanguage.JAVA_SDK,
     SupportedLanguage.CLI,
     SupportedLanguage.CURL,

--- a/src/components/Docs/SnippetViewer/ListUsersRequestViewer.tsx
+++ b/src/components/Docs/SnippetViewer/ListUsersRequestViewer.tsx
@@ -1,0 +1,325 @@
+import { getFilteredAllowedLangs, SupportedLanguage, DefaultAuthorizationModelId } from './SupportedLanguage';
+import { defaultOperationsViewer } from './DefaultTabbedViewer';
+import assertNever from 'assert-never/index';
+import { ListUsersResponse, TupleKey } from '@openfga/sdk';
+
+interface ListUsersRequestViewerOpts {
+  authorizationModelId?: string;
+  objectType: string;
+  objectId: string;
+  relation: string;
+  userFilterType: string;
+  userFilterRelation?: string;
+  contextualTuples?: TupleKey[];
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  context?: Record<string, any>;
+  expectedResults: ListUsersResponse;
+  skipSetup?: boolean;
+  allowedLanguages?: SupportedLanguage[];
+}
+
+function listUsersRequestViewer(lang: SupportedLanguage, opts: ListUsersRequestViewerOpts): string {
+  const { relation, objectType, objectId, userFilterType, userFilterRelation, contextualTuples, context, expectedResults } = opts;
+  const modelId = opts.authorizationModelId ? opts.authorizationModelId : DefaultAuthorizationModelId;
+
+  const response = `{"users": [${expectedResults.users.map((r) => JSON.stringify(r)).join(', ')}],"excluded_users":[${expectedResults.users.map((r) => JSON.stringify(r)).join(', ')}]}`;
+
+  switch (lang) {
+    case SupportedLanguage.PLAYGROUND:
+      return `# Note: List Users is not currently supported on the playground`;
+    case SupportedLanguage.CLI:
+
+      return `fga query list-users --store-id=\${FGA_STORE_ID} --model-id=${modelId} --object ${objectType}:${objectId} --relation ${relation} --user-filter ${userFilterType}${userFilterRelation ? `#${userFilterRelation}`: ""} ${
+        contextualTuples
+          ? `${contextualTuples
+              .map((tuple) => ` --contextual-tuple "${tuple.user} ${tuple.relation} ${tuple.object}"`)
+              .join(' ')}`
+          : ''
+      }${context ? ` --context='${JSON.stringify(context)}'` : ''}
+
+# Response: ${response}`;
+    case SupportedLanguage.CURL:
+      /* eslint-disable max-len */
+      return `curl -X POST $FGA_API_URL/stores/$FGA_STORE_ID/list-users \\
+  -H "Authorization: Bearer $FGA_API_TOKEN" \\ # Not needed if service does not require authorization
+  -H "content-type: application/json" \\
+  -d '{
+        "authorization_model_id": "${modelId}",
+        "object": {
+          "type: "${objectType}",
+          "id": "${objectId}",
+        },
+        "relation": "${relation}",
+        "user_filters": [
+          { 
+            "type": "${userFilterType}"${userFilterRelation ? `,
+            "relation": "${userFilterRelation}"` : ""}
+          }
+        ]${
+          contextualTuples
+            ? `,
+        "contextual_tuples": {
+          "tuple_keys": [${contextualTuples
+            .map(
+              (tuple) => `
+            {"object": "${tuple.object}", "relation": "${tuple.relation}", "user": "${tuple.user}"}`,
+            )
+            .join(',')}
+          ]
+        }`
+            : ''
+        }${
+          context
+            ? `,
+        "context":${JSON.stringify(context)}`
+            : ''
+        }
+    }'
+
+
+# Response: ${response}`;
+    /* eslint-enable max-len */
+    case SupportedLanguage.JS_SDK:
+
+      return `const response = await fgaClient.listUsers({
+  object: {
+    type: "${objectType}",
+    id: "${objectId}"
+  },
+  user_filters: [{
+    type: "${userFilterType}"${userFilterRelation ? `,
+    relation: "${userFilterRelation}"` : ""}
+  }],
+  relation: "${relation}",${
+    contextualTuples?.length
+      ? `
+      contextualTuples: {
+    tuple_keys: [${contextualTuples
+      .map(
+        (tupleKey) => `{
+      user: "${tupleKey.user}",
+      relation: "${tupleKey.relation}",
+      object: "${tupleKey.object}"
+    }`,
+      )
+      .join(', ')}]
+  },`
+      : ''
+  }${
+    context
+      ? `
+  context:${JSON.stringify(context)},`
+      : ''
+  }
+}, {
+  authorization_model_id: "${modelId}",
+});
+// response.getUsers() = ${expectedResults.users.map(u => JSON.stringify(u)).join(",")}
+// response.getExcludedUsers() = ${expectedResults.excluded_users.map(u => JSON.stringify(u)).join(",")}`;
+    case SupportedLanguage.GO_SDK:
+      /* eslint-disable no-tabs */
+      return `options := ClientListUsersOptions{
+    AuthorizationModelId: PtrString("${modelId}"),
+}
+
+userFilters := []openfga.UserTypeFilter{{ Type:"${userFilterType}"${userFilterRelation ? `,Relation:${userFilterRelation} ` : " "}}}
+
+body := ClientListUsersRequest{
+    Object:       openfga.Object{
+        Type:    "${objectType}",
+        Id:      "${objectId}",
+    },
+    Relation:     "${relation}",
+    UserFilter:   userFilters,${
+      !contextualTuples
+        ? ''
+        : `
+    ContextualTuples: []ClientContextualTupleKey{
+${
+  !contextualTuples
+    ? ''
+    : contextualTuples
+        .map(
+          (tuple) =>
+            `        {
+             User:     "${tuple.user}",
+             Relation: "${tuple.relation}",
+             Object:   "${tuple.object}",
+        },`,
+        )
+        .join('\n')
+}
+    },`
+    }${
+      context
+        ? `
+    Context: &map[string]interface{}${JSON.stringify(context)},`
+        : ''
+    }
+}
+
+data, err := fgaClient.ListUsers(context.Background()).
+    Body(body).
+    Options(options).
+    Execute()
+
+// data.Users = [{ "objects": [${expectedResults.users.map((u) => JSON.stringify(u)).join(', ')}] }]
+// data.ExcludedUsers = [{ "objects": [${expectedResults.excluded_users.map((u) => JSON.stringify(u)).join(', ')}] }]`;
+    case SupportedLanguage.DOTNET_SDK:
+      return `
+var options = new ClientWriteOptions {
+    AuthorizationModelId = "${modelId}",
+};
+var body = new ClientListUsersRequest {
+    Object = new FgaObject {
+      Type = "${objectType}",
+      Id = "${objectId}"
+    },
+    Relation = "${relation}",
+    UserFilters = new List<UserTypeFilter> {
+      new() {
+        Type = "${userFilterType}"${userFilterRelation ? `
+        Relation = "${userFilterRelation}"
+        ` : ""}
+      }
+    }${
+      contextualTuples
+        ? `,
+    ,ContextualTuples = new List<ClientTupleKey>({
+    ${contextualTuples
+      .map((tuple) => `new(user: "${tuple.user}", relation: "${tuple.relation}", _object: "${tuple.object}")`)
+      .join(',\n    ')}
+})`
+        : ''
+    }
+    ${
+      context
+        ? `Context = new { ${Object.entries(context)
+            .map(([k, v]) => `${k}="${v}"`)
+            .join(',')} }`
+        : ''
+    }
+};
+
+var response = await fgaClient.ListUsers(body, options);
+
+// response.Users = [${expectedResults.users.map(u => JSON.stringify(u)).join(",")}]
+// response.ExcludedUsers = [${expectedResults.excluded_users.map(u => JSON.stringify(u)).join(",")}]`;
+    case SupportedLanguage.PYTHON_SDK:
+      return `
+options = {
+    "authorization_model_id": "${modelId}"
+}
+
+userFilters=[UserTypeFilter(type="${userFilterType}"${userFilterRelation ? `, relation="${userFilterRelation}"` : ""})]
+
+body = ClientListUsersRequest(
+    object=FgaObject(type="${objectId}, id="${objectId}"),
+    relation="${relation}",
+    userFilters=userFilters,${
+      contextualTuples
+        ? `
+    contextual_tuples=[
+        ${contextualTuples
+          .map(
+            (tuple) => `ClientTupleKey(user="${tuple.user}", relation="${tuple.relation}", object="${tuple.object}")`,
+          )
+          .join(',\n                ')}
+    ],`
+        : ``
+    }${
+      context
+        ? `
+    context=dict(${Object.entries(context)
+      .map(
+        ([k, v]) => `
+        ${k}="${v}"`,
+      )
+      .join(',')}
+    )`
+        : ''
+    }
+)
+
+response = await fga_client.list_objects(body, options)
+
+# response.users = [${expectedResults.users.map(u => JSON.stringify(u)).join(",")}]
+# response.excludedUsers = [${expectedResults.excluded_users.map(u => JSON.stringify(u)).join(",")}]`;
+    case SupportedLanguage.RPC:
+      return `listUsers(
+  "${objectId}", // list the objects that the user \`${objectId}\`
+  "${relation}", // has an \`${relation}\` relation
+  "${objectType}", // and that are of type \`${objectType}\`
+  authorization_model_id = "${modelId}", // for this particular authorization model id ${
+    contextualTuples
+      ? `
+  contextual_tuples = [ // Assuming the following is true
+    ${contextualTuples
+      .map((tuple) => `{user = "${tuple.user}", relation = "${tuple.relation}", object = "${tuple.object}"}`)
+      .join(',\n    ')}
+  ]`
+      : ''
+  }
+);
+
+Reply: ${response}`;
+
+    case SupportedLanguage.JAVA_SDK: {
+      const contextualTuplesList = contextualTuples
+        ? `
+        .contextualTupleKeys(
+                List.of(${contextualTuples.map(
+                  (tuple) => `
+                        new ClientTupleKey()
+                                .user("${tuple.user}")
+                                .relation("${tuple.relation}")
+                                ._object("${tuple.object}")
+                ))`,
+                )}`
+        : '';
+      const contextCall = context
+        ? `
+        .context(Map.of(${Object.entries(context)
+          .map(([k, v]) => `"${k}", "${v}"`)
+          .join(',')}))`
+        : '';
+      return `var options = new ClientListUsersOptions()
+        .authorizationModelId("${modelId}");
+
+var userFilters = new ArrayList<UserTypeFilter>() {
+  {
+      add(new UserTypeFilter().type("${userFilterType}")${userFilterRelation ? `.relation("${userFilterRelation}")` : ""});
+  }
+};
+
+
+var body = new ClientListUsersRequest()
+        ._object(new FgaObject().type("${objectType}").id("${objectId}"))
+        .relation("${relation}")
+        .userFilters(userFilters)${contextualTuplesList}${contextCall};
+
+var response = fgaClient.listUsers(body, options).get();
+
+// response.getUsers() = [${expectedResults.users.map(u => JSON.stringify(u)).join(",")}]
+// response.getExcludedUsers() = [${expectedResults.excluded_users.map(u => JSON.stringify(u)).join(",")}]`;
+    }
+    default:
+      assertNever(lang);
+  }
+}
+
+export function ListUsersRequestViewer(opts: ListUsersRequestViewerOpts): JSX.Element {
+  const defaultLangs = [
+    SupportedLanguage.JS_SDK,
+    SupportedLanguage.GO_SDK,
+    SupportedLanguage.DOTNET_SDK,
+    SupportedLanguage.PYTHON_SDK,
+    SupportedLanguage.JAVA_SDK,
+    SupportedLanguage.CLI,
+    SupportedLanguage.CURL,
+    SupportedLanguage.RPC,
+  ];
+  const allowedLanguages = getFilteredAllowedLangs(opts.allowedLanguages, defaultLangs);
+  return defaultOperationsViewer<ListUsersRequestViewerOpts>(allowedLanguages, opts, listUsersRequestViewer);
+}

--- a/src/components/Docs/SnippetViewer/ListUsersRequestViewer.tsx
+++ b/src/components/Docs/SnippetViewer/ListUsersRequestViewer.tsx
@@ -32,7 +32,7 @@ function listUsersRequestViewer(lang: SupportedLanguage, opts: ListUsersRequestV
   } = opts;
   const modelId = opts.authorizationModelId ? opts.authorizationModelId : DefaultAuthorizationModelId;
 
-  const response = `{"users": [${expectedResults.users.map((r) => JSON.stringify(r)).join(', ')}],"excluded_users":[${expectedResults.users.map((r) => JSON.stringify(r)).join(', ')}]}`;
+  const response = `{"users": [${expectedResults.users.map((r) => JSON.stringify(r)).join(', ')}],"excluded_users":[${expectedResults.excluded_users.map((r) => JSON.stringify(r)).join(', ')}]}`;
 
   switch (lang) {
     case SupportedLanguage.PLAYGROUND:
@@ -130,8 +130,8 @@ function listUsersRequestViewer(lang: SupportedLanguage, opts: ListUsersRequestV
 }, {
   authorization_model_id: "${modelId}",
 });
-// response.getUsers() = ${expectedResults.users.map((u) => JSON.stringify(u)).join(',')}
-// response.getExcludedUsers() = ${expectedResults.excluded_users.map((u) => JSON.stringify(u)).join(',')}`;
+// response.getUsers() = [${expectedResults.users.map((u) => JSON.stringify(u)).join(',')}]
+// response.getExcludedUsers() = p${expectedResults.excluded_users.map((u) => JSON.stringify(u)).join(',')}]`;
     case SupportedLanguage.GO_SDK:
       /* eslint-disable no-tabs */
       return `options := ClientListUsersOptions{
@@ -179,8 +179,8 @@ data, err := fgaClient.ListUsers(context.Background()).
     Options(options).
     Execute()
 
-// data.Users = [{ "objects": [${expectedResults.users.map((u) => JSON.stringify(u)).join(', ')}] }]
-// data.ExcludedUsers = [{ "objects": [${expectedResults.excluded_users.map((u) => JSON.stringify(u)).join(', ')}] }]`;
+// data.Users = [${expectedResults.users.map((u) => JSON.stringify(u)).join(', ')}]
+// data.ExcludedUsers = [${expectedResults.excluded_users.map((u) => JSON.stringify(u)).join(', ')}]`;
     case SupportedLanguage.DOTNET_SDK:
       return `
 var options = new ClientWriteOptions {

--- a/src/components/Docs/SnippetViewer/ListUsersRequestViewer.tsx
+++ b/src/components/Docs/SnippetViewer/ListUsersRequestViewer.tsx
@@ -20,7 +20,16 @@ interface ListUsersRequestViewerOpts {
 }
 
 function listUsersRequestViewer(lang: SupportedLanguage, opts: ListUsersRequestViewerOpts): string {
-  const { relation, objectType, objectId, userFilterType, userFilterRelation, contextualTuples, context, expectedResults } = opts;
+  const {
+    relation,
+    objectType,
+    objectId,
+    userFilterType,
+    userFilterRelation,
+    contextualTuples,
+    context,
+    expectedResults,
+  } = opts;
   const modelId = opts.authorizationModelId ? opts.authorizationModelId : DefaultAuthorizationModelId;
 
   const response = `{"users": [${expectedResults.users.map((r) => JSON.stringify(r)).join(', ')}],"excluded_users":[${expectedResults.users.map((r) => JSON.stringify(r)).join(', ')}]}`;
@@ -29,8 +38,7 @@ function listUsersRequestViewer(lang: SupportedLanguage, opts: ListUsersRequestV
     case SupportedLanguage.PLAYGROUND:
       return `# Note: List Users is not currently supported on the playground`;
     case SupportedLanguage.CLI:
-
-      return `fga query list-users --store-id=\${FGA_STORE_ID} --model-id=${modelId} --object ${objectType}:${objectId} --relation ${relation} --user-filter ${userFilterType}${userFilterRelation ? `#${userFilterRelation}`: ""} ${
+      return `fga query list-users --store-id=\${FGA_STORE_ID} --model-id=${modelId} --object ${objectType}:${objectId} --relation ${relation} --user-filter ${userFilterType}${userFilterRelation ? `#${userFilterRelation}` : ''} ${
         contextualTuples
           ? `${contextualTuples
               .map((tuple) => ` --contextual-tuple "${tuple.user} ${tuple.relation} ${tuple.object}"`)
@@ -53,8 +61,12 @@ function listUsersRequestViewer(lang: SupportedLanguage, opts: ListUsersRequestV
         "relation": "${relation}",
         "user_filters": [
           { 
-            "type": "${userFilterType}"${userFilterRelation ? `,
-            "relation": "${userFilterRelation}"` : ""}
+            "type": "${userFilterType}"${
+              userFilterRelation
+                ? `,
+            "relation": "${userFilterRelation}"`
+                : ''
+            }
           }
         ]${
           contextualTuples
@@ -81,15 +93,18 @@ function listUsersRequestViewer(lang: SupportedLanguage, opts: ListUsersRequestV
 # Response: ${response}`;
     /* eslint-enable max-len */
     case SupportedLanguage.JS_SDK:
-
       return `const response = await fgaClient.listUsers({
   object: {
     type: "${objectType}",
     id: "${objectId}"
   },
   user_filters: [{
-    type: "${userFilterType}"${userFilterRelation ? `,
-    relation: "${userFilterRelation}"` : ""}
+    type: "${userFilterType}"${
+      userFilterRelation
+        ? `,
+    relation: "${userFilterRelation}"`
+        : ''
+    }
   }],
   relation: "${relation}",${
     contextualTuples?.length
@@ -115,15 +130,15 @@ function listUsersRequestViewer(lang: SupportedLanguage, opts: ListUsersRequestV
 }, {
   authorization_model_id: "${modelId}",
 });
-// response.getUsers() = ${expectedResults.users.map(u => JSON.stringify(u)).join(",")}
-// response.getExcludedUsers() = ${expectedResults.excluded_users.map(u => JSON.stringify(u)).join(",")}`;
+// response.getUsers() = ${expectedResults.users.map((u) => JSON.stringify(u)).join(',')}
+// response.getExcludedUsers() = ${expectedResults.excluded_users.map((u) => JSON.stringify(u)).join(',')}`;
     case SupportedLanguage.GO_SDK:
       /* eslint-disable no-tabs */
       return `options := ClientListUsersOptions{
     AuthorizationModelId: PtrString("${modelId}"),
 }
 
-userFilters := []openfga.UserTypeFilter{{ Type:"${userFilterType}"${userFilterRelation ? `,Relation:${userFilterRelation} ` : " "}}}
+userFilters := []openfga.UserTypeFilter{{ Type:"${userFilterType}"${userFilterRelation ? `,Relation:${userFilterRelation} ` : ' '}}}
 
 body := ClientListUsersRequest{
     Object:       openfga.Object{
@@ -179,9 +194,13 @@ var body = new ClientListUsersRequest {
     Relation = "${relation}",
     UserFilters = new List<UserTypeFilter> {
       new() {
-        Type = "${userFilterType}"${userFilterRelation ? `
+        Type = "${userFilterType}"${
+          userFilterRelation
+            ? `
         Relation = "${userFilterRelation}"
-        ` : ""}
+        `
+            : ''
+        }
       }
     }${
       contextualTuples
@@ -204,15 +223,15 @@ var body = new ClientListUsersRequest {
 
 var response = await fgaClient.ListUsers(body, options);
 
-// response.Users = [${expectedResults.users.map(u => JSON.stringify(u)).join(",")}]
-// response.ExcludedUsers = [${expectedResults.excluded_users.map(u => JSON.stringify(u)).join(",")}]`;
+// response.Users = [${expectedResults.users.map((u) => JSON.stringify(u)).join(',')}]
+// response.ExcludedUsers = [${expectedResults.excluded_users.map((u) => JSON.stringify(u)).join(',')}]`;
     case SupportedLanguage.PYTHON_SDK:
       return `
 options = {
     "authorization_model_id": "${modelId}"
 }
 
-userFilters=[UserTypeFilter(type="${userFilterType}"${userFilterRelation ? `, relation="${userFilterRelation}"` : ""})]
+userFilters=[UserTypeFilter(type="${userFilterType}"${userFilterRelation ? `, relation="${userFilterRelation}"` : ''})]
 
 body = ClientListUsersRequest(
     object=FgaObject(type="${objectId}, id="${objectId}"),
@@ -244,8 +263,8 @@ body = ClientListUsersRequest(
 
 response = await fga_client.list_objects(body, options)
 
-# response.users = [${expectedResults.users.map(u => JSON.stringify(u)).join(",")}]
-# response.excludedUsers = [${expectedResults.excluded_users.map(u => JSON.stringify(u)).join(",")}]`;
+# response.users = [${expectedResults.users.map((u) => JSON.stringify(u)).join(',')}]
+# response.excludedUsers = [${expectedResults.excluded_users.map((u) => JSON.stringify(u)).join(',')}]`;
     case SupportedLanguage.RPC:
       return `listUsers(
   "${objectId}", // list the objects that the user \`${objectId}\`
@@ -289,7 +308,7 @@ Reply: ${response}`;
 
 var userFilters = new ArrayList<UserTypeFilter>() {
   {
-      add(new UserTypeFilter().type("${userFilterType}")${userFilterRelation ? `.relation("${userFilterRelation}")` : ""});
+      add(new UserTypeFilter().type("${userFilterType}")${userFilterRelation ? `.relation("${userFilterRelation}")` : ''});
   }
 };
 
@@ -301,8 +320,8 @@ var body = new ClientListUsersRequest()
 
 var response = fgaClient.listUsers(body, options).get();
 
-// response.getUsers() = [${expectedResults.users.map(u => JSON.stringify(u)).join(",")}]
-// response.getExcludedUsers() = [${expectedResults.excluded_users.map(u => JSON.stringify(u)).join(",")}]`;
+// response.getUsers() = [${expectedResults.users.map((u) => JSON.stringify(u)).join(',')}]
+// response.getExcludedUsers() = [${expectedResults.excluded_users.map((u) => JSON.stringify(u)).join(',')}]`;
     }
     default:
       assertNever(lang);

--- a/src/components/Docs/SnippetViewer/index.ts
+++ b/src/components/Docs/SnippetViewer/index.ts
@@ -2,6 +2,7 @@ export * from './CheckRequestViewer';
 export * from './DefaultTabbedViewer';
 export * from './ExpandRequestViewer';
 export * from './ListObjectsRequestViewer';
+export * from './ListUsersRequestViewer';
 export * from './ReadChangesRequestViewer';
 export * from './ReadRequestViewer';
 export { SdkSetupHeader } from './SdkSetup';


### PR DESCRIPTION
## Description

* 30aaf25016608937b4870eda07e38edb80d9d1e8 - Adds the snippet viewer for list users, the python implementation is currently a guess as it's not implemented
* f6dba22dd4ad63e1a2895974ea6f2708d4bc1776 - Adds docs for list users to the concepts page, the testing guide, and a perform list users page. The latter two include a warning banner that states the experimental nature and link to the announcement.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
