### PR TITLE
fix: fix incorrect response in Gdrive modelling guide

### DIFF
--- a/docs/content/modeling/advanced/gdrive.mdx
+++ b/docs/content/modeling/advanced/gdrive.mdx
@@ -966,7 +966,7 @@ Beth is a member of the xyz.com domain, and so can comment but cannot write
 Erik is NOT a member of the xyz.com domain, and so can only view the document
 
 <CheckRequestViewer user={'user:erik'} relation={'writer'} object={'document:2021-public-roadmap'} allowed={false} />
-<CheckRequestViewer user={'user:erik'} relation={'viewer'} object={'document:2021-public-roadmap'} allowed={false} />
+<CheckRequestViewer user={'user:erik'} relation={'viewer'} object={'document:2021-public-roadmap'} allowed={true} />
 
 <Playground title="Google Drive" preset="drive" example="Google Drive" store="gdrive" />
 


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
Erik is mentioned in text to be a allowed viewer of the document when describing 'type bound public access' in Google Drive. But the code snippet says false. Took me some time to figure out.

## References
The relevant [text](https://openfga.dev/docs/modeling/advanced/gdrive#03-folder-permission-propagation:~:text=Erik%20is%20NOT%20a%20member%20of%20the%20xyz.com%20domain%2C%20and%20so%20can%20only%20view%20the%20document) in the documentation.

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
