### PR TITLE
doc: updating configure-openfga.mdx with correct parameter for second…

### DIFF
--- a/docs/content/getting-started/setup-openfga/configure-openfga.mdx
+++ b/docs/content/getting-started/setup-openfga/configure-openfga.mdx
@@ -58,13 +58,13 @@ To use read replicas, you need to configure both a primary datastore (for writes
 openfga run \
     --datastore-engine postgres \
     --datastore-uri 'postgres://postgres:password@primary:5432/postgres?sslmode=disable' \
-    --secondary-datastore-uri 'postgres://postgres:password@replica:5432/postgres?sslmode=disable'
+    --datastore-secondary-uri 'postgres://postgres:password@replica:5432/postgres?sslmode=disable'
 ```
 
 **Important considerations:**
 
 - The `--datastore-uri` parameter specifies the primary database (used for writes and high-consistency reads)
-- The `--secondary-datastore-uri` parameter specifies the read replica (used for regular read operations)
+- The `--datastore-secondary-uri` parameter specifies the read replica (used for regular read operations)
 - Both databases must have the same schema and should be kept in sync through PostgreSQL replication
 
 ##### Synchronous vs Asynchronous Replication


### PR DESCRIPTION
## Summary
Fix incorrect flag name for configuring the PostgreSQL read replica in the docs.

## Problem
The documentation refers to `--secondary-datastore-uri`, which is not a valid flag. This can lead to misconfiguration when setting up a read replica.

## Changes
Replaced all occurrences of `--secondary-datastore-uri` with the correct flag `--datastore-secondary-uri` in the relevant documentation pages.

## Why
Align docs with the actual server flags to prevent setup errors and confusion.

## How to verify
- Run `openfga run --help` and check that the flag is listed as `--datastore-secondary-uri`.
- Follow the “Configure OpenFGA” guide with the corrected flag and ensure the server starts with a primary + read-replica configuration.

## References
- `https://openfga.dev/docs/getting-started/setup-openfga/configuration` (lists `datastore-secondary-uri`)
- `https://openfga.dev/docs/getting-started/setup-openfga/configure-openfga` (page being corrected)

## Impact
Docs-only change. No behavior change, no migration required.

## Review Checklist
- [x] I have enabled “allow edits by maintainers”.
- [x] Documentation has been updated in this PR (docs-only change).
- [x] The correct base branch is selected (not necessarily `main`).
- [x] Tests: N/A (no code changes).

