### PR TITLE
chore: Include CLI setting for Pre-shared key Authn

### DIFF
--- a/docs/content/getting-started/cli.mdx
+++ b/docs/content/getting-started/cli.mdx
@@ -27,7 +27,13 @@ The API Url setting needs to point to the OpenFGA server:
 | ------- | --------- | ----------- | ----------- | ----------------------- |
 | API Url | --api-url | FGA_API_URL | api-url     | `http://localhost:8080` |
 
-If you use [pre-shared key authentication](./setup-openfga/configure-openfga.mdx#pre-shared-key-authentication), configure the following parameters based on the OIDC server that’s used to issue tokens:
+If you use [pre-shared key authentication](./setup-openfga/configure-openfga.mdx#pre-shared-key-authentication), provide the following parameters which appends the pre-shared key in the HTTP request header:
+| Name           | Flag               | Environment          | ~/.fga.yaml      |
+| -------------- | ------------------ | -------------------- | ---------------- |
+| API Token      | --api-token        | FGA_API_TOKEN        | api-token        |
+
+
+If you use [OIDC authentication](./setup-openfga/configure-openfga.mdx#oidc), configure the following parameters based on the OIDC server that’s used to issue tokens:
 
 | Name           | Flag               | Environment          | ~/.fga.yaml      |
 | -------------- | ------------------ | -------------------- | ---------------- |


### PR DESCRIPTION
## Description
The current document only describes how the CLI tool authenticates with OIDC, yet named as pre-shared key authn.

This PR includes the actual Pre-shared Key Authn parameter for the CLI tool.

## References

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected

