### PR TITLE
ci: ignore 403s during Markdown link check

### DIFF
--- a/.github/workflows/markdown.links.config.json
+++ b/.github/workflows/markdown.links.config.json
@@ -65,5 +65,6 @@
 			"Accept-Encoding": "zstd, br, gzip, deflate"
 		  }
 		}
-	  ]
+	  ],
+	"aliveStatusCodes": [200, 206, 403]
   }


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description

Our CI is failing sporadically. The culprit: `tcort/github-action-markdown-link-check` receives 403s from certain domains — particularly `sched.com` — due to bot detection (likely Cloudflare's human verification).

Example: https://github.com/openfga/openfga.dev/actions/runs/17049794090/job/48334366062?pr=1091

This PR configures the action to treat 403s as "alive" in `markdown.links.config.json`.

Note: We could add `sched.com` to the ignore pattern list as an alternative, but then we'd miss actual dead links in the future. This change maintains our link coverage and simply avoids the intermittent false positives.

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated link validation to treat 200, 206, and 403 responses as valid (“alive”), reducing false positives for restricted or partial-content links.
  - Improves reliability of Markdown link checks in pull requests and automated workflows, leading to fewer unnecessary CI failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->