### PR TITLE
fix: rebranding okta fga to auth0 fga

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## About OpenFGA
 <!-- markdown-link-check-disable -->
-[OpenFGA](https://github.com/openfga/openfga) is an open source Fine-Grained Authorization solution based on Google's Zanzibar. It was created by the Okta FGA team and welcomes community contribution. OpenFGA is designed to make it easy for application builders to quickly add fine-grained authorization to their applications. It offers an HTTP API and has SDKs for programming languages including [JavaScript](https://github.com/openfga/js-sdk), [GoLang](https://github.com/openfga/go-sdk) and [.NET](https://github.com/openfga/dotnet-sdk). More SDKs and integrations such as Rego are planned for the future. OpenFGA is designed and optimized for reliability and low latency at a high scale.
+[OpenFGA](https://github.com/openfga/openfga) is an open source Fine-Grained Authorization solution based on Google's Zanzibar. It was created by the Auth0 FGA team and welcomes community contribution. OpenFGA is designed to make it easy for application builders to quickly add fine-grained authorization to their applications. It offers an HTTP API and has SDKs for programming languages including [JavaScript](https://github.com/openfga/js-sdk), [GoLang](https://github.com/openfga/go-sdk) and [.NET](https://github.com/openfga/dotnet-sdk). More SDKs and integrations such as Rego are planned for the future. OpenFGA is designed and optimized for reliability and low latency at a high scale.
 <!-- markdown-link-check-enable-->
 
 ## About OpenFGA docs

--- a/blog/fine-grained-news-2024-02.md
+++ b/blog/fine-grained-news-2024-02.md
@@ -22,7 +22,7 @@ We'll be pretty busy during [KubeCon Europe 2024](https://events.linuxfoundation
 
 - OpenFGA will be present in [Canonical's Operator's day](https://app.myonvent.com/event/operator-day/), co-located at KubeCon EU. Andres Aguiar and Massimilano Gori from Canonical, will talk about how Canonical adopted OpenFGA for implementing authorization in [Juju](https://juju.is/).
 
--  Andres Aguiar will also be delivering a Lightning Talk titled **OpenFGA - The Cloud Native way to implement Fine Grained Authorization** (link not available yet :) ).
+-  Andres Aguiar will also be delivering a Lightning Talk titled **OpenFGA - The Cloud Native way to implement Fine-Grained Authorization** (link not available yet :) ).
 
 We'll also have a kiosk in the CNCF Project Pavilion, so if you plan to attend let us know and we can schedule some time together!
 

--- a/blog/fine-grained-news-2024-03.md
+++ b/blog/fine-grained-news-2024-03.md
@@ -18,7 +18,7 @@ You can now watch online:
 
 - An AppDeveloperCon session about [Implementing Modern Cloud Native Authorization Using OpenFGA](https://www.youtube.com/watch?v=5NkJHeToEwo) where [Pauline Jamin](https://github.com/paulinejamin) and [Andres Aguiar](https://github.com/aaguiarz) go over how OpenFGA is helping Agicap to implement fine-grained authorization.
 
-- A 7-min Lightning Talk about [OpenFGA: The Cloud Native way to implement Fine Grained Authorization](https://www.youtube.com/watch?v=K7Me3OjFxJ0).
+- A 7-min Lightning Talk about [OpenFGA: The Cloud Native way to implement Fine-Grained Authorization](https://www.youtube.com/watch?v=K7Me3OjFxJ0).
 
 - [Jonathan Whitaker](https://www.linkedin.com/in/jonathan-whitaker-5a8b2484/)'s talk about [Federated IAM for Kubernetes with OpenFGA](https://www.youtube.com/watch?v=UaK1EnRgrng), demoing how to use OpenFGA and KeyCloak to implement fine-grained authorization in a Kubernetes cluster, in ways it's not possible today, like giving access to a user for 90 seconds.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,13 +6,13 @@ hide_title: true
 
 ## About OpenFGA
 
-[OpenFGA](https://github.com/openfga/openfga) is an open source Fine-Grained Authorization solution based on Google's Zanzibar. It was created by the Okta FGA team and welcomes community contribution. OpenFGA is designed to make it easy for application builders to quickly add fine-grained authorization to their applications. OpenFGA is designed and optimized for reliability and low latency at a high scale.
+[OpenFGA](https://github.com/openfga/openfga) is an open source Fine-Grained Authorization solution based on Google's Zanzibar. It was created by the Auth0 FGA team and welcomes community contribution. OpenFGA is designed to make it easy for application builders to quickly add fine-grained authorization to their applications. OpenFGA is designed and optimized for reliability and low latency at a high scale.
 
 It offers an HTTP API, a gRPC API, and has SDKs for programming languages including [JavaScript](https://github.com/openfga/js-sdk), [GoLang](https://github.com/openfga/go-sdk), [.NET](https://github.com/openfga/dotnet-sdk) and [Python](https://github.com/openfga/python-sdk) and [Java](https://github.com/openfga/java-sdk). 
 
 ## Resources
 
-- [Okta FGA Playground](https://play.fga.dev)
+- [Auth0 FGA Playground](https://play.fga.dev)
 - [Zanzibar Academy](https://zanzibar.academy)
 - [OpenFGA on Twitter](https://twitter.com/OpenFGA)
 - [OpenFGA Community](https://openfga.dev/community) in Slack and GitHub

--- a/docs/content/getting-started/framework.mdx
+++ b/docs/content/getting-started/framework.mdx
@@ -523,7 +523,7 @@ func checkAuthorization(c *fiber.Ctx) error {
     },
     {
       title: 'IoT',
-      description: 'Modeling Fine Grained Authorization for an IoT Security Camera System with {ProductName}.',
+      description: 'Modeling Fine-Grained Authorization for an IoT Security Camera System with {ProductName}.',
       link: '../modeling/advanced/iot',
     },
     {

--- a/docs/content/modeling/advanced/iot.mdx
+++ b/docs/content/modeling/advanced/iot.mdx
@@ -1,6 +1,6 @@
 ---
 title: IoT
-description: Modeling fine grained authorization for an IoT security camera system
+description: Modeling fine-grained authorization for an IoT security camera system
 sidebar_position: 3
 slug: /modeling/advanced/iot
 ---

--- a/docs/content/modeling/advanced/slack.mdx
+++ b/docs/content/modeling/advanced/slack.mdx
@@ -900,7 +900,7 @@ Upcoming tutorials will dive deeper into <ProductName format={ProductNameFormat.
 
 <Playground title="Slack" preset="slack" example="Slack" store="slack" />
 
-If you are interested in learning more about Authorization and Role Management at Slack, check out the Okta Fine Grained Authorization (FGA) team's chat with the Slack engineering team.
+If you are interested in learning more about Authorization and Role Management at Slack, check out the Auth0 Fine-Grained Authorization (FGA) team's chat with the Slack engineering team.
 
 <figure className="video_container">
   <iframe

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -38,7 +38,7 @@ const config = {
         icon: 'ZanzibarIcon',
       },
       {
-        text: 'Okta FGA Playground →',
+        text: 'Auth0 FGA Playground →',
         href: 'https://play.fga.dev/',
         icon: 'ModelIcon',
       },
@@ -70,7 +70,7 @@ const config = {
     // link to the concept page (relative to baseURL)
     conceptLink: `docs/concepts`,
     longProductName: `OpenFGA`,
-    landingPageTitle: 'Fine Grained Authorization',
+    landingPageTitle: 'Fine-Grained Authorization',
 
     // define playgroundName and playgroundURL if you want to show your examples through playground
     //playgroundName: '',


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

