### PR TITLE
Docs: update limit for mysql from 128 to 255

### DIFF
--- a/docs/content/getting-started/setup-openfga/configure-openfga.mdx
+++ b/docs/content/getting-started/setup-openfga/configure-openfga.mdx
@@ -92,7 +92,7 @@ To learn how to run in Docker, check our [Docker documentation](./docker-setup.m
 The MySQL datastore has stricter limits for the max length of some fields for tuples compared to other datastore engines, in particular:
 
 - object type is at most 128 characters (down from 256)
-- object id is at most 128 characters (down from 256)
+- object id is at most 255 characters (down from 256)
 - user is at most 256 characters (down from 512)
 
 The connection URI needs to specify the query `parseTime=true`.


### PR DESCRIPTION
## Description
Changes the limit from 128 to 255 for mysql limits in the documentation.

## References
https://github.com/openfga/openfga/pull/2230

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected

