### PR TITLE
 chore(ci): restrict test deploymeny workflow permissions to only read contents

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -7,6 +7,8 @@ on:
     # Review gh actions docs if you want to further define triggers, paths, etc
     # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#on
 
+permissions:
+  contents: read
 jobs:
   test-deploy:
     name: Test deployment


### PR DESCRIPTION
Potential fix for [https://github.com/openfga/openfga.dev/security/code-scanning/5](https://github.com/openfga/openfga.dev/security/code-scanning/5)

To fix the problem, you should add a `permissions` block to the workflow or to the specific job. Since the workflow only contains a single job, you can add the `permissions` block at the job level (under `test-deploy:`) or at the root of the workflow (top-level, before `jobs:`). The minimal required permission for this workflow is `contents: read`, which allows the workflow to read repository contents but not to write or modify them. This change should be made in `.github/workflows/test-deploy.yml`, either above the `jobs:` key or under the `test-deploy:` job definition. No additional methods, imports, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow configuration for test deployment with improved permissions settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->