### PR TITLE
fix: typo in Authorization Model ID

### DIFF
--- a/src/components/Docs/SnippetViewer/CheckRequestViewer.tsx
+++ b/src/components/Docs/SnippetViewer/CheckRequestViewer.tsx
@@ -197,7 +197,7 @@ response = await fga_client.check(body, options)
       .join(',\n    ')}
   ],`
       : ''
-  } authorization_id = "${modelId}"
+  } authorization_model_id = "${modelId}"
 );
 
 Reply: ${allowed}`;


### PR DESCRIPTION
Fix typo to avoid confusion.

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

