### PR TITLE
doc: `fga tuple delete --file=(csv|json|yaml)` now supports CSV

### DIFF
--- a/docs/content/getting-started/cli.mdx
+++ b/docs/content/getting-started/cli.mdx
@@ -327,7 +327,7 @@ When using the CSV format, you can omit certain headers, and you don’t need to
 
 ## Delete Tuples
 
-To delete a tuple, specify the user/relation/object you want to delete. To delete a group of tuples, specify a file that contains those tuples.
+To delete a tuple, specify the user/relation/object you want to delete. To delete a group of tuples, specify a file that contains those tuples. Supported file formats are `json`, `yaml` and `csv`.
 
 ```bash
 $ fga tuple delete --file tuples.yaml


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
Added a line to indicate `fga tuple delete --file=(csv|json|yaml)` now supports CSV as well.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->
1. [feat: support csv in fga tuple delete](https://github.com/openfga/cli/pull/478)

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

