### PR TITLE
ci: replace deprecated link check action

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: gaurav-nelson/github-action-markdown-link-check@5c5dfc0ac2e225883c0e5f03a85311ec2830d368
+      - uses: tcort/github-action-markdown-link-check@a800ad5f1c35bf61987946fd31c15726a1c9f2ba # v1.1.0
         with:
           file-extension: '.md'
           use-quiet-mode: 'yes'
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: gaurav-nelson/github-action-markdown-link-check@5c5dfc0ac2e225883c0e5f03a85311ec2830d368
+      - uses: tcort/github-action-markdown-link-check@a800ad5f1c35bf61987946fd31c15726a1c9f2ba # v1.1.0
         with:
           file-extension: '.mdx'
           use-quiet-mode: 'yes'

--- a/docs/content/modeling/advanced/slack.mdx
+++ b/docs/content/modeling/advanced/slack.mdx
@@ -901,7 +901,7 @@ Upcoming tutorials will dive deeper into <ProductName format={ProductNameFormat.
 <Playground title="Slack" preset="slack" example="Slack" store="slack" />
 
 If you are interested in learning more about Authorization and Role Management at Slack, check out the Auth0 Fine-Grained Authorization (FGA) team's chat with the Slack engineering team.
-
+<!-- markdown-link-check-disable -->
 <figure className="video_container">
   <iframe
     style={{ marginTop: 36, borderRadius: 8 }}
@@ -913,6 +913,7 @@ If you are interested in learning more about Authorization and Role Management a
     allowFullScreen
   />
 </figure>
+<!-- markdown-link-check-enable -->
 
 ### Exercises for you
 

--- a/docs/content/modeling/user-groups.mdx
+++ b/docs/content/modeling/user-groups.mdx
@@ -97,10 +97,13 @@ There are possible use cases where a group of users have a certain role on or pe
 
 To represent this in <ProductName format={ProductNameFormat.ShortForm}/>:
 
+<!-- We disable the check for these links because markdown-link-check doesn't support reading the docusaurus syntax to define the link -->
+<!-- markdown-link-check-disable --> 
 1. Introduce the concept of a `team` to the authorization model. [→](#step-1)
 2. Add users as `members` to the `team`. [→](#step-2)
 3. Assign the `team` members a relation to an object. [→](#step-3)
 4. Check an individual member's access to the object. [→](#step-4)
+<!-- markdown-link-check-enable -->
 
 ### 01. Introduce the concept of a team to the authorization model {#step-1}
 


### PR DESCRIPTION
## Description

`gaurav-nelson/github-action-markdown-link-check` was recently deprecated and recommends `tcort/github-action-markdown-link-check`, a fork maintained by the author of the npm package.

I don't think this is the cause of the failures we've been seeing in the action, but it's a sensible change to make and allows testing out any potential issues.


## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

