### PR TITLE
docs: Update Contextual Tuples docs with Expand dndpoint support

### DIFF
--- a/docs/content/modeling/token-claims-contextual-tuples.mdx
+++ b/docs/content/modeling/token-claims-contextual-tuples.mdx
@@ -155,7 +155,7 @@ The authorization check returns `allowed = true`, as there's a stored tuple sayi
 Contextual tuples:
 - Do not persist in the store.
 
-- Are only supported on the <UpdateProductNameInLinks link="/api/service#Relationship%20Queries/Check" name="Check API endpoint" />, <UpdateProductNameInLinks link="/api/service#Relationship%20Queries/ListObjects" name="ListObjects API endpoint" /> and <UpdateProductNameInLinks link="/api/service#Relationship%20Queries/ListUsers" name="ListUsers API endpoint" />. They are not supported on read, expand, or other endpoints.
+- Are only supported on the <UpdateProductNameInLinks link="/api/service#Relationship%20Queries/Check" name="Check API endpoint" />, <UpdateProductNameInLinks link="/api/service#Relationship%20Queries/ListObjects" name="ListObjects API endpoint" />, <UpdateProductNameInLinks link="/api/service#Relationship%20Queries/ListUsers" name="ListUsers API endpoint" />, and <UpdateProductNameInLinks link="/api/service#Relationship%20Queries/Expand" name="Expand API endpoint" />. They are not supported on read or other endpoints.
 
 - If you use the <UpdateProductNameInLinks link="/api/service#Relationship%20Tuples/ReadChanges" name="Read Changes API endpoint" /> to build a permission aware search index, it may be difficult to account for contextual tuples.
 :::


### PR DESCRIPTION
## Description
Update Contextual Tuple documentation from previously merged feature

[Issue 951](https://github.com/openfga/openfga/issues/951) was closed without proper documentation updates.

[api](https://github.com/openfga/api/pull/202) and [api docs](https://github.com/openfga/api/pull/209) were updated, but the [main site docs](https://openfga.dev/docs/modeling/token-claims-contextual-tuples) were not.

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

