### PR TITLE
docs: Minor grammar fix on Playgrounds page

### DIFF
--- a/docs/content/getting-started/setup-openfga/playground.mdx
+++ b/docs/content/getting-started/setup-openfga/playground.mdx
@@ -14,7 +14,7 @@ The Playground is designed for early prototyping and learning. It has several li
 
 - It works by embedding the public [Playground website](https://play.fga.dev) in an `<iframe>`. To do this securely, the public Playground configures its Content Security Policies to enable running it from `localhost`. **You can't run the Playground in a host different than `localhost`.
 - It does not support OIDC authentication. 
-- It's loads up to 100 tuples.
+- It loads up to 100 tuples.
 - It does not support conditional tuples or contextual tuples.
 
 We have [the intention](https://github.com/openfga/roadmap/issues/7) to rewrite the Playground code and open source it, which will make it possible to overcome some of those limitations. 


### PR DESCRIPTION
Corrected grammar on bullet regarding tuple limit within Playground

## Description
Very small grammatical edit. Self-evident in the diff.

## References
N/A

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected

