### PR TITLE
docs: add .NET custom header usage example

### DIFF
--- a/src/components/Docs/SnippetViewer/CheckRequestViewer.tsx
+++ b/src/components/Docs/SnippetViewer/CheckRequestViewer.tsx
@@ -165,9 +165,9 @@ data, err := fgaClient.Check(context.Background()).
     case SupportedLanguage.DOTNET_SDK:
       return `
 var options = new ClientCheckOptions {
-    AuthorizationModelId = "${modelId}",${
+    AuthorizationModelId = "${modelId}"${
       headers && Object.keys(headers).length > 0
-        ? `\n    Headers = new Dictionary<string, string> {\n${Object.entries(headers)
+        ? `,\n    Headers = new Dictionary<string, string> {\n${Object.entries(headers)
             .map(([key, value]) => `        { "${key}", "${value}" }`)
             .join(',\n')}\n    }`
         : ''
@@ -178,16 +178,16 @@ var body = new ClientCheckRequest {
     Relation = "${relation}",
     Object = "${object}",${
       contextualTuples
-        ? `,
-    ContextualTuples = new List<ClientTupleKey>({
+        ? `
+    ContextualTuples = new List<ClientTupleKey> {
     ${contextualTuples
       .map((tuple) => `new(user: "${tuple.user}", relation: "${tuple.relation}", _object: "${tuple.object}")`)
       .join(',\n    ')}
-})`
+    }`
         : ''
     }${
       context
-        ? `Context = new { ${Object.entries(context)
+        ? `\n    Context = new { ${Object.entries(context)
             .map(([k, v]) => `${k}="${v}"`)
             .join(',')} }`
         : ''


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description

Adds .NET SDK usage example for passing custom headers.

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for per-request headers in code examples
* **Bug Fixes**
  * Improved formatting of contextual tuples and context blocks in code snippet displays
  * Ensured consistent inclusion of authorization model identifiers in request configuration examples
<!-- end of auto-generated comment: release notes by coderabbit.ai -->