### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,5 +1,8 @@
 # .github/workflows/preview.yml
 name: Deploy PR previews
+permissions:
+  contents: read
+  pull-requests: write
 concurrency:
   group: preview-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/openfga/openfga.dev/security/code-scanning/4](https://github.com/openfga/openfga.dev/security/code-scanning/4)

To fix the problem, you should add a `permissions` block to the workflow. The best way is to add it at the root level of the workflow file, so it applies to all jobs unless overridden. The minimal starting point is `contents: read`, but you should also consider whether any steps require additional permissions. In this case, the workflow deploys a preview using `rossjrw/pr-preview-action`, which typically requires `contents: read` and `pull-requests: write` to post preview links to PRs. Therefore, the recommended fix is to add:

```yaml
permissions:
  contents: read
  pull-requests: write
```

directly below the `name:` field (after line 2) in `.github/workflows/preview.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
