### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -1,4 +1,6 @@
 name: 'Run Checks: Lint, Audit and Build'
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/openfga/openfga.dev/security/code-scanning/6](https://github.com/openfga/openfga.dev/security/code-scanning/6)

To fix the problem, add a `permissions` block to the workflow file to explicitly set the minimum required permissions for all jobs. Since all jobs in this workflow only need to read repository contents, set `permissions: contents: read` at the top level of the workflow (just after the `name` and before `on`). This will apply to all jobs unless a job-level override is specified. No other changes are needed, as none of the jobs require additional permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow configuration to clarify repository access permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->