### PR TITLE
fix(blog)!: rename 'stronger' to 'query' consistency options

### DIFF
--- a/blog/fine-grained-news-2024-07.md
+++ b/blog/fine-grained-news-2024-07.md
@@ -23,7 +23,7 @@ We value your feedback and invite you to participate in our [2024 OpenFGA Commun
 **Latest Features**
 
 
-- We’ve introduced consistency options for query requests. This new, experimental, feature provides more flexibility and control over how queries are executed, enhancing the accuracy and reliability of query results. [Learn more about this update](https://openfga.dev/blog/stronger-consistency-options-announcement).
+- We’ve introduced consistency options for query requests. This new, experimental, feature provides more flexibility and control over how queries are executed, enhancing the accuracy and reliability of query results. [Learn more about this update](https://openfga.dev/blog/query-consistency-options-announcement).
 
 
 - We’re now publishing images to `ghcr.io/openfga/openfga` as an alternative to DockerHub, thanks to the contribution from [@JAORMX](https://github.com/JAORMX). This provides an additional option for accessing and deploying our containers. [Read more](https://github.com/openfga/openfga/pull/1775).

--- a/blog/query-consistency-options-announcement.md
+++ b/blog/query-consistency-options-announcement.md
@@ -1,14 +1,14 @@
 ---
-title: Stronger Consistency Query Options
-description: Stronger Consistency Query Options
-slug: stronger-consistency-options-announcement
+title: Query Consistency Options in OpenFGA
+description: Query Consistency Options in OpenFGA
+slug: query-consistency-options-announcement
 date: 2024-07-30
 authors: aaguiar
 tags: [openfga,features]
 image: https://openfga.dev/img/og-rich-embed.png
 hide_table_of_contents: false
 ---
-# Stronger Consistency Query Options in OpenFGA
+# Query Consistency Options in OpenFGA
 
 OpenFGA query APIs now allows to specify the desired consistency of query results. By default, OpenFGA does not use a cache. However, when caching is enabled, it applies to all requests. This means that any changes in permissions won't be reflected in authorization checks during the cache TTL period.
 


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->
I renamed this post:
https://openfga.dev/pr-preview/pr-802/blog/query-consistency-options-announcement

And updated the link to it here:
https://openfga.dev/pr-preview/pr-802/blog/fine-grained-news-2024-07

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
