### PR TITLE
Correct go install command

### DIFF
--- a/docs/content/getting-started/install-sdk.mdx
+++ b/docs/content/getting-started/install-sdk.mdx
@@ -177,10 +177,8 @@ docker pull openfga/cli; docker run -it openfga/cli
 
 ### Go
 
-> note that the command will be named `cli`
-
 ```shell
-go install github.com/openfga/cli@latest
+go install github.com/openfga/cli/cmd/fga@latest
 ```
 
 ### Manually


### PR DESCRIPTION
## Description
Corrected instructions for installing `fga` directly with go. CLI PR 242 moved the command into the subdirectory `cmd/fga` meaning that the URL needs to change. Also this invalidates the note which previously stated:
 > note that the command will be named `cli`

This is no longer true and the command will be named `fga`


## References
 - https://github.com/openfga/cli/pull/242
 
## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

