### PR TITLE
fix: resolve wrong python SDK Link in intro

### DIFF
--- a/docs/content/intro.mdx
+++ b/docs/content/intro.mdx
@@ -28,7 +28,7 @@ Inspired by [Google’s Zanzibar](https://zanzibar.academy), Google’s internal
 - A [Playground](./getting-started/setup-openfga/playground.mdx) to learn how to use the product effectively
 - Support for multiple [stores](./concepts.mdx#what-is-a-store) that allow authorization management in different environments (prod/testing/dev), use cases (internal apps, external apps, infrastructure)
 - Support for ABAC scenarios with [Contextual Tuples](./modeling/token-claims-contextual-tuples.mdx) and [Conditional Relationship Tuples](./modeling/conditions.mdx)
-- SDKs for [Java](https://github.com/openfga/java-sdk), [.NET](https://github.com/openfga/dotnet-sdk), [Javascript](https://github.com/openfga/js-sdk), [Go](https://github.com/openfga/go-sdk), and [Python](https://github.com/openfga/java-sdk).
+- SDKs for [Java](https://github.com/openfga/java-sdk), [.NET](https://github.com/openfga/dotnet-sdk), [Javascript](https://github.com/openfga/js-sdk), [Go](https://github.com/openfga/go-sdk), and [Python](https://github.com/openfga/python-sdk).
 - An [HTTP](https://docs.fga.dev/api/service) and [gRPC API](https://buf.build/openfga/api)
 - [A Command Line Interface tool](./getting-started/cli.mdx) for managing <ProductName format={ProductNameFormat.ShortForm}/>  environments, test models, import/export models, and data.
 - Github Actions for [testing](https://github.com/marketplace/actions/openfga-model-testing-action) and [deploying](https://github.com/marketplace/actions/openfga-model-deploy-action) models


### PR DESCRIPTION



## Description
Fix a bad link in documentation intro page: previous "Python" link lead to java sdk and not python sdk.


## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] N/A: I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev]
- [x] The correct base branch is being used, if not `main`
- [x] N/A: I have added tests to validate that the change in functionality is working as expected
