### PR TITLE
docs: Add warning about duplicate tuples in write requests

### DIFF
--- a/docs/content/interacting/transactional-writes.mdx
+++ b/docs/content/interacting/transactional-writes.mdx
@@ -102,7 +102,7 @@ The following example uses public access. To learn more, [read about Public Acce
 - A <ProductConcept section="what-is-a-user" linkName="User" />: an entity in the system that can be related to an object
 - A <ProductConcept section="what-is-a-relation" linkName="Relation" />: is a string defined in the type definition of an authorization model that defines the possibility of a relationship between an object of the same type as the type definition and a user in the system
 - A <ProductConcept section="what-is-a-relation" linkName="Relation" />: a string defined in the type definition of an authorization model that defines the possibility of a relationship between an object of the same type as the type definition and a user in the system
-- A <ProductConcept section="what-is-a-relationship-tuple" linkName="Relationship Tuple" />: a group stored in <ProductName format={ProductNameFormat.ShortForm}/> that consists of a user, a relation, and an object 
+- A <ProductConcept section="what-is-a-relationship-tuple" linkName="Relationship Tuple" />: a group stored in <ProductName format={ProductNameFormat.ShortForm}/> that consists of a user, a relation, and an object
 
 </details>
 
@@ -135,6 +135,37 @@ Deleting the previous tuple converts this `tweet` to private:
 />
 
 By removing the tuple, we made the tweet visible to no-one, which may not be what we want.
+
+<details>
+<summary>Limitations on duplicate tuples in a single request</summary>
+
+<br/>
+When using the Write API, you cannot include the same tuple (same user, relation, and object) in both the writes and deletes arrays within a single request. The API will return an error with code `cannot_allow_duplicate_tuples_in_one_request` if duplicate tuples are detected.
+
+For example, this request would fail:
+
+```bash
+curl -X POST 'http://localhost:8080/stores/{store_id}/write' \
+  -H 'content-type: application/json' \
+  --data '{
+    "writes": {
+      "tuple_keys": [{
+        "user": "user:anne",
+        "relation": "member",
+        "object": "group:2"
+      }]
+    },
+    "deletes": {
+      "tuple_keys": [{
+        "user": "user:anne",
+        "relation": "member",
+        "object": "group:2"
+      }]
+    }
+  }'
+```
+
+</details>
 
 The Write API allows you to send up to 100 unique tuples in the request. (This limit applies to the sum of both writes and deletes in that request). This means we can submit one API call that converts the `tweet` from public to visible to only the `user`'s followers.
 


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

Add documentation about write request limitations regarding duplicate tuples.

<img width="817" alt="image" src="https://github.com/user-attachments/assets/d2de26fc-8ed1-450c-bbd7-780e761a4700" />


## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

fixes #919

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

