### PR TITLE
fix(docs): remove batchcheck endpoint support to js/python sdk note

### DIFF
--- a/docs/content/interacting/relationship-queries.mdx
+++ b/docs/content/interacting/relationship-queries.mdx
@@ -186,8 +186,6 @@ The <ProductName format={ProductNameFormat.ShortForm}/> API will return `true` d
 
 If you are making less than 10 checks, it may be faster to call the [Check API](/api/service#Relationship%20Queries/Check) in parallel instead of Batch Check.
 
-The new BatchCheck endpoint is currently supported by the JS SDK (>=[v0.8.0](https://github.com/openfga/js-sdk/releases/tag/v0.8.0) and the Python SDK (>=[v0.9.0](https://github.com/openfga/python-sdk/releases/tag/v0.9.0)). Support in the other SDKs is being worked on.
-
 ## Read
 
 ### What Is It For?

--- a/docs/content/interacting/relationship-queries.mdx
+++ b/docs/content/interacting/relationship-queries.mdx
@@ -181,10 +181,22 @@ For example, you can call Batch Check to determine whether `bob` has `can_view_n
 
 The <ProductName format={ProductNameFormat.ShortForm}/> API will return `true` depending on the level of access assigned to that user and the implied relationships inherited in the authorization model.
 
-
 ### Caveats and when not to use it
 
 If you are making less than 10 checks, it may be faster to call the [Check API](/api/service#Relationship%20Queries/Check) in parallel instead of Batch Check.
+
+:::note
+The BatchCheck endpoint is currently supported by the following SDKs:
+- Go SDK ([>=0.7.0](https://github.com/openfga/go-sdk/releases/tag/v0.7.0))
+- JavaScript SDK ([>=v0.8.0](https://github.com/openfga/js-sdk/releases/tag/v0.8.0))
+- Python SDK ([>=v0.9.0](https://github.com/openfga/python-sdk/releases/tag/v0.9.0))
+- Java SDK ([>=0.8.1](https://github.com/openfga/java-sdk/releases/tag/v0.8.1))
+- Support for .NET is in progress and coming soon.
+
+In SDKs that support the `BatchCheck` endpoint (server-side batch checks), the previous `BatchCheck` method has been renamed to `ClientBatchCheck`. `ClientBatchCheck` performs client-side batch checks by making multiple check requests with limited parallelization.
+
+The .NET SDK does not yet support the `BatchCheck` endpoint (coming soon). Until then, the `BatchCheck` method maintains its current behavior, performing client-side batch checks equivalent to `ClientBatchCheck` in other SDKs.
+:::
 
 ## Read
 

--- a/docs/content/interacting/relationship-queries.mdx
+++ b/docs/content/interacting/relationship-queries.mdx
@@ -196,6 +196,8 @@ The BatchCheck endpoint is currently supported by the following SDKs:
 In SDKs that support the `BatchCheck` endpoint (server-side batch checks), the previous `BatchCheck` method has been renamed to `ClientBatchCheck`. `ClientBatchCheck` performs client-side batch checks by making multiple check requests with limited parallelization.
 
 The .NET SDK does not yet support the `BatchCheck` endpoint (coming soon). Until then, the `BatchCheck` method maintains its current behavior, performing client-side batch checks equivalent to `ClientBatchCheck` in other SDKs.
+
+Refer to the README for each SDK for more information. Refer to the release notes of the relevant SDK version for more information on how to migrate from client-side to the server-side `BatchCheck`.
 :::
 
 ## Read


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
Remove `The new BatchCheck endpoint is currently supported by the JS SDK (>=[v0.8.0](https://github.com/openfga/js-sdk/releases/tag/v0.8.0) and the Python SDK (>=[v0.9.0](https://github.com/openfga/python-sdk/releases/tag/v0.9.0)). Support in the other SDKs is being worked on.` and replaced it with a clearer note

<img width="1014" alt="Screenshot 2025-05-23 at 3 38 14 PM" src="https://github.com/user-attachments/assets/ca436814-c38a-4d30-ba40-c3b5c384f646" />


## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected

