### PR TITLE
fix: python check call snippets

### DIFF
--- a/src/components/Docs/SnippetViewer/BatchCheckRequestViewer.tsx
+++ b/src/components/Docs/SnippetViewer/BatchCheckRequestViewer.tsx
@@ -245,7 +245,7 @@ checks = [${checks.map(
     }`,
       )}
 ]
-options = {${modelId ? `\n  authorization_model_id="${modelId}"` : ''}}
+options = {${modelId ? `\n  "authorization_model_id": "${modelId}"` : ''}}
 response = await fga_client.batch_check(ClientBatchCheckRequest(checks=checks), options)
 
 # response.results = [${checks

--- a/src/components/Docs/SnippetViewer/CheckRequestViewer.tsx
+++ b/src/components/Docs/SnippetViewer/CheckRequestViewer.tsx
@@ -152,7 +152,7 @@ var response = await fgaClient.Check(body, options);
 // response.Allowed = ${allowed}`;
     case SupportedLanguage.PYTHON_SDK:
       return `options = {
-    authorization_model_id="${modelId}"
+    "authorization_model_id": "${modelId}"
 }
 body = ClientCheckRequest(
     user="${user}",


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

This is not python
![image](https://github.com/user-attachments/assets/d93f6ed1-4bde-4672-8042-6bf480d7fdb9)
Dict keys must be inside quotes and field atribution must use colon (instead of equal)

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

https://openfga.dev/docs/getting-started/perform-check

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected

