### PR TITLE
feat: Add docs for new Batch Check API endpoint

### DIFF
--- a/docs/content/getting-started/perform-check.mdx
+++ b/docs/content/getting-started/perform-check.mdx
@@ -175,11 +175,11 @@ This means you can use:
 - ULID `01JBMD9YG0XH3B4GVA8A9D2PSN`
 - or some other unique string
 
-But each `correlation_id` must be unique for the entire request.
+But each `correlation_id` within a request must be unique.
 
 Coming Soon: If you are using one of our SDKs, the `correlation_id` is inserted for you by default and automatically correlates the `allowed` response with the proper `tuple_key`.
 
-To check whether user `user:anne` has multiple relationships `can_edit, can_view` with object `document:Z`
+To check whether user `user:anne` has multiple relationships `can_edit` and `can_view` with object `document:Z`
 
 <BatchCheckRequestViewer
   checks={[

--- a/docs/content/getting-started/perform-check.mdx
+++ b/docs/content/getting-started/perform-check.mdx
@@ -142,11 +142,11 @@ To obtain the [access token](https://auth0.com/docs/get-started/authentication-a
 
 ### 02. Calling Check API
 
-To check whether user `user:anne` has relationship `reader` with object `document:Z`
+To check whether user `user:anne` has relationship `can_view` with object `document:Z`
 
 <CheckRequestViewer
   user={'user:anne'}
-  relation={'reader'}
+  relation={'can_view'}
   object={'document:Z'}
   allowed={true}
   skipSetup={true}
@@ -174,7 +174,26 @@ If you are using one of our SDKs, the `correlation_id` is inserted for you by de
 To check whether user `user:anne` has multiple relationships `can_edit, can_view` with object `document:Z`
 
 <BatchCheckRequestViewer
-  
+  checks={[
+    {
+      user: 'user:anne',
+      relation: 'can_edit',
+      object: 'document:Z',
+      correlation_id: '886224f6-04ae-4b13-bd8e-559c7d3754e1',
+      allowed: false
+    },
+    {
+      user: 'user:anne',
+      relation: 'can_view',
+      object: 'document:Z',
+      correlation_id: 'da452239-a4e0-4791-b5d1-fb3d451ac078',
+      allowed: true
+    }
+  ]}
+  skipSetup={true}
+  allowedLanguages={[
+    SupportedLanguage.CURL,
+  ]}
 />
 
 The result will include an `allowed` field for each authorization check that will return `true` if the relationship exists and `false` if the relationship does not exist.
@@ -193,7 +212,7 @@ The result will include an `allowed` field for each authorization check that wil
 />
 
 <RelatedSection
-  description="Take a look at the following section for more on how to perform authorization checks in your system"
+  description="Take a look at the following section for more on how to perform batch authorization checks in your system"
   relatedLinks={[
     {
       title: '{ProductName} Batch Check API',

--- a/docs/content/getting-started/perform-check.mdx
+++ b/docs/content/getting-started/perform-check.mdx
@@ -140,7 +140,7 @@ To obtain the [access token](https://auth0.com/docs/get-started/authentication-a
 </TabItem>
 </Tabs>
 
-### 02. Calling check API
+### 02. Calling Check API
 
 To check whether user `user:anne` has relationship `reader` with object `document:Z`
 
@@ -162,6 +162,12 @@ To check whether user `user:anne` has relationship `reader` with object `documen
 />
 
 The result's `allowed` field will return `true` if the relationship exists and `false` if the relationship does not exist.
+
+## Batch Check API
+
+If you want to make multiple checks consecutively, you can use the Batch Check API endpoint. 
+
+
 
 ## Related Sections
 

--- a/docs/content/getting-started/perform-check.mdx
+++ b/docs/content/getting-started/perform-check.mdx
@@ -168,7 +168,7 @@ The result's `allowed` field will return `true` if the relationship exists and `
 
 If you want to check multiple user-object-relationship combinations in a single request, you can use the [Batch Check](/api/service#Relationship%20Queries/BatchCheck) API endpoint. Batching authorization checks together in a single request significantly reduces overall network latency.    
 
-The Batch Check endpoint requires a `correlation_id` parameter for each check. The `correlation_id` is used to "correlate" the check respones with the checks sent in the request, since `tuple_keys` and `contextual_tuples` are not returned in the response to improve network latency. A `correlation_id` can be composed of any string of alphanumeric characters or dashes between 1-36 characters in length. 
+The Batch Check endpoint requires a `correlation_id` parameter for each check. The `correlation_id` is used to "correlate" the check respones with the checks sent in the request, since `tuple_keys` and `contextual_tuples` are not returned in the response on purpuse to reduce data transfer to improve network latency. A `correlation_id` can be composed of any string of alphanumeric characters or dashes between 1-36 characters in length. 
 This means you can use:
 - simple iterating integers `1,2,3,etc`
 - UUID `e5fe049b-f252-40b3-b795-fe485d588279`

--- a/docs/content/getting-started/perform-check.mdx
+++ b/docs/content/getting-started/perform-check.mdx
@@ -163,11 +163,21 @@ To check whether user `user:anne` has relationship `reader` with object `documen
 
 The result's `allowed` field will return `true` if the relationship exists and `false` if the relationship does not exist.
 
-## Batch Check API
+### 03. Calling Batch Check API
 
-If you want to make multiple checks consecutively, you can use the Batch Check API endpoint. 
+If you want to check multiple user-object-relationship combinations in a single request, you can use the [Batch Check](/api/service#Relationship%20Queries/BatchCheck) API endpoint. Batching authorization checks together in a single request significantly reduces overall network latency.    
 
+The Batch Check endpoint requires a `correlation_id` parameter for each check. The `correlation_id` is used to "correlate" the check respones with the checks sent in the request, since `tuple_keys` and `contextual_tuples` are not returned in the response to improve network latency. A `correlation_id` can be composed of any string of alphanumeric characters or dashes between 1-36 characters in length. This means you can use simple iterating integers `1,2,3,etc`, UUID `e5fe049b-f252-40b3-b795-fe485d588279`, ULID `01JBMD9YG0XH3B4GVA8A9D2PSN`, or something else, but they must be unique for the entire request.
 
+If you are using one of our SDKs, the `correlation_id` is inserted for you by default.
+
+To check whether user `user:anne` has multiple relationships `can_edit, can_view` with object `document:Z`
+
+<BatchCheckRequestViewer
+  
+/>
+
+The result will include an `allowed` field for each authorization check that will return `true` if the relationship exists and `false` if the relationship does not exist.
 
 ## Related Sections
 
@@ -178,6 +188,17 @@ If you want to make multiple checks consecutively, you can use the Batch Check A
       title: '{ProductName} Check API',
       description: 'Read the Check API documentation and see how it works.',
       link: '/api/service#Relationship%20Queries/Check',
+    },
+  ]}
+/>
+
+<RelatedSection
+  description="Take a look at the following section for more on how to perform authorization checks in your system"
+  relatedLinks={[
+    {
+      title: '{ProductName} Batch Check API',
+      description: 'Read the Batch Check API documentation and see how it works.',
+      link: '/api/service#Relationship%20Queries/BatchCheck',
     },
   ]}
 />

--- a/docs/content/getting-started/perform-check.mdx
+++ b/docs/content/getting-started/perform-check.mdx
@@ -177,7 +177,7 @@ This means you can use:
 
 But each `correlation_id` within a request must be unique.
 
-Coming Soon: If you are using one of our SDKs, the `correlation_id` is inserted for you by default and automatically correlates the `allowed` response with the proper `tuple_key`.
+*Coming Soon*: If you are using one of our SDKs, the `correlation_id` is inserted for you by default and automatically correlates the `allowed` response with the proper `tuple_key`.
 
 To check whether user `user:anne` has multiple relationships `can_edit` and `can_view` with object `document:Z`
 

--- a/docs/content/getting-started/perform-check.mdx
+++ b/docs/content/getting-started/perform-check.mdx
@@ -168,7 +168,7 @@ The result's `allowed` field will return `true` if the relationship exists and `
 
 If you want to check multiple user-object-relationship combinations in a single request, you can use the [Batch Check](/api/service#Relationship%20Queries/BatchCheck) API endpoint. Batching authorization checks together in a single request significantly reduces overall network latency.    
 
-The Batch Check endpoint requires a `correlation_id` parameter for each check. The `correlation_id` is used to "correlate" the check respones with the checks sent in the request, since `tuple_keys` and `contextual_tuples` are not returned in the response on purpuse to reduce data transfer to improve network latency. A `correlation_id` can be composed of any string of alphanumeric characters or dashes between 1-36 characters in length. 
+The Batch Check endpoint requires a `correlation_id` parameter for each check. The `correlation_id` is used to "correlate" the check respones with the checks sent in the request, since `tuple_keys` and `contextual_tuples` are not returned in the response on purpose to reduce data transfer to improve network latency. A `correlation_id` can be composed of any string of alphanumeric characters or dashes between 1-36 characters in length. 
 This means you can use:
 - simple iterating integers `1,2,3,etc`
 - UUID `e5fe049b-f252-40b3-b795-fe485d588279`
@@ -177,22 +177,22 @@ This means you can use:
 
 But each `correlation_id` within a request must be unique.
 
-*Coming Soon*: If you are using one of our SDKs, the `correlation_id` is inserted for you by default and automatically correlates the `allowed` response with the proper `tuple_key`.
+*Note*: If you are using one of our SDKs, the `correlation_id` is inserted for you by default and automatically correlates the `allowed` response with the proper `tuple_key`.
 
-To check whether user `user:anne` has multiple relationships `can_edit` and `can_view` with object `document:Z`
+To check whether user `user:anne` has multiple relationships `writer` and `reader` with object `document:Z`
 
 <BatchCheckRequestViewer
   checks={[
     {
       user: 'user:anne',
-      relation: 'can_edit',
+      relation: 'writer',
       object: 'document:Z',
       correlation_id: '886224f6-04ae-4b13-bd8e-559c7d3754e1',
       allowed: false
     },
     {
       user: 'user:anne',
-      relation: 'can_view',
+      relation: 'reader',
       object: 'document:Z',
       correlation_id: 'da452239-a4e0-4791-b5d1-fb3d451ac078',
       allowed: true

--- a/docs/content/getting-started/perform-check.mdx
+++ b/docs/content/getting-started/perform-check.mdx
@@ -168,7 +168,7 @@ The result's `allowed` field will return `true` if the relationship exists and `
 
 If you want to check multiple user-object-relationship combinations in a single request, you can use the [Batch Check](/api/service#Relationship%20Queries/BatchCheck) API endpoint. Batching authorization checks together in a single request significantly reduces overall network latency.    
 
-The Batch Check endpoint requires a `correlation_id` parameter for each check. The `correlation_id` is used to "correlate" the check respones with the checks sent in the request, since `tuple_keys` and `contextual_tuples` are not returned in the response on purpose to reduce data transfer to improve network latency. A `correlation_id` can be composed of any string of alphanumeric characters or dashes between 1-36 characters in length. 
+The Batch Check endpoint requires a `correlation_id` parameter for each check. The `correlation_id` is used to "correlate" the check responses with the checks sent in the request, since `tuple_keys` and `contextual_tuples` are not returned in the response on purpose to reduce data transfer to improve network latency. A `correlation_id` can be composed of any string of alphanumeric characters or dashes between 1-36 characters in length. 
 This means you can use:
 - simple iterating integers `1,2,3,etc`
 - UUID `e5fe049b-f252-40b3-b795-fe485d588279`

--- a/docs/content/getting-started/perform-check.mdx
+++ b/docs/content/getting-started/perform-check.mdx
@@ -169,7 +169,7 @@ If you want to check multiple user-object-relationship combinations in a single 
 
 The Batch Check endpoint requires a `correlation_id` parameter for each check. The `correlation_id` is used to "correlate" the check respones with the checks sent in the request, since `tuple_keys` and `contextual_tuples` are not returned in the response to improve network latency. A `correlation_id` can be composed of any string of alphanumeric characters or dashes between 1-36 characters in length. This means you can use simple iterating integers `1,2,3,etc`, UUID `e5fe049b-f252-40b3-b795-fe485d588279`, ULID `01JBMD9YG0XH3B4GVA8A9D2PSN`, or something else, but they must be unique for the entire request.
 
-If you are using one of our SDKs, the `correlation_id` is inserted for you by default.
+If you are using one of our SDKs, the `correlation_id` is inserted for you by default and automatically correlates the `allowed` response with the proper `tuple_key`.
 
 To check whether user `user:anne` has multiple relationships `can_edit, can_view` with object `document:Z`
 

--- a/docs/content/getting-started/perform-check.mdx
+++ b/docs/content/getting-started/perform-check.mdx
@@ -9,6 +9,7 @@ import {
   SupportedLanguage,
   languageLabelMap,
   CheckRequestViewer,
+  BatchCheckRequestViewer,
   DocumentationNotice,
   ProductConcept,
   ProductName,
@@ -167,9 +168,16 @@ The result's `allowed` field will return `true` if the relationship exists and `
 
 If you want to check multiple user-object-relationship combinations in a single request, you can use the [Batch Check](/api/service#Relationship%20Queries/BatchCheck) API endpoint. Batching authorization checks together in a single request significantly reduces overall network latency.    
 
-The Batch Check endpoint requires a `correlation_id` parameter for each check. The `correlation_id` is used to "correlate" the check respones with the checks sent in the request, since `tuple_keys` and `contextual_tuples` are not returned in the response to improve network latency. A `correlation_id` can be composed of any string of alphanumeric characters or dashes between 1-36 characters in length. This means you can use simple iterating integers `1,2,3,etc`, UUID `e5fe049b-f252-40b3-b795-fe485d588279`, ULID `01JBMD9YG0XH3B4GVA8A9D2PSN`, or something else, but they must be unique for the entire request.
+The Batch Check endpoint requires a `correlation_id` parameter for each check. The `correlation_id` is used to "correlate" the check respones with the checks sent in the request, since `tuple_keys` and `contextual_tuples` are not returned in the response to improve network latency. A `correlation_id` can be composed of any string of alphanumeric characters or dashes between 1-36 characters in length. 
+This means you can use:
+- simple iterating integers `1,2,3,etc`
+- UUID `e5fe049b-f252-40b3-b795-fe485d588279`
+- ULID `01JBMD9YG0XH3B4GVA8A9D2PSN`
+- or some other unique string
 
-If you are using one of our SDKs, the `correlation_id` is inserted for you by default and automatically correlates the `allowed` response with the proper `tuple_key`.
+But each `correlation_id` must be unique for the entire request.
+
+Coming Soon: If you are using one of our SDKs, the `correlation_id` is inserted for you by default and automatically correlates the `allowed` response with the proper `tuple_key`.
 
 To check whether user `user:anne` has multiple relationships `can_edit, can_view` with object `document:Z`
 
@@ -190,6 +198,7 @@ To check whether user `user:anne` has multiple relationships `can_edit, can_view
       allowed: true
     }
   ]}
+
   skipSetup={true}
   allowedLanguages={[
     SupportedLanguage.CURL,
@@ -208,12 +217,6 @@ The result will include an `allowed` field for each authorization check that wil
       description: 'Read the Check API documentation and see how it works.',
       link: '/api/service#Relationship%20Queries/Check',
     },
-  ]}
-/>
-
-<RelatedSection
-  description="Take a look at the following section for more on how to perform batch authorization checks in your system"
-  relatedLinks={[
     {
       title: '{ProductName} Batch Check API',
       description: 'Read the Batch Check API documentation and see how it works.',

--- a/docs/content/getting-started/setup-openfga/configure-openfga.mdx
+++ b/docs/content/getting-started/setup-openfga/configure-openfga.mdx
@@ -288,13 +288,15 @@ The following table enumerates the experimental flags, a description of what the
 
 | Name                       | Description                                                        | OpenFGA Version       |
 |----------------------------|--------------------------------------------------------------------|-----------------------|
-| otel-metrics               | Enables support for exposing OpenFGA metrics through OpenTelemetry | `0.3.2 <= v < v0.3.5` |
-| list-objects               | Enables ListObjects API                                            | `0.2.0 <= v < v0.3.3` |
-| check-query-cache          | Enables caching of check subproblem result                         | `1.3.1 <= v < v1.3.6` |
-| enable-conditions          | Enables conditional relationship tuples                            | `1.3.8 <= v < v1.4.0` |
-| enable-modular-models      | Enables modular authorization modules                              | `1.5.1 <= v < v1.5.3` |
+| otel-metrics               | Enables support for exposing OpenFGA metrics through OpenTelemetry | `0.3.2 <= v < 0.3.5`  |
+| list-objects               | Enables ListObjects API                                            | `0.2.0 <= v < 0.3.3`  |
+| check-query-cache          | Enables caching of check subproblem result                         | `1.3.1 <= v < 1.3.6`  |
+| enable-conditions          | Enables conditional relationship tuples                            | `1.3.8 <= v < 1.4.0`  |
+| enable-modular-models      | Enables modular authorization modules                              | `1.5.1 <= v < 1.5.3`  |
 | enable-list-users          | Enables new ListUsers API                                          | `1.5.4 <= v < 1.5.6`  |
-| enable-consistency-params  | Enables consistency options                                        | `1.5.6 <= v `         |
+| enable-consistency-params  | Enables consistency options                                        | `1.5.6 <= v < 1.6.0`  |
+| enable-check-optimizations | Enables performance optimization on Check                          | `1.6.2 <= v `         |
+| enable-access-control      | Enables the ability to configure and setup [access control](./access-control.mdx) | `1.7.0 <= v `         |
 
 :::caution Warning
 Experimental features are not guaranteed to be stable and may lead to server instabilities. It is not recommended to enable experimental features for anything other than experimentation.

--- a/docs/content/interacting/relationship-queries.mdx
+++ b/docs/content/interacting/relationship-queries.mdx
@@ -147,7 +147,7 @@ The [Batch Check API](/api/service#Relationship%20Queries/BatchCheck) is an API 
 Batching authorization checks together in a single request significantly reduces overall network latency.
 
 Two scenarios are common to use Batch Check:
-1. When determining if the user has access to a list of objects (such as [Option 1 in Search with Permissions](/docs/interacting/search-with-permissions#option-1-search-then-check)), filter and sort on your database, then call `/batch-check`. Repeat to perform pagination.
+1. When determining if the user has access to a list of objects (such as [Option 1 in Search with Permissions](/docs/interacting/search-with-permissions)), filter and sort on your database, then call `/batch-check`. Repeat to perform pagination.
 2. When determining fields on a web page the user has access to, call `/batch-check` for every relation necessary to show/hide each field.  
 
 For example, you can call Batch Check to determine whether `bob` has `can_view_name`, `can_view_dob`, and `can_view_ssn` relationships with `patient_record:1`.

--- a/docs/content/interacting/relationship-queries.mdx
+++ b/docs/content/interacting/relationship-queries.mdx
@@ -147,10 +147,10 @@ The [Batch Check API](/api/service#Relationship%20Queries/BatchCheck) is an API 
 Batching authorization checks together in a single request significantly reduces overall network latency.
 
 Two scenarios are common to use Batch Check:
-1. When determining if the user has access to a list of objects (such as [Option 1 in Search with Permissions](/docs/interacting/search-with-permissions#option-1-search-then-check)), filter and sort on your database, then call `/batch-check` for the first 50 objects. Repeat to perform pagination.
+1. When determining if the user has access to a list of objects (such as [Option 1 in Search with Permissions](/docs/interacting/search-with-permissions#option-1-search-then-check)), filter and sort on your database, then call `/batch-check`. Repeat to perform pagination.
 2. When determining fields on a web page the user has access to, call `/batch-check` for every relation necessary to show/hide each field.  
 
-For example, you can call Batch Check to determine whether `bob` has `can_view_name`, `can_view_dob`, and `can_view_ssn` relationship with `patient_record:1`.
+For example, you can call Batch Check to determine whether `bob` has `can_view_name`, `can_view_dob`, and `can_view_ssn` relationships with `patient_record:1`.
 
 <BatchCheckRequestViewer
   checks={[
@@ -184,11 +184,9 @@ The <ProductName format={ProductNameFormat.ShortForm}/> API will return `true` d
 
 ### Caveats and when not to use it
 
-Check is designed to answer the question "Does user:X have relationship Y with object:Z?". It is _not_ designed to answer the following questions:
+Currently, the Batch Check API endpoint has a limit of 50 checks per request.
 
-- "Who has relationship Y with object:Z?"
-- "What are the objects that userX has relationship Y with?"
-- "Why does user:X have relationship Y with object:Z?"
+If you are making less than 10 checks, it may be faster to call the [Check API](/api/service#Relationship%20Queries/Check) in parellel instead of Batch Check. 
 
 ## Read
 

--- a/docs/content/interacting/relationship-queries.mdx
+++ b/docs/content/interacting/relationship-queries.mdx
@@ -8,6 +8,7 @@ description: An overview of how to use the Check, Read, Expand, and ListObject A
 import {
   AuthzModelSnippetViewer,
   CheckRequestViewer,
+  BatchCheckRequestViewer,
   DocumentationNotice,
   ExpandRequestViewer,
   ListObjectsRequestViewer,
@@ -126,6 +127,60 @@ The <ProductName format={ProductNameFormat.ShortForm}/> API will return `true` b
 
 - every `writer` is also a `reader`
 - `bob` is a `writer` for `document:planning`
+
+### Caveats and when not to use it
+
+Check is designed to answer the question "Does user:X have relationship Y with object:Z?". It is _not_ designed to answer the following questions:
+
+- "Who has relationship Y with object:Z?"
+- "What are the objects that userX has relationship Y with?"
+- "Why does user:X have relationship Y with object:Z?"
+
+## Batch Check
+
+### What is it for?
+
+The [Batch Check API](/api/service#Relationship%20Queries/BatchCheck) is an API endpoint that allows you to check multiple user-object-relationship combinations in a single request. 
+
+### When to use?
+
+Batching authorization checks together in a single request significantly reduces overall network latency.
+
+Two scenarios are common to use Batch Check:
+1. When determining if the user has access to a list of objects (such as [Option 1 in Search with Permissions](/docs/interacting/search-with-permissions#option-1-search-then-check)), filter and sort on your database, then call `/batch-check` for the first 50 objects. Repeat to perform pagination.
+2. When determining fields on a web page the user has access to, call `/batch-check` for every relation necessary to show/hide each field.  
+
+For example, you can call Batch Check to determine whether `bob` has `can_view_name`, `can_view_dob`, and `can_view_ssn` relationship with `patient_record:1`.
+
+<BatchCheckRequestViewer
+  checks={[
+    {
+      user: 'user:bob',
+      relation: 'can_view_name',
+      object: 'patient_record:1',
+      correlation_id: '1',
+      allowed: true
+    },
+    {
+      user: 'user:bob',
+      relation: 'can_view_dob',
+      object: 'patient_record:1',
+      correlation_id: '2',
+      allowed: true
+    },
+    {
+      user: 'user:bob',
+      relation: 'can_view_ssn',
+      object: 'patient_record:1',
+      correlation_id: '3',
+      allowed: false
+    }
+  ]}
+  skipSetup={true}
+/>
+
+The <ProductName format={ProductNameFormat.ShortForm}/> API will return `true` depending on the level of access assigned to that user and the implied relationships inherited in the authorization model.
+
 
 ### Caveats and when not to use it
 

--- a/docs/content/interacting/relationship-queries.mdx
+++ b/docs/content/interacting/relationship-queries.mdx
@@ -147,7 +147,7 @@ The [Batch Check API](/api/service#Relationship%20Queries/BatchCheck) is an API 
 Batching authorization checks together in a single request significantly reduces overall network latency.
 
 Two scenarios are common to use Batch Check:
-1. When determining if the user has access to a list of objects (such as [Option 1 in Search with Permissions](/docs/interacting/search-with-permissions)), filter and sort on your database, then call `/batch-check`. Repeat to perform pagination.
+1. When determining if the user has access to a list of objects (such as [Option 1 in Search with Permissions]((./search-with-permissions.mdx#option-1-search-then-check))), filter and sort on your database, then call `/batch-check`. Repeat to perform pagination.
 2. When determining fields on a web page the user has access to, call `/batch-check` for every relation necessary to show/hide each field.  
 
 For example, you can call Batch Check to determine whether `bob` has `can_view_name`, `can_view_dob`, and `can_view_ssn` relationships with `patient_record:1`.

--- a/docs/content/interacting/relationship-queries.mdx
+++ b/docs/content/interacting/relationship-queries.mdx
@@ -184,9 +184,7 @@ The <ProductName format={ProductNameFormat.ShortForm}/> API will return `true` d
 
 ### Caveats and when not to use it
 
-Currently, the Batch Check API endpoint has a limit of 50 checks per request.
-
-If you are making less than 10 checks, it may be faster to call the [Check API](/api/service#Relationship%20Queries/Check) in parellel instead of Batch Check. 
+If you are making less than 10 checks, it may be faster to call the [Check API](/api/service#Relationship%20Queries/Check) in parallel instead of Batch Check. 
 
 ## Read
 

--- a/docs/content/interacting/relationship-queries.mdx
+++ b/docs/content/interacting/relationship-queries.mdx
@@ -147,7 +147,7 @@ The [Batch Check API](/api/service#Relationship%20Queries/BatchCheck) is an API 
 Batching authorization checks together in a single request significantly reduces overall network latency.
 
 Two scenarios are common to use Batch Check:
-1. When determining if the user has access to a list of objects (such as [Option 1 in Search with Permissions]((./search-with-permissions.mdx#option-1-search-then-check))), filter and sort on your database, then call `/batch-check`. Repeat to perform pagination.
+1. When determining if the user has access to a list of objects (such as [Option 1 in Search with Permissions](./search-with-permissions.mdx#option-1-search-then-check)), filter and sort on your database, then call `/batch-check`. Repeat to perform pagination.
 2. When determining fields on a web page the user has access to, call `/batch-check` for every relation necessary to show/hide each field.  
 
 For example, you can call Batch Check to determine whether `bob` has `can_view_name`, `can_view_dob`, and `can_view_ssn` relationships with `patient_record:1`.

--- a/docs/content/interacting/search-with-permissions.mdx
+++ b/docs/content/interacting/search-with-permissions.mdx
@@ -31,12 +31,12 @@ To return the set of results that match the user's search query, you will need t
 
 There are three possible ways to do this:
 
-### Option 1: search, then check
+### Option 1: Search, then check
 
-Pre-filter, then call <ProductName format={ProductNameFormat.ShortForm}/> Check endpoint.
+Pre-filter, then call <ProductName format={ProductNameFormat.ShortForm}/> Batch Check endpoint.
 
 1. Filter and sort on your database.
-1. Call [`/check`](./relationship-queries.mdx#check) in parallel on each object returned from your database.
+1. Call [`/batch-check`](./relationship-queries.mdx#batch-check) to check access for multiple objects in a single request.
 1. Filter out objects the user does not have access to.
 1. Return the filtered result to the user.
 

--- a/src/components/Docs/SnippetViewer/BatchCheckRequestViewer.tsx
+++ b/src/components/Docs/SnippetViewer/BatchCheckRequestViewer.tsx
@@ -58,7 +58,7 @@ function batchCheckRequestViewer(lang: SupportedLanguage, opts: BatchCheckReques
   "results": {
     ${checks
       .map(
-        (check) => `{ "${check.correlation_id}": { "allowed":${check.allowed} }}, # ${check.relation}
+        (check) => `{ "${check.correlation_id}": { "allowed": ${check.allowed} }}, # ${check.relation}
     `,
       )
       .join('')}

--- a/src/components/Docs/SnippetViewer/BatchCheckRequestViewer.tsx
+++ b/src/components/Docs/SnippetViewer/BatchCheckRequestViewer.tsx
@@ -67,7 +67,7 @@ function batchCheckRequestViewer(lang: SupportedLanguage, opts: BatchCheckReques
     }
 
     default:
-      assertNever(lang);
+      '';
   }
   /* eslint-enable no-tabs */
 }

--- a/src/components/Docs/SnippetViewer/BatchCheckRequestViewer.tsx
+++ b/src/components/Docs/SnippetViewer/BatchCheckRequestViewer.tsx
@@ -1,0 +1,70 @@
+import { getFilteredAllowedLangs, SupportedLanguage, DefaultAuthorizationModelId } from './SupportedLanguage';
+import { defaultOperationsViewer } from './DefaultTabbedViewer';
+import assertNever from 'assert-never/index';
+import { TupleKey } from '@openfga/sdk';
+
+interface Check {
+  user: string;
+  relation: string;
+  object: string;
+  correlation_id: string;
+  allowed: boolean;
+  contextualTuples?: TupleKey[];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  context?: Record<string, any>;
+}
+interface BatchCheckRequestViewerOpts {
+  authorizationModelId?: string;
+  checks: Check[];
+  skipSetup?: boolean;
+  allowedLanguages?: SupportedLanguage[];
+}
+
+function batchCheckRequestViewer(lang: SupportedLanguage, opts: BatchCheckRequestViewerOpts): string {
+  const { checks } = opts;
+  const modelId = opts.authorizationModelId ? opts.authorizationModelId : DefaultAuthorizationModelId;
+
+  switch (lang) {
+    case SupportedLanguage.CURL:
+      /* eslint-disable max-len */
+      return `curl -X POST $FGA_API_URL/stores/$FGA_STORE_ID/batch-check \\
+      -H "Authorization: Bearer $FGA_API_TOKEN" \\ # Not needed if service does not require authorization
+      -H "content-type: application/json" \\
+      -d '{"authorization_model_id": "${modelId}", "checks": [
+        ${checks.map((check) => `
+          {"tuple_key":{"user":"${check.user}","relation":"${check.relation}","object":"${check.object}"},"correlation_id": "da452239-a4e0-4791-b5d1-fb3d451ac078"}${
+          check.contextualTuples
+            ? `,"contextual_tuples":{"tuple_keys":[${check.contextualTuples
+                .map((tuple) => `{"user":"${tuple.user}","relation":"${tuple.relation}","object":"${tuple.object}"}`)
+                .join(',')}]}`
+            : ''
+        }${check.context ? `,"context":${JSON.stringify(check.context)}}` : '}'}
+      ]'
+        `
+      ).join(',')}
+        
+
+      # Response: {
+        "results": {
+          ${checks.map((check) => `{
+            "${check.correlation_id}": { "allowed":${check.allowed} }
+          }`
+        )}
+          
+        }
+        
+      }`;
+
+    default:
+      assertNever(lang);
+  }
+  /* eslint-enable no-tabs */
+}
+
+export function BatchCheckRequestViewer(opts: BatchCheckRequestViewerOpts): JSX.Element {
+  const defaultLangs = [
+    SupportedLanguage.CURL,
+  ];
+  const allowedLanguages = getFilteredAllowedLangs(opts.allowedLanguages, defaultLangs);
+  return defaultOperationsViewer<BatchCheckRequestViewerOpts>(allowedLanguages, opts, batchCheckRequestViewer);
+}

--- a/src/components/Docs/SnippetViewer/BatchCheckRequestViewer.tsx
+++ b/src/components/Docs/SnippetViewer/BatchCheckRequestViewer.tsx
@@ -25,6 +25,30 @@ function batchCheckRequestViewer(lang: SupportedLanguage, opts: BatchCheckReques
   const modelId = opts.authorizationModelId ? opts.authorizationModelId : DefaultAuthorizationModelId;
 
   switch (lang) {
+    case SupportedLanguage.PLAYGROUND:
+      return '';
+
+    case SupportedLanguage.CLI:
+      return '';
+
+    case SupportedLanguage.JS_SDK:
+      return '';
+
+    case SupportedLanguage.GO_SDK:
+      return '';
+
+    case SupportedLanguage.DOTNET_SDK:
+      return '';
+
+    case SupportedLanguage.PYTHON_SDK:
+      return '';
+
+    case SupportedLanguage.JAVA_SDK:
+      return '';
+
+    case SupportedLanguage.RPC:
+      return '';
+
     case SupportedLanguage.CURL: {
       /* eslint-disable max-len */
       return `curl -X POST $FGA_API_URL/stores/$FGA_STORE_ID/batch-check \\
@@ -67,7 +91,7 @@ function batchCheckRequestViewer(lang: SupportedLanguage, opts: BatchCheckReques
     }
 
     default:
-      '';
+      assertNever(lang);
   }
   /* eslint-enable no-tabs */
 }

--- a/src/components/Docs/SnippetViewer/index.ts
+++ b/src/components/Docs/SnippetViewer/index.ts
@@ -1,4 +1,5 @@
 export * from './CheckRequestViewer';
+export * from './BatchCheckRequestViewer';
 export * from './DefaultTabbedViewer';
 export * from './ExpandRequestViewer';
 export * from './ListObjectsRequestViewer';


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

Adding documentation to the "Perform a Check" doc giving the option to perform a Batch Check using the new API endpoint. 

## Description
- Added a new "Calling Batch Check API" section under the normal batch check
- Explained the purpose of the `correlation_id`, mentioning that the SDK handles it automatically (or it at least will very soon). 
- Created a BatchCheckRequestViewer component, but only with the CURL language, since the SDKs are not done. 

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected

If you haven't done so yet, we would appreciate it if you could star the [OpenFGA repository](https://github.com/openfga/openfga). :) 
