### PR TITLE
fix: correct some broken links due to site changes

### DIFF
--- a/docs/content/concepts.mdx
+++ b/docs/content/concepts.mdx
@@ -24,7 +24,7 @@ import {
 
 <DocumentationNotice />
 
-The <ProductName format={ProductNameFormat.ProductLink}/> service answers <IntroductionSection linkName="authorization" section="authentication-vs-authorization"/> [checks](#what-is-a-check-request) by determining whether a **[relationship](#what-is-a-relation)** exists between an [object](#what-is-an-object) and a [user](#what-is-a-user). Checks reference your **[authorization model](#what-is-an-authorization-model)** against your **[relationship tuples](#what-is-a-relationship-tuple)** for authorization authority. Below are explanations of basic FGA concepts, like type and authorization model, and a [playground](https://play.fga.dev/) to test your knowledge.
+The <ProductName format={ProductNameFormat.ProductLink}/> service answers <IntroductionSection linkName="authorization" section="authentication-and-authorization"/> [checks](#what-is-a-check-request) by determining whether a **[relationship](#what-is-a-relation)** exists between an [object](#what-is-an-object) and a [user](#what-is-a-user). Checks reference your **[authorization model](#what-is-an-authorization-model)** against your **[relationship tuples](#what-is-a-relationship-tuple)** for authorization authority. Below are explanations of basic FGA concepts, like type and authorization model, and a [playground](https://play.fga.dev/) to test your knowledge.
 
 <Playground />
 
@@ -343,7 +343,7 @@ For the following model, only [relationship tuples](#what-is-a-relationship-tupl
 
 A relationship tuple with user `user:anne` or `user:3f7768e0-4fa7-4e93-8417-4da68ce1846c` may be written for objects with type `document` and relation `viewer`, so writing `{"user": "user:anne","relation":"viewer","object":"document:roadmap"}` succeeds.
 A relationship tuple with a disallowed user type for the `viewer` relation on objects of type `document` - for example `workspace:auth0` or `folder:planning#editor` - will be rejected, so writing `{"user": "folder:product","relation":"viewer","object":"document:roadmap"}` will fail.
-This affects only relations that are [directly related](#what-are-direct-and-implied-relationships) and have [direct relationship type restrictions](./configuration-language.mdx#the-direct-relationship-type-restrictions) in their relation definition.
+This affects only relations that are [directly related](#what-are-direct-and-implied-relationships) and have [direct relationship type restrictions](./configuration-language.mdx#direct-relationship-type-restrictions) in their relation definition.
 
 </details>
 
@@ -443,13 +443,13 @@ An [authorization model](#what-is-an-authorization-model), together with [relati
 
 ## What Are Direct And Implied Relationships?
 
-A **direct relationship** (R) between user X and object Y means the relationship tuple (user=X, relation=R, object=Y) exists, and the <ProductName format={ProductNameFormat.ShortForm}/> authorization model for that relation allows the direct relationship because of [direct relationship type restrictions](./configuration-language.mdx#the-direct-relationship-type-restrictions)).
+A **direct relationship** (R) between user X and object Y means the relationship tuple (user=X, relation=R, object=Y) exists, and the <ProductName format={ProductNameFormat.ShortForm}/> authorization model for that relation allows the direct relationship because of [direct relationship type restrictions](./configuration-language.mdx#direct-relationship-type-restrictions)).
 
 An **implied (or computed) relationship** (R) exists between user X and object Y if user X is related to an object Z that is in a direct or implied relationship with object Y, and the <ProductName format={ProductNameFormat.ShortForm}/> authorization model allows it.
 
 </summary>
 
-- `user:anne` has a direct relationship with `document:new-roadmap` as `viewer` if the [type definition](#what-is-a-type-definition) allows it with [direct relationship type restrictions](./configuration-language.mdx#the-direct-relationship-type-restrictions), and one of the following [relationship tuples](#what-is-a-relationship-tuple) exist:
+- `user:anne` has a direct relationship with `document:new-roadmap` as `viewer` if the [type definition](#what-is-a-type-definition) allows it with [direct relationship type restrictions](./configuration-language.mdx#direct-relationship-type-restrictions), and one of the following [relationship tuples](#what-is-a-relationship-tuple) exist:
 
   - <RelationshipTuplesViewer
       relationshipTuples={[

--- a/docs/content/configuration-language.mdx
+++ b/docs/content/configuration-language.mdx
@@ -388,7 +388,7 @@ Above, `document` <ProductConcept section="what-is-a-type-definition" linkName="
 
 :::info
 
-`can_rename` does not reference the [direct relationship type restrictions](#the-direct-relationship-type-restrictions), which means a user cannot be directly assigned this relation and it must be inherited when the `editor` relation is assigned. Conversely, the `viewer` relation allows both direct and indirect relationships using the [Union Operator](#the-union-operator).
+`can_rename` does not reference the [direct relationship type restrictions](#direct-relationship-type-restrictions), which means a user cannot be directly assigned this relation and it must be inherited when the `editor` relation is assigned. Conversely, the `viewer` relation allows both direct and indirect relationships using the [Union Operator](#the-union-operator).
 
 :::
 
@@ -827,7 +827,7 @@ The JSON syntax accepted by the <ProductName format={ProductNameFormat.ShortForm
 
 | Zanzibar           | <ProductName format={ProductNameFormat.ShortForm}/> JSON | <ProductName format={ProductNameFormat.ShortForm}/> DSL |
 | :----------------- | :------------------------------------------------------- | :------------------------------------------------------ |
-| `this`             | `this`                                                   | [`[<type1>,<type2>]`](#the-direct-relationship-type-restrictions)                                                  |
+| `this`             | `this`                                                   | [`[<type1>,<type2>]`](#direct-relationship-type-restrictions)                                                  |
 | `union`            | `union`                                                  | `or`                                                    |
 | `intersection`     | `intersection`                                           | `and`                                                   |
 | `exclusion`        | `difference`                                             | `but not`                                               |

--- a/docs/content/getting-started/production-best-practices.mdx
+++ b/docs/content/getting-started/production-best-practices.mdx
@@ -16,10 +16,10 @@ import {
 
 The following list outlines best practices for running OpenFGA in a production environment:
 
-- [Configure Authentication](./setup-openfga/docker-setup.mdx#configuring-authentication)
+- [Configure Authentication](./setup-openfga/configure-openfga.mdx#configuring-authentication)
 - Enable HTTP TLS or gRPC TLS or both
 - Set the log format to "json" and log level to "info"
-- [Disable the Playground](./setup-openfga/docker-setup.mdx#playground)
+- [Disable the Playground](./setup-openfga/playground.mdx#disabling-the-playground)
 - [Set Cluster](#cluster-recommendations)
 - [Set Database Options](#database-recommendations)
 - [Set Maximum Results](#maximum-results)
@@ -36,7 +36,7 @@ We recommend:
 
 ## Database Recommendations
 
-To ensure good performance for OpenFGA, it is recommended that the [database](./setup-openfga/docker-setup.mdx#configuring-data-storage) be:
+To ensure good performance for OpenFGA, it is recommended that the [database](./setup-openfga/configure-openfga.mdx#configuring-data-storage) be:
 - Co-located in the same physical datacenter and network as your OpenFGA servers. This will minimize latency of database calls.
 - Used exclusively for OpenFGA and not shared with other applications. This allows scaling the database independently and avoiding contention with your database.
 - Bootstrapped and managed with the `openfga migrate` command. This will ensure the appropriate database indexes are created.
@@ -53,7 +53,7 @@ It's strongly recommended to fine-tune your server database connection settings 
 
 ## Concurrency Limits
 :::note
-Before modifying concurrency limits please make sure you've followed the guidance for [Database Recommendations](./#database-recommendations)
+Before modifying concurrency limits please make sure you've followed the guidance for [Database Recommendations](#database-recommendations)
 :::
 
 OpenFGA queries such as Check, ListObjects and ListUsers can be quite database and CPU intensive in some cases. If you notice that a single request is consuming a lot of CPU or creating a high degree of database contention, then you may consider setting some concurrency limits to protect other requests from being negatively impacted by overly aggressive queries. 

--- a/docs/content/interacting/relationship-queries.mdx
+++ b/docs/content/interacting/relationship-queries.mdx
@@ -303,7 +303,7 @@ There's two variations of the List Objects API.
 
 ### Caveats
 
-ListObjects will return the results found within the time allotted (`listObjectsDeadline`, default: `3s`) up to the maximum number of results configured (`listObjectsMaxResults`, default: `1000`). See [Configuring the Server](../getting-started/setup-openfga/docker-setup.mdx#configuring-the-server)) for more on how to change the default configuration.
+ListObjects will return the results found within the time allotted (`listObjectsDeadline`, default: `3s`) up to the maximum number of results configured (`listObjectsMaxResults`, default: `1000`). See [Configuring the Server](../getting-started/setup-openfga/configure-openfga.mdx)) for more on how to change the default configuration.
 
 - If you set `listObjectsDeadline` to `1s`, the server will spend at most 1 second finding results.
 - If you set `listObjectsMaxResults` to `10`, the server will return, at most, 10 objects.
@@ -336,7 +336,7 @@ Use the ListUsers API to get which users have a relation to a specific object.
 
 ### Caveats
 
-ListUsers will return the results found within the time allotted (`listUsersDeadline`, default: `3s`) up to the maximum number of results configured (`listUsersMaxResults`, default: `1000`). See [Configuring the Server](../getting-started/setup-openfga/docker-setup.mdx#configuring-the-server)) for more on how to change the default configuration.
+ListUsers will return the results found within the time allotted (`listUsersDeadline`, default: `3s`) up to the maximum number of results configured (`listUsersMaxResults`, default: `1000`). See [Configuring the Server](../getting-started/setup-openfga/configure-openfga.mdx)) for more on how to change the default configuration.
 
 - If you set `listUsersDeadline` to `1s`, the server will spend at most 1 second finding results.
 - If you set `listUsersMaxResults` to `10`, the server will return, at most, 10 objects.

--- a/docs/content/modeling/advanced/entitlements.mdx
+++ b/docs/content/modeling/advanced/entitlements.mdx
@@ -354,7 +354,7 @@ Add it now. Like so:
 
 In this tutorial, you will find the phrases <ProductConcept section="what-are-direct-and-implied-relationships" linkName="direct relationship and implied relationship" />.
 
-A _direct relationship_ R between user X and object Y means the relationship tuple (user=X, relation=R, object=Y) exists, and the <ProductName format={ProductNameFormat.ShortForm}/> authorization model for that relation allows this direct relationship (by use of [direct relationship type restrictions](../../configuration-language.mdx#the-direct-relationship-type-restrictions)).
+A _direct relationship_ R between user X and object Y means the relationship tuple (user=X, relation=R, object=Y) exists, and the <ProductName format={ProductNameFormat.ShortForm}/> authorization model for that relation allows this direct relationship (by use of [direct relationship type restrictions](../../configuration-language.mdx#direct-relationship-type-restrictions)).
 
 An _implied relationship_ R exists between user X and object Y if user X is related to an object Z that is in direct or implied relationship with object Y, and the <ProductName format={ProductNameFormat.ShortForm}/> authorization model allows it.
 
@@ -906,7 +906,7 @@ In this tutorial, you learned:
 - how to start with a set of requirements and scenarios and iterate on the <ProductName format={ProductNameFormat.ShortForm}/> authorization model until the checks match the expected scenarios
 - how to model [**parent-child relationships**](../parent-child.mdx) to indicate that a user having a relationship with a certain object implies having a relationship with another object in <ProductName format={ProductNameFormat.ShortForm}/>
 - how to use [**the union operator**](../../configuration-language.mdx#the-union-operator) condition to indicate multiple possible paths for a relationship between two objects to be computed
-- using [**direct relationship type restrictions**](../../configuration-language.mdx#the-direct-relationship-type-restrictions) in a <ProductName format={ProductNameFormat.ShortForm}/> authorization model, and how to block direct relationships by removing it
+- using [**direct relationship type restrictions**](../../configuration-language.mdx#direct-relationship-type-restrictions) in a <ProductName format={ProductNameFormat.ShortForm}/> authorization model, and how to block direct relationships by removing it
 
 <Playground title="Entitlements" preset="entitlements" example="Entitlements" store="entitlements" />
 

--- a/docs/content/modeling/advanced/iot.mdx
+++ b/docs/content/modeling/advanced/iot.mdx
@@ -717,7 +717,7 @@ To remedy this, remove `[user]` from `live_video_viewer`, `recorded_video_viewer
 
 :::info
 
-Notice that any reference to the [**direct relationship type restrictions**](../../configuration-language.mdx#the-direct-relationship-type-restrictions) has been removed. That indicates that a user cannot have a <ProductConcept section="what-are-direct-and-implied-relationships" linkName="direct relationship" /> with an object in this type.
+Notice that any reference to the [**direct relationship type restrictions**](../../configuration-language.mdx#direct-relationship-type-restrictions) has been removed. That indicates that a user cannot have a <ProductConcept section="what-are-direct-and-implied-relationships" linkName="direct relationship" /> with an object in this type.
 
 With this change, `anne` can no longer have a `live_video_viewer` permission for `device:1` except through having a `security_guard` or `it_admin` role first, and when she loses access to that role, she will automatically lose access to the `live_video_viewer` permission.
 
@@ -749,7 +749,7 @@ To test this, we can add a new user `emily`. Emily is **not** a `security_guard`
   ]}
 />
 
-Now try to query `is emily related to device:1 as live_video_viewer?`. The returned result should be `emily is not related to device:1 as live_video_viewer`. This confirms that direct relations have no effect on the `live_video_viewer` relations, and that is because the [**direct relationship type restriction**](../../configuration-language.mdx#the-direct-relationship-type-restrictions) was removed from the relation configuration.
+Now try to query `is emily related to device:1 as live_video_viewer?`. The returned result should be `emily is not related to device:1 as live_video_viewer`. This confirms that direct relations have no effect on the `live_video_viewer` relations, and that is because the [**direct relationship type restriction**](../../configuration-language.mdx#direct-relationship-type-restrictions) was removed from the relation configuration.
 
 <CheckRequestViewer user={'user:emily'} relation={'live_video_viewer'} object={'device:1'} allowed={false} />
 
@@ -762,7 +762,7 @@ Query on the other relationships and you will see:
 
 ## Summary
 
-In this post, you were introduced to <IntroductionSection linkName="fine grain authentication" section="what-is-fine-grained-authorization-fga"/> and <ProductName format={ProductNameFormat.LongForm}/>.
+In this post, you were introduced to <IntroductionSection linkName="fine grain authentication" section="what-is-fine-grained-authorization"/> and <ProductName format={ProductNameFormat.LongForm}/>.
 
 Upcoming posts will dive deeper into <ProductName format={ProductNameFormat.LongForm}/>, introducing concepts that will improve on the model you built today, and tackling more complex permission systems, with more relations and requirements that need to be met.
 

--- a/docs/content/modeling/advanced/slack.mdx
+++ b/docs/content/modeling/advanced/slack.mdx
@@ -201,7 +201,7 @@ Here is how you would express than in <ProductName format={ProductNameFormat.Sho
 - Member (`member`)
 - Guest (`guest`)
 
-[Direct relationship type restrictions](../../configuration-language.mdx#the-direct-relationship-type-restrictions) indicate that a user can have a <ProductConcept section="what-are-direct-and-implied-relationships" linkName="direct relationship" /> with an object of the type the relation specifies.
+[Direct relationship type restrictions](../../configuration-language.mdx#direct-relationship-type-restrictions) indicate that a user can have a <ProductConcept section="what-are-direct-and-implied-relationships" linkName="direct relationship" /> with an object of the type the relation specifies.
 
 :::
 
@@ -888,12 +888,12 @@ Repeat this for the following relations
 
 ## Summary
 
-- Have a basic understanding of <IntroductionSection linkName="authorization" section="authentication-vs-authorization"/> and <ProductConcept/>.
+- Have a basic understanding of <IntroductionSection linkName="authorization" section="authentication-and-authorization"/> and <ProductConcept/>.
 - Understand how to model authorization for a communication platform like Slack using <ProductName format={ProductNameFormat.ProductLink}/>.
 
 In this tutorial, you:
 
-- were introduced to <IntroductionSection linkName="fine grain authentication" section="what-is-fine-grained-authorization-fga"/> and <ProductName format={ProductNameFormat.ProductLink}/>.
+- were introduced to <IntroductionSection linkName="fine grain authentication" section="what-is-fine-grained-authorization"/> and <ProductName format={ProductNameFormat.ProductLink}/>.
 - learned how to build and test an <ProductName format={ProductNameFormat.LongForm}/> authorization model for a communication platforms like Slack.
 
 Upcoming tutorials will dive deeper into <ProductName format={ProductNameFormat.LongForm}/>, introducing concepts that will improve on the model you built today, and tackling different permission systems, with other relations and requirements that need to be met.

--- a/docs/content/modeling/building-blocks/direct-relationships.mdx
+++ b/docs/content/modeling/building-blocks/direct-relationships.mdx
@@ -61,7 +61,7 @@ You need to know how to create an authorization model and create a relationship 
 - A <ProductConcept section="what-is-a-relation" linkName="Relation" />: is a string defined in the type definition of an authorization model that defines the possibility of a relationship between an object of the same type as the type definition and a user in the system
 - An <ProductConcept section="what-is-an-object" linkName="Object" />: represents an entity in the system. Users' relationships to it can be define through relationship tuples and the authorization model
 - A <ProductConcept section="what-is-a-relationship-tuple" linkName="Relationship Tuple" />: a grouping consisting of a user, a relation and an object stored in <ProductName format={ProductNameFormat.ShortForm}/>
-- [Direct Relationship Type Restrictions](../../configuration-language.mdx#the-direct-relationship-type-restrictions): used in the context of the relation definition can be used to allow direct relationships to the objects of this type
+- [Direct Relationship Type Restrictions](../../configuration-language.mdx#direct-relationship-type-restrictions): used in the context of the relation definition can be used to allow direct relationships to the objects of this type
 
 </details>
 
@@ -79,7 +79,7 @@ When checking for a relationship, a direct relationship exists if a _<ProductCon
 
 ## Enable Or Disable Direct Relationships
 
-Direct relationships can be enabled for a specific relation on an _<ProductConcept section="what-is-a-type" linkName="object type" />_ by adding [direct relationship type restrictions](../../configuration-language.mdx#the-direct-relationship-type-restrictions) from that <ProductConcept section="what-is-a-relation-definition" linkName="relation's definition" />. Likewise, they can be disabled by removing the direct relationship type restrictions.
+Direct relationships can be enabled for a specific relation on an _<ProductConcept section="what-is-a-type" linkName="object type" />_ by adding [direct relationship type restrictions](../../configuration-language.mdx#direct-relationship-type-restrictions) from that <ProductConcept section="what-is-a-relation-definition" linkName="relation's definition" />. Likewise, they can be disabled by removing the direct relationship type restrictions.
 
 <AuthzModelSnippetViewer
   configuration={{

--- a/docs/content/modeling/building-blocks/object-to-object-relationships.mdx
+++ b/docs/content/modeling/building-blocks/object-to-object-relationships.mdx
@@ -250,7 +250,7 @@ To do this, the authorization model will have two <ProductConcept section="what-
 
 Type `feature` has two relations, associated_plan and access. Relation `associated_plan` allows associating plans with features while `access` defines who can access the feature. In our case, the access can be achieved either from
 
-- <ProductConcept section="what-are-direct-and-implied-relationships" linkName="direct relationship" /> via  [direct relationship type restrictions](../../configuration-language.mdx#the-direct-relationship-type-restrictions).
+- <ProductConcept section="what-are-direct-and-implied-relationships" linkName="direct relationship" /> via  [direct relationship type restrictions](../../configuration-language.mdx#direct-relationship-type-restrictions).
   or `this`
 - object to object relationship where a user can access because it is a subscriber_member of a particular plan AND that plan is associated with the feature.
 

--- a/docs/content/modeling/getting-started.mdx
+++ b/docs/content/modeling/getting-started.mdx
@@ -31,7 +31,7 @@ import FGAIcon from '@site/static/img/getting-started-fga-logo.svg';
 
 <DocumentationNotice />
 
-Creating a <IntroductionSection linkName="Relationship Based Access Control (ReBAC)" section="what-is-relationship-based-access-control-rebac"/> authorization model might feel odd at first. Most of us tend to think about authorization models in terms of roles and permissions. After all, most software works like that. Your existing systems are likely built on a model using roles and permissions.
+Creating a <IntroductionSection linkName="Relationship Based Access Control (ReBAC)" section="what-is-relationship-based-access-control"/> authorization model might feel odd at first. Most of us tend to think about authorization models in terms of roles and permissions. After all, most software works like that. Your existing systems are likely built on a model using roles and permissions.
 
 This guide outlines a process for defining your <ProductConcept section="what-is-an-authorization-model" linkName="authorization model" /> with <ProductName format={ProductNameFormat.ProductLink}/>.
 
@@ -796,7 +796,7 @@ Why? This relation definition states that:
   - `{ user: "drive:{id}", relation: "parent", object: "document:{id}" }`
 
 
-We can use [direct type restriction](../configuration-language.mdx#the-direct-relationship-type-restrictions) to ensure a document's parent can only be an object of type either drive or folder.
+We can use [direct type restriction](../configuration-language.mdx#direct-relationship-type-restrictions) to ensure a document's parent can only be an object of type either drive or folder.
 
 :::note Side note
 You might have noticed that the "user" in the tuple is an object. This is a special syntax <ProductName format={ProductNameFormat.ShortForm}/> accepts in the "user" parameter to write [object to object relationships](./building-blocks/object-to-object-relationships.mdx). You can read more about writing data to manage object to object relationships in [Managing Relationships Between Objects](../interacting/managing-relationships-between-objects.mdx).
@@ -853,7 +853,7 @@ We can achieve that with the following definition using <UpdateProductNameInLink
 
 There are a few key things here:
 
-- **We don't use a [direct relationship type restriction](../configuration-language.mdx#the-direct-relationship-type-restrictions) as part of the definition.** can_share is a common example of representing a permission that is defined in terms of other relations but is not directly assignable by the system.
+- **We don't use a [direct relationship type restriction](../configuration-language.mdx#direct-relationship-type-restrictions) as part of the definition.** can_share is a common example of representing a permission that is defined in terms of other relations but is not directly assignable by the system.
 - The relation definition contains a [union operator](../configuration-language.mdx#the-union-operator) separating a list of relations that the user must have with the object in order to "be able to share the document". It is any of:
   - Being an owner of the document
   - Being an editor of the document

--- a/docs/content/modeling/roles-and-permissions.mdx
+++ b/docs/content/modeling/roles-and-permissions.mdx
@@ -103,7 +103,7 @@ Learn how to create an authorization model and create a relationship tuple to gr
 - An <ProductConcept section="what-is-an-object" linkName="Object" />: represents an entity in the system. Users' relationships to it can be define through relationship tuples and the authorization model
 - A <ProductConcept section="what-is-a-relationship-tuple" linkName="Relationship Tuple" />: a group consisting of a user, a relation, and an object stored in Auth <ProductName format={ProductNameFormat.ShortForm}/>
 - A <ProductConcept section="what-is-a-relationship" linkName="Relationship" />: <ProductName format={ProductNameFormat.ShortForm}/> will be called to check if there is a relationship between a user and an object, indicating that the access is allowed
-- [Direct Relationship Type Restrictions](../configuration-language.mdx#the-direct-relationship-type-restrictions): can be used to indicate direct relationships between users and objects
+- [Direct Relationship Type Restrictions](../configuration-language.mdx#direct-relationship-type-restrictions): can be used to indicate direct relationships between users and objects
 - A <ProductConcept section="what-is-a-check-request" linkName="Check API Request" />: used to check for relationships between users and objects
 
 </details>
@@ -157,7 +157,7 @@ In <ProductName format={ProductNameFormat.ShortForm}/>, roles are relations that
 
 ### 02. Add Permissions For Bookings
 
-In <ProductName format={ProductNameFormat.LongForm}/>, permissions are relations that users get only through other relations. To represent permissions, define the relation by other relations to indicate that it is a permission both granted to and implied from a different relation. Doing so avoids adding a [direct relationship type restriction](../configuration-language.mdx#the-direct-relationship-type-restrictions) to the relation in the authorization model.
+In <ProductName format={ProductNameFormat.LongForm}/>, permissions are relations that users get only through other relations. To represent permissions, define the relation by other relations to indicate that it is a permission both granted to and implied from a different relation. Doing so avoids adding a [direct relationship type restriction](../configuration-language.mdx#direct-relationship-type-restrictions) to the relation in the authorization model.
 
 To add permissions related to bookings, add new relations to the `trip` object type denoting the various actions a user can take on `trips`, like view, edit, or delete.
 
@@ -218,7 +218,7 @@ To allow `viewers` of a `trip` to view bookings and `owners` to add/view booking
   }}
 />
 
-> Note: Both `booking_viewer` and `booking_adder` don't have [direct relationship type restrictions](../configuration-language.mdx#the-direct-relationship-type-restrictions). This ensures that the relation can only be assigned through the role and not directly.
+> Note: Both `booking_viewer` and `booking_adder` don't have [direct relationship type restrictions](../configuration-language.mdx#direct-relationship-type-restrictions). This ensures that the relation can only be assigned through the role and not directly.
 
 ### 03. Checking User Roles And Their Permissions
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -64,8 +64,9 @@ const config = {
     description: `OpenFGA is an open source Fine-Grained Authorization solution based on Google's Zanzibar.`,
     productName: `OpenFGA`,
     // link to product description section (relative to baseURL)
-    introLink: `docs/intro`,
+    introLink: `docs/authorization-concepts`,
     productDescriptionSection: `#what-is-openfga`,
+    productDescriptionLink: `docs/fga`,
     // link to the concept page (relative to baseURL)
     conceptLink: `docs/concepts`,
     longProductName: `OpenFGA`,

--- a/src/components/Docs/ProductName/ProductName.tsx
+++ b/src/components/Docs/ProductName/ProductName.tsx
@@ -14,8 +14,7 @@ interface ProductNameOpts {
 // ProductName replaces the ProductName with the config's custom field value
 export function ProductName(opts: ProductNameOpts): JSX.Element {
   const { siteConfig } = useDocusaurusContext();
-  const productLink = (siteConfig.baseUrl +
-    ((siteConfig.customFields.introLink as string) + siteConfig.customFields.productDescriptionSection)) as string;
+  const productLink = (siteConfig.baseUrl + siteConfig.customFields.productDescriptionLink) as string as string;
   switch (opts.format) {
     case ProductNameFormat.ProductLink:
       return <a href={productLink}>{siteConfig.customFields.productName as string}</a>;


### PR DESCRIPTION
## Description

Fixes some links that have occurred due to refactoring and renaming of pages, the following warnings still exist but are not issues because it's down to docusaurus having issues locating the element rather than it not existing (this has been manually verified)

<details>
<summary>Docusaurus output</summary>

```
Exhaustive list of all broken anchors found:
- Broken anchor on source page path = /docs/concepts:
   -> linking to /api/service#Relationship%20Queries/Check
   -> linking to /api/service#Relationship%20Queries/ListObjects
   -> linking to /api/service#Relationship%20Queries/ListUsers
- Broken anchor on source page path = /docs/getting-started/configure-model:
   -> linking to /api/service#Authorization%20Models/WriteAuthorizationModel
- Broken anchor on source page path = /docs/getting-started/immutable-models:
   -> linking to /api/service#/Authorization%20Models/ReadAuthorizationModels
   -> linking to /api/service#/Relationship%20Queries/Check
   -> linking to /api/service#/Relationship%20Queries/ListObjects
   -> linking to /api/service#/Relationship%20Queries/ListUsers
   -> linking to /api/service#/Relationship%20Queries/Expand
   -> linking to /api/service#/Relationship%20Tuples/Write
- Broken anchor on source page path = /docs/getting-started/perform-check:
   -> linking to /api/service#Relationship%20Queries/Check
- Broken anchor on source page path = /docs/getting-started/perform-list-objects:
   -> linking to /api/service#Relationship%20Queries/ListObjects
- Broken anchor on source page path = /docs/getting-started/perform-list-users:
   -> linking to /api/service#Relationship%20Queries/ListUsers
- Broken anchor on source page path = /docs/interacting/relationship-queries:
   -> linking to /api/service#Relationship%20Queries/Check
   -> linking to /api/service#Relationship%20Tuples/Read
   -> linking to /api/service#/Relationship%20Queries/Expand
   -> linking to /api/service#/Relationship%20Queries/ListObjects
   -> linking to /api/service#Relationship%20Queries/ListObjects
   -> linking to /api/service#Relationship%20Queries/StreamedListObjects
   -> linking to /api/service#/Relationship%20Queries/ListUsers
   -> linking to /api/service#Relationship%20Queries/Expand
   -> linking to /api/service#Relationship%20Queries/ListUsers
- Broken anchor on source page path = /docs/interacting/transactional-writes:
   -> linking to /api/service#Relationship%20Tuples/Write
- Broken anchor on source page path = /docs/modeling/building-blocks/usersets:
   -> linking to /api/service#Relationship%20Queries/Expand
- Broken anchor on source page path = /docs/modeling/contextual-time-based-authorization:
   -> linking to /api/service#Relationship%20Queries/Check
- Broken anchor on source page path = /docs/modeling/organization-context-authorization:
   -> linking to /api/service#Relationship%20Queries/Check
- Broken anchor on source page path = /docs/modeling/token-claims-contextual-tuples:
   -> linking to /api/service#Relationship%20Queries/Check
- Broken anchor on source page path = /:
   -> linking to #quick-start (resolved as: /#quick-start)
   
```
</details>

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
