### PR TITLE
fix: fixed spacing in CLI configuration bullets

### DIFF
--- a/docs/content/getting-started/cli.mdx
+++ b/docs/content/getting-started/cli.mdx
@@ -25,7 +25,6 @@ The CLI is configured to use a specific FGA server in one of three ways:
     2. **User-specific config directory**
        * Unix: `$XDG_CONFIG_HOME` (if set), otherwise `$HOME/.config`
        * Windows: `%AppData%`
-      
     3. **`fga` subdirectory under the user config directory**
     4. **User's home directory**
        * Unix: `$HOME`


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->


https://openfga.dev/pr-preview/pr-1182/docs/getting-started/cli

### Before

<img width="929" height="694" alt="image" src="https://github.com/user-attachments/assets/de0f3b11-0b51-449f-9c80-a0f48875f6d8" />


### After

<img width="856" height="419" alt="image" src="https://github.com/user-attachments/assets/f1e32b23-36a3-42b5-b8e2-30b24b245eb5" />


#### What problem is being solved?

#### How is it being solved?

#### What changes are made to solve it?

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Documentation
  * Refined CLI documentation formatting for the configuration search order list: condensed layout, consistent indentation, and clearer alignment.
  * Clarified per-item Unix/Windows notes through improved indentation, without altering content, order, or semantics.
  * Enhances readability and consistency across the section; no behavioral or functional changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->