### PR TITLE
feat: add python to list users snippet

### DIFF
--- a/docs/content/getting-started/perform-list-users.mdx
+++ b/docs/content/getting-started/perform-list-users.mdx
@@ -236,6 +236,7 @@ Then calling the List Users API for `document:1` with relation `viewer` of type 
     SupportedLanguage.JS_SDK,
     SupportedLanguage.GO_SDK,
     SupportedLanguage.DOTNET_SDK,
+    SupportedLanguage.PYTHON_SDK,
     SupportedLanguage.JAVA_SDK,
     SupportedLanguage.CLI,
     SupportedLanguage.CURL,

--- a/docs/content/getting-started/perform-list-users.mdx
+++ b/docs/content/getting-started/perform-list-users.mdx
@@ -61,14 +61,14 @@ This section will illustrate how to perform a <ProductConcept section="what-is-a
 
 </TabItem>
 
-{ /* <TabItem value={SupportedLanguage.PYTHON_SDK} label={languageLabelMap.get(SupportedLanguage.PYTHON_SDK)}>
+<TabItem value={SupportedLanguage.PYTHON_SDK} label={languageLabelMap.get(SupportedLanguage.PYTHON_SDK)}>
 
 1. <SdkSetupPrerequisite />
 2. You have [installed the SDK](./install-sdk.mdx).
 3. You have [configured the _authorization model_](./configure-model.mdx) and [updated the _relationship tuples_](./update-tuples.mdx).
 4. You have loaded `FGA_STORE_ID` and `FGA_API_URL` as environment variables.
 
-</TabItem> */}
+</TabItem>
 
 <TabItem value={SupportedLanguage.JAVA_SDK} label={languageLabelMap.get(SupportedLanguage.JAVA_SDK)}>
 
@@ -120,11 +120,11 @@ Before calling the List Users API, you will need to configure the API client.
 <SdkSetupHeader lang={SupportedLanguage.DOTNET_SDK} />
 
 </TabItem>
-{/* <TabItem value={SupportedLanguage.PYTHON_SDK} label={languageLabelMap.get(SupportedLanguage.PYTHON_SDK)}>
+<TabItem value={SupportedLanguage.PYTHON_SDK} label={languageLabelMap.get(SupportedLanguage.PYTHON_SDK)}>
 
 <SdkSetupHeader lang={SupportedLanguage.PYTHON_SDK} />
 
-</TabItem> */}
+</TabItem>
 <TabItem value={SupportedLanguage.JAVA_SDK} label={languageLabelMap.get(SupportedLanguage.JAVA_SDK)}>
 
 <SdkSetupHeader lang={SupportedLanguage.JAVA_SDK} />
@@ -162,6 +162,7 @@ To return all users of type `user` that have have the `reader` relationship with
     SupportedLanguage.JS_SDK,
     SupportedLanguage.GO_SDK,
     SupportedLanguage.DOTNET_SDK,
+    SupportedLanguage.PYTHON_SDK,
     SupportedLanguage.JAVA_SDK,
     SupportedLanguage.CLI,
     SupportedLanguage.CURL,

--- a/src/components/Docs/SnippetViewer/ListUsersRequestViewer.tsx
+++ b/src/components/Docs/SnippetViewer/ListUsersRequestViewer.tsx
@@ -223,43 +223,44 @@ var response = await fgaClient.ListUsers(body, options);
 
 // response.Users = [${expectedResults.users.map((u) => JSON.stringify(u)).join(',')}]`;
     case SupportedLanguage.PYTHON_SDK:
-      return '';
-    //       return `
-    // options = {
-    //     "authorization_model_id": "${modelId}"
-    // }
+      return `
+  options = {
+      "authorization_model_id": "${modelId}"
+  }
 
-    // userFilters=[UserTypeFilter(type="${userFilterType}"${userFilterRelation ? `, relation="${userFilterRelation}"` : ''})]
+  userFilters = [
+      UserTypeFilter(type="${userFilterType}"${userFilterRelation ? `, relation="${userFilterRelation}"` : ''})
+  ]
 
-    // body = ClientListUsersRequest(
-    //     object=FgaObject(type="${objectId}, id="${objectId}"),
-    //     relation="${relation}",
-    //     userFilters=userFilters,${
-    //       contextualTuples
-    //         ? `
-    //     contextual_tuples=[
-    //         ${contextualTuples
-    //           .map(
-    //             (tuple) => `ClientTupleKey(user="${tuple.user}", relation="${tuple.relation}", object="${tuple.object}")`,
-    //           )
-    //           .join(',\n                ')}
-    //     ],`
-    //         : ``
-    //     }${
-    //       context
-    //         ? `
-    //     context=dict(${Object.entries(context)
-    //       .map(
-    //         ([k, v]) => `
-    //         ${k}="${v}"`,
-    //       )
-    //       .join(',')}
-    //     )`
-    //         : ''
-    //     }
-    // )
+  body = ClientListUsersRequest(
+      object="${objectId}:${objectId}",
+      relation="${relation}",
+      user_filters=userFilters,${
+        contextualTuples
+          ? `
+      contextual_tuples=[
+          ${contextualTuples
+            .map(
+              (tuple) => `ClientTupleKey(user="${tuple.user}", relation="${tuple.relation}", object="${tuple.object}")`,
+            )
+            .join(',\n                ')}
+      ],`
+          : ``
+      }${
+        context
+          ? `
+      context=dict(${Object.entries(context)
+        .map(
+          ([k, v]) => `
+          ${k}="${v}"`,
+        )
+        .join(',')}
+      )`
+          : ''
+      }
+  )
 
-    // response = await fga_client.list_users(body, options)
+  response = await fga_client.list_users(body, options)
 
     // # response.users = [${expectedResults.users.map((u) => JSON.stringify(u)).join(',')}]`;
     case SupportedLanguage.RPC:
@@ -329,7 +330,7 @@ export function ListUsersRequestViewer(opts: ListUsersRequestViewerOpts): JSX.El
     SupportedLanguage.JS_SDK,
     SupportedLanguage.GO_SDK,
     SupportedLanguage.DOTNET_SDK,
-    // SupportedLanguage.PYTHON_SDK,
+    SupportedLanguage.PYTHON_SDK,
     SupportedLanguage.JAVA_SDK,
     SupportedLanguage.CLI,
     SupportedLanguage.CURL,

--- a/src/components/Docs/SnippetViewer/ListUsersRequestViewer.tsx
+++ b/src/components/Docs/SnippetViewer/ListUsersRequestViewer.tsx
@@ -262,7 +262,7 @@ var response = await fgaClient.ListUsers(body, options);
 
   response = await fga_client.list_users(body, options)
 
-    // # response.users = [${expectedResults.users.map((u) => JSON.stringify(u)).join(',')}]`;
+  # response.users = [${expectedResults.users.map((u) => JSON.stringify(u)).join(',')}]`;
     case SupportedLanguage.RPC:
       return `listUsers(
   "${objectId}", // list the objects that the user \`${objectId}\`

--- a/src/components/Docs/SnippetViewer/ListUsersRequestViewer.tsx
+++ b/src/components/Docs/SnippetViewer/ListUsersRequestViewer.tsx
@@ -229,11 +229,11 @@ var response = await fgaClient.ListUsers(body, options);
   }
 
   userFilters = [
-      UserTypeFilter(type="${userFilterType}"${userFilterRelation ? `, relation="${userFilterRelation}"` : ''})
+      UserTypeFilter(type="${userFilterType}"${userFilterRelation ? `,relation="${userFilterRelation}"` : ''})
   ]
 
   body = ClientListUsersRequest(
-      object="${objectId}:${objectId}",
+      object=FgaObject(type="${objectType}"${objectId ? `,id="${objectId}"` : ''}),
       relation="${relation}",
       user_filters=userFilters,${
         contextualTuples


### PR DESCRIPTION
## Description

Adds support for producing a python example for the list users snippet code

![image](https://github.com/openfga/openfga.dev/assets/8705251/b36849f6-99f6-48e4-92a7-9de625bb6fbd)


## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
