### PR TITLE
Remove mentions of ListUsers excluded users 

### DIFF
--- a/blog/list-users-announcement.md
+++ b/blog/list-users-announcement.md
@@ -26,10 +26,6 @@ The new functionality is available on the latest versions of the [Java](https://
 
 We'll be releasing support for the Python SDK soon.
 
-## What's next?
-
-We have a [limitation](https://openfga.dev/docs/getting-started/perform-list-users#exclusion-of-nested-usersets) we are working on regarding the behavior of the `excluded_users` return value that we'll address before removing the experimental flag.
-
 ## We want your feedback!
 
 We want to learn how you use this API and how we can improve it!

--- a/docs/content/concepts.mdx
+++ b/docs/content/concepts.mdx
@@ -620,8 +620,7 @@ For example, the following returns all the users of type `user` that have the `v
     users: [
       { object: { type: "user", id: "anne" }}, 
       { object: { type: "user", id: "beth" }}
-    ],
-    excluded_users: []
+    ]
   }}
 />
 

--- a/docs/content/getting-started/perform-list-users.mdx
+++ b/docs/content/getting-started/perform-list-users.mdx
@@ -23,7 +23,7 @@ import TabItem from '@theme/TabItem';
 # Perform a List Users call
 
 :::caution Warning
-List Users is currently an experimental feature and not yet suitable for production. There are [known limitations](#known-limitations) to be aware of. Read [the announcement](https://openfga.dev/blog/list-users-announcement) for more information.
+List Users is currently an experimental feature and not yet suitable for production. Read [the announcement](https://openfga.dev/blog/list-users-announcement) for more information.
 :::
 
 <DocumentationNotice />
@@ -155,8 +155,7 @@ To return all users of type `user` that have have the `reader` relationship with
   relation="reader"
   userFilterType="user"
   expectedResults={{
-    users: [{ object: { type: "user", id: "anne" } }, { object: { type: "user", id: "beth" } }],
-    excluded_users: []
+    users: [{ object: { type: "user", id: "anne" } }, { object: { type: "user", id: "beth" } }]
   }}
   skipSetup={true}
   allowedLanguages={[
@@ -227,8 +226,7 @@ Then calling the List Users API for `document:1` with relation `viewer` of type 
         relation:"member",
         type:"group"
       }
-    }],
-    excluded_users: []
+    }]
   }}
   skipSetup={true}
   allowedLanguages={[
@@ -244,7 +242,11 @@ Then calling the List Users API for `document:1` with relation `viewer` of type 
 
 ## Type-bound Public Access
 
-The List Users API supports tuples expressing public access via the wildcard syntax (e.g. `user:*`). Wildcard tuples that satisfy the query criteria will be returned with the `wildcard` root object property that will specify the type. The API will not expand wildcard results further to any ID'd subjects. Further, specific users that have been granted accesss will be returned in addition to any public acccess for that user's type.
+The List Users API supports tuples expressing public access via the wildcard syntax (e.g. `user:*`). Wildcard tuples that satisfy the query criteria will be returned with the `wildcard` root object property that will specify the type. A typed-bound public access result indicates that the object has a public relation but it doesn't necessarily indicate that all users of that type have that relation, it is possible that exclusions via the `but not` syntax exists. The API will not expand wildcard results further to any ID'd subjects. Further, specific users that have been granted accesss will be returned in addition to any public acccess for that user's type.
+
+:::caution
+**Note:** A ListUsers response with a type-bound public access result (e.g. `user:*`) doesn't necessarily indicate that all users of that type have acces, it is possible that exclusions exist. It is recommended to [perform a Check](./perform-check.mdx) on specific users to ensure they have access to the target object.
+:::
 
 Example response with type-bound public access:
 
@@ -262,101 +264,9 @@ Example response with type-bound public access:
         "id":"anne"
       }
     }
-  ],
-  "excluded_users":[]
-}
-
-```
-
-## Excluded Users
-
-In certain cases, it is important to communicate that certain users are excluded from returned usersets and do not have a relation to the target obect. Most notably, this occurs in models with type-bound public access via wildcard syntax (e.g. `user:*`) and negation via the `but not` syntax. 
-
-Below is an example where excluded users are returned:
-
-```dsl.openfga
-model
-  schema 1.1
-
-type user
-
-type document
-  relations
-    define viewer: [user:*] but not blocked
-    define blocked: [user]
-```
-
-With the tuples:
-
-| user | relation| object|
-|------|---------|-------|
-| user:* | viewer| document:1|
-| user:anne | blocked| document:1|
-
-Calling the List Users API for `document:1` with relation `viewer` of type `user` will yield the response below. It indicates that any object of type `user` (including those not already in OpenFGA as parts of tuples) has access to the system, except for a `user` with id `anne`.
-
-```json
-{
-  "users": [
-    { "wildcard": { "type": "user" } }
-  ],
-  "excluded_users": [
-    { "object": { "type": "user", "id": "anne" } }
   ]
 }
-```
 
-## Known Limitations
-
-The List Users API is currently available in an experimental capacity and is not yet suitable for production. There are known limitations to note below.
-
-### Exclusion of Nested Usersets
-
-Usersets that are nested within other usersets inherit access their parents' resources by virtue of their nesting. However, child usersets that are negated via the `but not` syntax to either the parent userset or the target document will _not_ be included in the `excluded_users` portion of the payload. 
-
-Example:
-
-```dsl.openfga
-model
-  schema 1.1
-
-type user
-
-type group
-  relations
-    define member: [group#member, user] but not blocked
-    define blocked: [group#member, user]
-
-type document
-  relations
-    define viewer: [group#member]
-```
-
-With the tuples:
-
-| user | relation| object|
-|------|---------|-------|
-| group:A#member | viewer| document:1|
-| group:B#member | member| group:A|
-| group:B#member | blocked| group:A|
-
-<br/>
-
-Then calling the List Users API for `document:1` with relation `viewer` of type `group#member` will yield the response below. Note that `group:B#member` is omitted from `excluded_users`. This omission is problematic for authorization decisions because the response could be interpreted that `group:B#member` has access by virtue of `group:A#member`. 
-
-```json
-{
-  "users": [
-    {
-      "userset": {
-        "id":"A",
-        "relation":"member",
-        "type":"group"
-      }
-    }
-  ],
-  "excluded_users": [] // `excluded_users` should have `group:B#member`
-}
 ```
 
 ## Related Sections

--- a/docs/content/modeling/testing-models.mdx
+++ b/docs/content/modeling/testing-models.mdx
@@ -82,7 +82,7 @@ Tests have the following structure:
 |`tuples` | A set of tuples that are only considered for the test | 
 |`check` | A set of tests for Check calls, each with a user/object and a set of assertions |
 |`list_objects` | A set of tests for ListObjects calls, each one with a user/type and a set of assertions for any number of relations|
-|`list_users` | A set of tests for ListUsers calls, each one with an object and user filter and a set of assertions for the users and excluded_users for any number of relations |
+|`list_users` | A set of tests for ListUsers calls, each one with an object and user filter and a set of assertions for the users for any number of relations |
 
 ## Write Check tests
 
@@ -165,9 +165,8 @@ Each list users verification has the following structure:
 |`assertions` | A list of assertions to make |
 |`<relation>` | The name of the relation you want to verify |
 |`<relation>.users` | The users who should have the stated relation to the object |
-|`<relation>.excluded_users` | The users who should have explicitly not have access to the object due to evaluations of type bound public access and negation (e.g. "all users except anne") |
 
-In order to simplify test writing, the following syntax is supported for the various object types included in `users` and `excluded_users` from the API response:
+In order to simplify test writing, the following syntax is supported for the various object types included in `users` from the API response:
 
 * `<type>:<id>` to represent a userset that is a user
 * `<type>:<id>#<relation>` to represent a userset that is a relation on a type
@@ -184,10 +183,8 @@ The following is an example of using the `list_users` option in <ProductName for
             member:
               users:
                 - user:anne
-              excluded_users: []
             admin:
               users: []
-              excluded_users: []
               
       - object: organization:acme
         user_filter:
@@ -197,11 +194,9 @@ The following is an example of using the `list_users` option in <ProductName for
         assertions:
             member:
               users: []
-              excluded_users: []
             admin:
               users:
                 - employee:peter
-              excluded_users: []
 
 ```
 The example above checks that `user:anne` has access to the `organization:acme` as a member and is not an admin of any organization. It also checks that `employee:peter`, given the current time is February 1st 2024, 0:10 AM, is not related to any organization as a member, but is related to `organization:acme` as an admin.

--- a/src/components/Docs/SnippetViewer/ListUsersRequestViewer.tsx
+++ b/src/components/Docs/SnippetViewer/ListUsersRequestViewer.tsx
@@ -32,19 +32,18 @@ function listUsersRequestViewer(lang: SupportedLanguage, opts: ListUsersRequestV
   } = opts;
   const modelId = opts.authorizationModelId ? opts.authorizationModelId : DefaultAuthorizationModelId;
 
-  const response = `{"users": [${expectedResults.users.map((r) => JSON.stringify(r)).join(', ')}],"excluded_users":[${expectedResults.excluded_users.map((r) => JSON.stringify(r)).join(', ')}]}`;
+  const response = `{"users": [${expectedResults.users.map((r) => JSON.stringify(r)).join(', ')}]}`;
 
   switch (lang) {
     case SupportedLanguage.PLAYGROUND:
       return `# Note: List Users is not currently supported on the playground`;
     case SupportedLanguage.CLI:
-      return `fga query list-users --store-id=\${FGA_STORE_ID} --model-id=${modelId} --object ${objectType}:${objectId} --relation ${relation} --user-filter ${userFilterType}${userFilterRelation ? `#${userFilterRelation}` : ''} ${
-        contextualTuples
-          ? `${contextualTuples
-              .map((tuple) => ` --contextual-tuple "${tuple.user} ${tuple.relation} ${tuple.object}"`)
-              .join(' ')}`
-          : ''
-      }${context ? ` --context='${JSON.stringify(context)}'` : ''}
+      return `fga query list-users --store-id=\${FGA_STORE_ID} --model-id=${modelId} --object ${objectType}:${objectId} --relation ${relation} --user-filter ${userFilterType}${userFilterRelation ? `#${userFilterRelation}` : ''} ${contextualTuples
+        ? `${contextualTuples
+          .map((tuple) => ` --contextual-tuple "${tuple.user} ${tuple.relation} ${tuple.object}"`)
+          .join(' ')}`
+        : ''
+        }${context ? ` --context='${JSON.stringify(context)}'` : ''}
 
 # Response: ${response}`;
     case SupportedLanguage.CURL:
@@ -61,16 +60,14 @@ function listUsersRequestViewer(lang: SupportedLanguage, opts: ListUsersRequestV
         "relation": "${relation}",
         "user_filters": [
           { 
-            "type": "${userFilterType}"${
-              userFilterRelation
-                ? `,
+            "type": "${userFilterType}"${userFilterRelation
+          ? `,
             "relation": "${userFilterRelation}"`
-                : ''
-            }
+          : ''
+        }
           }
-        ]${
-          contextualTuples
-            ? `,
+        ]${contextualTuples
+          ? `,
         "contextual_tuples": {
           "tuple_keys": [${contextualTuples
             .map(
@@ -80,12 +77,11 @@ function listUsersRequestViewer(lang: SupportedLanguage, opts: ListUsersRequestV
             .join(',')}
           ]
         }`
-            : ''
-        }${
-          context
-            ? `,
+          : ''
+        }${context
+          ? `,
         "context":${JSON.stringify(context)}`
-            : ''
+          : ''
         }
     }'
 
@@ -99,39 +95,35 @@ function listUsersRequestViewer(lang: SupportedLanguage, opts: ListUsersRequestV
     id: "${objectId}"
   },
   user_filters: [{
-    type: "${userFilterType}"${
-      userFilterRelation
-        ? `,
+    type: "${userFilterType}"${userFilterRelation
+          ? `,
     relation: "${userFilterRelation}"`
-        : ''
-    }
+          : ''
+        }
   }],
-  relation: "${relation}",${
-    contextualTuples?.length
-      ? `
+  relation: "${relation}",${contextualTuples?.length
+          ? `
       contextualTuples: {
     tuple_keys: [${contextualTuples
-      .map(
-        (tupleKey) => `{
+            .map(
+              (tupleKey) => `{
       user: "${tupleKey.user}",
       relation: "${tupleKey.relation}",
       object: "${tupleKey.object}"
     }`,
-      )
-      .join(', ')}]
+            )
+            .join(', ')}]
   },`
-      : ''
-  }${
-    context
-      ? `
+          : ''
+        }${context
+          ? `
   context:${JSON.stringify(context)},`
-      : ''
-  }
+          : ''
+        }
 }, {
   authorization_model_id: "${modelId}",
 });
-// response.users = [${expectedResults.users.map((u) => JSON.stringify(u)).join(',')}]
-// response.excluded_users = [${expectedResults.excluded_users.map((u) => JSON.stringify(u)).join(',')}]`;
+// response.users = [${expectedResults.users.map((u) => JSON.stringify(u)).join(',')}]`;
     case SupportedLanguage.GO_SDK:
       /* eslint-disable no-tabs */
       return `options := ClientListUsersOptions{
@@ -146,32 +138,29 @@ body := ClientListUsersRequest{
         Id:      "${objectId}",
     },
     Relation:     "${relation}",
-    UserFilters:   userFilters,${
-      !contextualTuples
-        ? ''
-        : `
+    UserFilters:   userFilters,${!contextualTuples
+          ? ''
+          : `
     ContextualTuples: []ClientContextualTupleKey{
-${
-  !contextualTuples
-    ? ''
-    : contextualTuples
-        .map(
-          (tuple) =>
-            `        {
+${!contextualTuples
+            ? ''
+            : contextualTuples
+              .map(
+                (tuple) =>
+                  `        {
              User:     "${tuple.user}",
              Relation: "${tuple.relation}",
              Object:   "${tuple.object}",
         },`,
-        )
-        .join('\n')
-}
+              )
+              .join('\n')
+          }
     },`
-    }${
-      context
-        ? `
+        }${context
+          ? `
     Context: &map[string]interface{}${JSON.stringify(context)},`
-        : ''
-    }
+          : ''
+        }
 }
 
 data, err := fgaClient.ListUsers(context.Background()).
@@ -179,8 +168,7 @@ data, err := fgaClient.ListUsers(context.Background()).
     Options(options).
     Execute()
 
-// data.Users = [${expectedResults.users.map((u) => JSON.stringify(u)).join(', ')}]
-// data.ExcludedUsers = [${expectedResults.excluded_users.map((u) => JSON.stringify(u)).join(', ')}]`;
+// data.Users = [${expectedResults.users.map((u) => JSON.stringify(u)).join(', ')}]`;
     case SupportedLanguage.DOTNET_SDK:
       return `
 var options = new ClientWriteOptions {
@@ -194,37 +182,33 @@ var body = new ClientListUsersRequest {
     Relation = "${relation}",
     UserFilters = new List<UserTypeFilter> {
       new() {
-        Type = "${userFilterType}"${
-          userFilterRelation
-            ? `
+        Type = "${userFilterType}"${userFilterRelation
+          ? `
         Relation = "${userFilterRelation}"
         `
-            : ''
+          : ''
         }
       }
-    }${
-      contextualTuples
-        ? `,
+    }${contextualTuples
+          ? `,
     ,ContextualTuples = new List<ClientTupleKey>({
     ${contextualTuples
-      .map((tuple) => `new(user: "${tuple.user}", relation: "${tuple.relation}", _object: "${tuple.object}")`)
-      .join(',\n    ')}
+            .map((tuple) => `new(user: "${tuple.user}", relation: "${tuple.relation}", _object: "${tuple.object}")`)
+            .join(',\n    ')}
 })`
-        : ''
-    }
-    ${
-      context
-        ? `Context = new { ${Object.entries(context)
+          : ''
+        }
+    ${context
+          ? `Context = new { ${Object.entries(context)
             .map(([k, v]) => `${k}="${v}"`)
             .join(',')} }`
-        : ''
-    }
+          : ''
+        }
 };
 
 var response = await fgaClient.ListUsers(body, options);
 
-// response.Users = [${expectedResults.users.map((u) => JSON.stringify(u)).join(',')}]
-// response.ExcludedUsers = [${expectedResults.excluded_users.map((u) => JSON.stringify(u)).join(',')}]`;
+// response.Users = [${expectedResults.users.map((u) => JSON.stringify(u)).join(',')}]`;
     case SupportedLanguage.PYTHON_SDK:
       return '';
     //       return `
@@ -264,23 +248,21 @@ var response = await fgaClient.ListUsers(body, options);
 
     // response = await fga_client.list_users(body, options)
 
-    // # response.users = [${expectedResults.users.map((u) => JSON.stringify(u)).join(',')}]
-    // # response.excludedUsers = [${expectedResults.excluded_users.map((u) => JSON.stringify(u)).join(',')}]`;
+    // # response.users = [${expectedResults.users.map((u) => JSON.stringify(u)).join(',')}]`;
     case SupportedLanguage.RPC:
       return `listUsers(
   "${objectId}", // list the objects that the user \`${objectId}\`
   "${relation}", // has an \`${relation}\` relation
   "${objectType}", // and that are of type \`${objectType}\`
-  authorization_model_id = "${modelId}", // for this particular authorization model id ${
-    contextualTuples
-      ? `
+  authorization_model_id = "${modelId}", // for this particular authorization model id ${contextualTuples
+          ? `
   contextual_tuples = [ // Assuming the following is true
     ${contextualTuples
-      .map((tuple) => `{user = "${tuple.user}", relation = "${tuple.relation}", object = "${tuple.object}"}`)
-      .join(',\n    ')}
+            .map((tuple) => `{user = "${tuple.user}", relation = "${tuple.relation}", object = "${tuple.object}"}`)
+            .join(',\n    ')}
   ]`
-      : ''
-  }
+          : ''
+        }
 );
 
 Reply: ${response}`;
@@ -290,13 +272,13 @@ Reply: ${response}`;
         ? `
         .contextualTupleKeys(
                 List.of(${contextualTuples.map(
-                  (tuple) => `
+          (tuple) => `
                         new ClientTupleKey()
                                 .user("${tuple.user}")
                                 .relation("${tuple.relation}")
                                 ._object("${tuple.object}")
                 ))`,
-                )}`
+        )}`
         : '';
       const contextCall = context
         ? `
@@ -321,8 +303,7 @@ var body = new ClientListUsersRequest()
 
 var response = fgaClient.listUsers(body, options).get();
 
-// response.getUsers() = [${expectedResults.users.map((u) => JSON.stringify(u)).join(',')}]
-// response.getExcludedUsers() = [${expectedResults.excluded_users.map((u) => JSON.stringify(u)).join(',')}]`;
+// response.getUsers() = [${expectedResults.users.map((u) => JSON.stringify(u)).join(',')}]`;
     }
     default:
       assertNever(lang);


### PR DESCRIPTION
## Description
Removes all mentions of `excluded_users` in the context of the ListUsers API. This feature was originally a well-intentioned way to communicate any negations that may exist on public-typed wildcard (e.g. `user:*`) as a means of being abundantly clear about what a `user:*` result entails. However, as we discover more possible situations where excluded users could arise, we realize that we were making a premature decision about the API. We fully intend to re-add `excluded_users` at some point in the future but may or may not be a flattened list as previously implemented.

## References
Removal from API: https://github.com/openfga/api/pull/171

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
