### PR TITLE
Remove ListUsers experimental warning

### DIFF
--- a/docs/content/getting-started/perform-list-users.mdx
+++ b/docs/content/getting-started/perform-list-users.mdx
@@ -22,10 +22,6 @@ import TabItem from '@theme/TabItem';
 
 # Perform a List Users call
 
-:::caution Warning
-List Users is currently an experimental feature and not yet suitable for production. Read [the announcement](https://openfga.dev/blog/list-users-announcement) for more information.
-:::
-
 <DocumentationNotice />
 
 This section will illustrate how to perform a <ProductConcept section="what-is-a-list-users-request" linkName="list users" /> request to determine all the <ProductConcept section="what-is-a-user" linkName="users" /> of a given <ProductConcept section="what-is-a-type" linkName="type" /> that have a specified <ProductConcept section="what-is-a-relationship" linkName="relationship" /> with a given <ProductConcept section="what-is-an-object" linkName="object" />.


### PR DESCRIPTION
## Description
Removing the ListUsers experimental warning as a show of confidence for production usage.

## References
Related PRs: (soon to come)

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
