### PR TITLE
fix(viewer): add missing parenthesis in Python SDK code rendering

### DIFF
--- a/src/components/Docs/SnippetViewer/BatchCheckRequestViewer.tsx
+++ b/src/components/Docs/SnippetViewer/BatchCheckRequestViewer.tsx
@@ -231,8 +231,9 @@ response.Responses = [${checks
     case SupportedLanguage.PYTHON_SDK:
       return `# Requires >=v0.9.0 for the server side BatchCheck, earlier versions support a client-side BatchCheck with a slightly different interface
 
-checks = [${checks.map(
-        (check) => `
+checks = [${checks
+        .map(
+          (check) => `
   ClientBatchCheckItem(
     user="${check.user}",
     relation="${check.relation}",
@@ -242,8 +243,10 @@ checks = [${checks.map(
         ? `,
     contextual_tuples=[${check.contextualTuples.map((tuple) => `ClientTuple(user="${tuple.user}", relation="${tuple.relation}", object="${tuple.object}")`).join(',')}]`
         : ''
-    }`,
-      )}
+    }
+  )`,
+        )
+        .join(',')}
 ]
 options = {${modelId ? `\n  "authorization_model_id": "${modelId}"` : ''}}
 response = await fga_client.batch_check(ClientBatchCheckRequest(checks=checks), options)


### PR DESCRIPTION
## Description
This fixes a bug in `BatchCheckRequestViewer.tsx` where the Python SDK code generator was emitting `ClientBatchCheckItem` calls without a closing parenthesis, resulting in invalid Python examples on the site. Each `ClientBatchCheckItem(...)` is now properly closed with `)` and items are separated with commas, producing valid Python syntax.

```python
# current rendering
checks = [
  ClientBatchCheckItem(
    user="user:anne",
    relation="writer",
    object="document:Z",
    correlation_id="886224f6-04ae-4b13-bd8e-559c7d3754e1",
  ClientBatchCheckItem(
    user="user:anne",
    relation="reader",
    object="document:Z",
    correlation_id="da452239-a4e0-4791-b5d1-fb3d451ac078"
]

# updated rendering
checks = [
  ClientBatchCheckItem(
    user="user:anne",
    relation="writer",
    object="document:Z",
    correlation_id="886224f6-04ae-4b13-bd8e-559c7d3754e1"
  ),
  ClientBatchCheckItem(
    user="user:anne",
    relation="reader",
    object="document:Z",
    correlation_id="da452239-a4e0-4791-b5d1-fb3d451ac078"
  )
]
```

Also, Prettier was run on the file and updated lines 234 and 235.

## References
The bug appears in these pages:

- Python example in "Perform Check - Calling Batch Check API": https://openfga.dev/docs/getting-started/perform-check#03-calling-batch-check-api  
- Python example in "Interacting - Relationship Queries - When to use": https://openfga.dev/docs/interacting/relationship-queries#when-to-use-1  

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected