### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -1,4 +1,6 @@
 name: 'Run Checks: Lint, Audit and Build'
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/openfga/openfga.dev/security/code-scanning/2](https://github.com/openfga/openfga.dev/security/code-scanning/2)

To fix the problem, you should add a `permissions` block to the workflow file. The best way to do this is to add the block at the top level of the workflow, so it applies to all jobs unless overridden. For this workflow, the jobs only need to read repository contents, so the minimal required permission is `contents: read`. You should add the following block immediately after the `name:` field and before the `on:` field in `.github/workflows/checks.yaml`:

```yaml
permissions:
  contents: read
```

No additional imports, methods, or definitions are needed. This change will ensure that the workflow and all jobs within it only have read access to repository contents, following the principle of least privilege.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
