### PR TITLE
fix: correct type for contextual tuples in python

### DIFF
--- a/src/components/Docs/SnippetViewer/CheckRequestViewer.tsx
+++ b/src/components/Docs/SnippetViewer/CheckRequestViewer.tsx
@@ -162,9 +162,7 @@ body = ClientCheckRequest(
         ? `
     contextual_tuples=[
         ${contextualTuples
-          .map(
-            (tuple) => `ClientTupleKey(user="${tuple.user}", relation="${tuple.relation}", object="${tuple.object}")`,
-          )
+          .map((tuple) => `ClientTuple(user="${tuple.user}", relation="${tuple.relation}", object="${tuple.object}")`)
           .join(',\n                ')}
     ],`
         : ``

--- a/src/components/Docs/SnippetViewer/ListObjectsRequestViewer.tsx
+++ b/src/components/Docs/SnippetViewer/ListObjectsRequestViewer.tsx
@@ -182,9 +182,7 @@ body = ClientListObjectsRequest(
         ? `
     contextual_tuples=[
         ${contextualTuples
-          .map(
-            (tuple) => `ClientTupleKey(user="${tuple.user}", relation="${tuple.relation}", object="${tuple.object}")`,
-          )
+          .map((tuple) => `ClientTuple(user="${tuple.user}", relation="${tuple.relation}", object="${tuple.object}")`)
           .join(',\n                ')}
     ],`
         : ``

--- a/src/components/Docs/SnippetViewer/ListUsersRequestViewer.tsx
+++ b/src/components/Docs/SnippetViewer/ListUsersRequestViewer.tsx
@@ -240,9 +240,7 @@ var response = await fgaClient.ListUsers(body, options);
           ? `
       contextual_tuples=[
           ${contextualTuples
-            .map(
-              (tuple) => `ClientTupleKey(user="${tuple.user}", relation="${tuple.relation}", object="${tuple.object}")`,
-            )
+            .map((tuple) => `ClientTuple(user="${tuple.user}", relation="${tuple.relation}", object="${tuple.object}")`)
             .join(',\n                ')}
       ],`
           : ``


### PR DESCRIPTION
## Description

The type in Python is `ClientTuple` https://github.com/openfga/python-sdk/#list-objects

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

If you haven't done so yet, we would appreciate it if you could star the [OpenFGA repository](https://github.com/openfga/openfga). :) 
