### PR TITLE
refactor: move migrating models content to its own page

### DIFF
--- a/docs/content/modeling/migrating/migrating-models.mdx
+++ b/docs/content/modeling/migrating/migrating-models.mdx
@@ -1,0 +1,44 @@
+---
+title: 'Model Migrations'
+slug: /modeling/migrating/migrating-models
+sidebar_position: 1
+---
+
+import { DocumentationNotice, ProductName, ProductNameFormat, IntroCard, CardGrid, CardBox} from '@components/Docs';
+
+<DocumentationNotice />
+
+You can think of model migrations for <ProductName format={ProductNameFormat.ShortForm}/> in the same way as you think about relational database migrations. You can perform migrations with or without downtime for both, and for some changes, doing them without downtime is harder.
+
+| <ProductName format={ProductNameFormat.ShortForm}/> | Relational Databases  |
+|-----------------------------------------------------|-----------------------|
+| Add a type                                          | Add a table           |
+| Remove a type                                       | Remove a table        |
+| Rename a type                                       | Rename a table        |
+| Add a relation                                      | Add a nullable column |
+| Rename a relation                                   | Rename a column       |
+| Delete a relation                                   | Delete a column       |
+
+When thinking about migrations, keep in mind that:
+
+- [Models are immutable](../../getting-started/immutable-models.mdx).
+- The tuples that are not valid according to the specified model, are ignored when evaluating queries.
+
+## To add a type or relation
+
+  1. Add the type or relation to the authorization model, and write the model to the store. This will generate a new model ID.
+  2. If you have tuples to write for the new types/relations, write them.
+  3. Update the application code to start using those new types/relations.
+  4. Configure the application to start using the new model ID.
+
+## To delete a type or relation
+
+  1. Delete the type or relation to the authorization model, and write the model to the store. This will generate a new model ID.
+  2. Update the application code to stops using the deleted types/relations.
+  3. Configure the application to start using the new model ID.
+  4. Delete the tuples for the deleted type/relations. While not required, doing so can improve performance. Invalid tuples will be ignored during query evaluation, but their presence may slow down the process if they need to be retrieved.
+
+## To rename a type or relation
+
+  - [This document](./migrating-relations.mdx) describes an end-to-end example for that use case.
+

--- a/docs/content/modeling/migrating/overview.mdx
+++ b/docs/content/modeling/migrating/overview.mdx
@@ -5,7 +5,7 @@ slug: /modeling/migrating
 sidebar_position: 0
 ---
 
-import { DocumentationNotice, ProductName, ProductNameFormat, IntroCard, CardGrid } from '@components/Docs';
+import { DocumentationNotice, IntroCard, CardGrid } from '@components/Docs';
 
 <DocumentationNotice />
 
@@ -15,41 +15,23 @@ This section has guides that focus on migrating models and relations.
   title="When to use"
   description="The content in this section is useful:"
   listItems={[
-    `If you want to introduce changes to your existing authorization model or upgrade it to the new schema version.`,
+    `If you want to introduce changes to your existing authorization model or upgrade it to a new schema version.`,
   ]}
 />
 
-You can think of model migrations for <ProductName format={ProductNameFormat.ShortForm}/>  in the same way as you think about relational database migrations. You can perform migrations with or without downtime for both, and for some changes, doing them without downtime is harder.
+# Content
 
-| <ProductName format={ProductNameFormat.ShortForm}/> | Relational Databases  |
-|-----------------------------------------------------|-----------------------|
-| Add a type                                          | Add a table           |
-| Remove a type                                       | Remove a table        |
-| Rename a type                                       | Rename a table        |
-| Add a relation                                      | Add a nullable column |
-| Rename a relation                                   | Rename a column       |
-| Delete a relation                                   | Delete a column       |
-
-When thinking about migrations, keep in mind that:
-
-- [Models are immutable](../../getting-started/immutable-models.mdx).
-- The tuples that are not valid according to the specified model, are ignored when evaluating queries. 
-
-## To add a type or relation
-
-  1. Add the type or relation to the authorization model, and write the model to the store. This will generate a new model ID.
-  2. If you have tuples to write for the new types/relations, write them.
-  3. Update the application code to start using those new types/relations.
-  4. Configure the application to start using the new model ID.
-
-## To delete a type or relation
-
-  1. Delete the type or relation to the authorization model, and write the model to the store. This will generate a new model ID.
-  2. Update the application code to stops using the deleted types/relations.
-  3. Configure the application to start using the new model ID.
-  4. Delete the tuples for the deleted type/relations. While not required, doing so can improve performance. Invalid tuples will be ignored during query evaluation, but their presence may slow down the process if they need to be retrieved.
-
-## To rename a type or relation
-
-  - [This document](./migrating-relations.mdx) describes an end-to-end example for that use case.
-
+<CardGrid 
+  middle={[
+    {
+      title: 'Migrating Relations',
+      description: 'A end-to-end example on renaming a relation.',
+      to: 'migrating/migrating-relations',
+    },
+    {
+      title: 'Migrating Models',
+      description: 'Learn how to safely update your model.',
+      to: 'migrating/migrating-models',
+    },
+  ]}
+/>

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -314,6 +314,11 @@ const sidebars = {
               label: 'Migrating Relations',
               id: 'content/modeling/migrating/migrating-relations',
             },
+            {
+              type: 'doc',
+              label: 'Migrating Models',
+              id: 'content/modeling/migrating/migrating-models',
+            },
           ],
         },
       ],


### PR DESCRIPTION
## Description

Moves the content for migrating models into a dedicated page so that the general theme of overview pages linking to child content is maintained.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

