### PR TITLE
fix: update parameter for read replica configuration in OpenFGA setup

### DIFF
--- a/docs/content/getting-started/setup-openfga/configure-openfga.mdx
+++ b/docs/content/getting-started/setup-openfga/configure-openfga.mdx
@@ -58,13 +58,13 @@ To use read replicas, you need to configure both a primary datastore (for writes
 openfga run \
     --datastore-engine postgres \
     --datastore-uri 'postgres://postgres:password@primary:5432/postgres?sslmode=disable' \
-    --secondary-datastore-uri 'postgres://postgres:password@replica:5432/postgres?sslmode=disable'
+    --datastore-secondary-uri 'postgres://postgres:password@replica:5432/postgres?sslmode=disable'
 ```
 
 **Important considerations:**
 
 - The `--datastore-uri` parameter specifies the primary database (used for writes and high-consistency reads)
-- The `--secondary-datastore-uri` parameter specifies the read replica (used for regular read operations)
+- The `--datastore-secondary-uri` parameter specifies the read replica (used for regular read operations)
 - Both databases must have the same schema and should be kept in sync through PostgreSQL replication
 
 ##### Synchronous vs Asynchronous Replication


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?

Corrected the parameter name for specifying the read replica in the OpenFGA setup documentation to ensure clarity and consistency in the configuration instructions.

#### How is it being solved?

#### What changes are made to solve it?

## References

https://github.com/openfga/openfga/blob/main/cmd/run/run.go#L151C16-L151C38
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated OpenFGA configuration guide to reflect the new PostgreSQL read replica flag name: use --datastore-secondary-uri (replacing --secondary-datastore-uri).
  * Revised command examples and “Important considerations” to match the new flag, reducing confusion when configuring read replicas.
  * Ensures users entering the provided commands will use the correct flag syntax across the setup steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->