### PR TITLE
Revert "chore(deps): bump @easyops-cn/docusaurus-search-local from 0.45.0 to 0.46.1 in the dependencies group across 1 directory"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@docusaurus/core": "3.6.3",
         "@docusaurus/plugin-client-redirects": "3.6.3",
         "@docusaurus/preset-classic": "3.6.3",
-        "@easyops-cn/docusaurus-search-local": "0.46.1",
+        "@easyops-cn/docusaurus-search-local": "0.45.0",
         "@lottiefiles/react-lottie-player": "3.5.4",
         "@openfga/frontend-utils": "^0.2.0-beta.11",
         "@openfga/sdk": "^0.7.0",
@@ -4140,10 +4140,9 @@
       }
     },
     "node_modules/@easyops-cn/docusaurus-search-local": {
-      "version": "0.46.1",
-      "resolved": "https://registry.npmjs.org/@easyops-cn/docusaurus-search-local/-/docusaurus-search-local-0.46.1.tgz",
-      "integrity": "sha512-kgenn5+pctVlJg8s1FOAm9KuZLRZvkBTMMGJvTTcvNTmnFIHVVYzYfA2Eg+yVefzsC8/cSZGKKJ0kLf8I+mQyw==",
-      "license": "MIT",
+      "version": "0.45.0",
+      "resolved": "https://registry.npmjs.org/@easyops-cn/docusaurus-search-local/-/docusaurus-search-local-0.45.0.tgz",
+      "integrity": "sha512-ccJjeYmBHrv2v8Y9eQnH79S0PEKcogACKkEatEKPcad7usQj/14jA9POUUUYW/yougLSXghwe+uIncbuUBuBFg==",
       "dependencies": {
         "@docusaurus/plugin-content-docs": "^2 || ^3",
         "@docusaurus/theme-translations": "^2 || ^3",
@@ -4154,7 +4153,6 @@
         "@node-rs/jieba": "^1.6.0",
         "cheerio": "^1.0.0",
         "clsx": "^1.1.1",
-        "comlink": "^4.4.2",
         "debug": "^4.2.0",
         "fs-extra": "^10.0.0",
         "klaw-sync": "^6.0.0",
@@ -7897,12 +7895,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/comlink": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/comlink/-/comlink-4.4.2.tgz",
-      "integrity": "sha512-OxGdvBmJuNKSCMO4NTl1L47VRp6xn2wG4F/2hYzB6tiCb709otOxtEYCSvK80PtjODfXXZu8ds+Nw5kVCjqd2g==",
-      "license": "Apache-2.0"
     },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@docusaurus/core": "3.6.3",
     "@docusaurus/plugin-client-redirects": "3.6.3",
     "@docusaurus/preset-classic": "3.6.3",
-    "@easyops-cn/docusaurus-search-local": "0.46.1",
+    "@easyops-cn/docusaurus-search-local": "0.45.0",
     "@lottiefiles/react-lottie-player": "3.5.4",
     "@openfga/frontend-utils": "^0.2.0-beta.11",
     "@openfga/sdk": "^0.7.0",


### PR DESCRIPTION
Reverts openfga/openfga.dev#901

Original merge is causing the search to fail

closes https://github.com/openfga/openfga.dev/issues/907