### PR TITLE
fix:  insert missing " in list-users documentation

### DIFF
--- a/src/components/Docs/SnippetViewer/ListUsersRequestViewer.tsx
+++ b/src/components/Docs/SnippetViewer/ListUsersRequestViewer.tsx
@@ -55,7 +55,7 @@ function listUsersRequestViewer(lang: SupportedLanguage, opts: ListUsersRequestV
   -d '{
         "authorization_model_id": "${modelId}",
         "object": {
-          "type: "${objectType}",
+          "type": "${objectType}",
           "id": "${objectId}",
         },
         "relation": "${relation}",


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
Fixes #934
A missing " in ListUsersRequestViewer.tsx led to a missing " in the documentation for list-users:

https://github.com/openfga/openfga.dev/blob/c144f0b701479ebd303e94ee6218ca6b05adaeef/src/components/Docs/SnippetViewer/ListUsersRequestViewer.tsx#L58

![grafik](https://github.com/user-attachments/assets/491ea7a2-3d89-4823-8243-3b4089d04e4b)


## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

