### PR TITLE
fix: template literal syntax in ReadRequestViewer RPC pseudocode

### DIFF
--- a/src/components/Docs/SnippetViewer/ReadRequestViewer.tsx
+++ b/src/components/Docs/SnippetViewer/ReadRequestViewer.tsx
@@ -130,7 +130,7 @@ response = await fga_client.read(body, options)
       const objectOrType = opts.object ? (opts.object.slice(-1) === ':' ? 'type' : 'object') : '';
       const requestTuples = opts.object
         ? (opts.user
-            ? `  "${opts.user}", // where user \`${opts.user}\` has $(opts.relation ? '': 'any ' )relation\n`
+            ? `  "${opts.user}", // where user \`${opts.user}\` has ${opts.relation ? '' : 'any '}relation\n`
             : `  // for users who have relation\n`) +
           (opts.relation ? `  "${opts.relation}", // \`${opts.relation}\`\n` : '') +
           `  "${opts.object}", // with the ${objectOrType} \`${opts.object}\``


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?
Fixes the broken pseudocode in ReadRequestViewer component by correcting invalid template literal syntax.

#### How is it being solved?
Replace `$(opts.relation ? '': 'any ' )relation` with correct syntax `${opts.relation ? '' : 'any '}`

#### What changes are made to solve it?
- Fixed invalid template literal syntax `$(opts.relation ? '': 'any ' )relation` 
- Replaced with correct syntax `${opts.relation ? '' : 'any '}`
- This affects the RPC (Pseudocode) tab in ReadRequestViewer components

## References
closes #989 
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] The correct base branch is being used, if not `main`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected display of relation information in code comments to accurately reflect when a relation is specified or defaults to "any relation".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->