### PR TITLE
feat: added authz for agents as principals

### DIFF
--- a/docs/content/modeling/agents/agent-principals-in-existing-app.mdx
+++ b/docs/content/modeling/agents/agent-principals-in-existing-app.mdx
@@ -1,0 +1,210 @@
+---
+title: Add Agent Principals to Existing Models
+description: Extend a user-centric authorization model with agent principals and least-privilege delegation
+sidebar_position: 4
+slug: /modeling/agents/agent-principals-in-existing-app
+---
+
+import {
+  CheckRequestViewer,
+  DocumentationNotice,
+  ProductName,
+  ProductNameFormat,
+  RelatedSection,
+} from '@components/Docs';
+
+# Add Agent Principals to Existing Models
+
+<DocumentationNotice />
+
+Most applications already have authorization models centered on human users. If you are building agents as part of your application, you can extend the existing model by adding `agent` as a first-class principal - the same way users are granted access to resources today.
+
+This is orthogonal to patterns like [Task-Based Authorization](./task-based-authorization.mdx). Even if you use task-scoped permissions, you still want to constrain what an agent can do in general - beyond the permissions required for a specific task.
+
+This guide shows how to add agent principals to a <ProductName format={ProductNameFormat.ShortForm}/> model using an issue-tracking application as an example. The agent receives permissions on domain resources (projects, issues) and inherits access through the same hierarchy that users do.
+
+## Before: user-centric model
+
+A typical issue-tracking model grants access to users and organization members:
+
+```dsl.openfga
+model
+  schema 1.1
+
+type user
+
+type organization
+  relations
+    define admin: [user]
+    define member: [user]
+
+type project
+  relations
+    define organization: [organization]
+    define owner: [user]
+    define member: [user]
+    define can_delete: owner or admin from organization
+    define can_edit: owner or admin from organization
+    define can_read: can_edit or member or member from organization
+    define can_create_issue: can_edit
+
+type issue
+  relations
+    define project: [project]
+    define reporter: [user]
+    define assignee: [user]
+    define can_delete: reporter or can_delete from project
+    define can_edit: assignee or can_edit from project
+    define can_read: reporter or can_edit or can_read from project
+```
+
+Users get access to issues through project membership, organization membership, or direct assignment. Agents have no place in this model yet.
+
+## After: adding agent principals
+
+Add an `agent` type and include it alongside `user` in the relations where agents need access:
+
+```dsl.openfga
+model
+  schema 1.1
+
+type user
+type agent
+
+type organization
+  relations
+    define admin: [user]
+    define member: [user, agent]
+
+type project
+  relations
+    define organization: [organization]
+    define owner: [user]
+    define member: [user, agent]
+    define can_delete: owner or admin from organization
+    define can_edit: owner or member or admin from organization
+    define can_read: can_edit or member or member from organization
+    define can_create_issue: can_edit
+
+type issue
+  relations
+    define project: [project]
+    define reporter: [user, agent]
+    define assignee: [user, agent]
+    define can_delete: reporter or can_delete from project
+    define can_edit: assignee or can_edit from project
+    define can_read: reporter or can_edit or can_read from project
+```
+
+The key changes:
+
+- `agent` is added as an allowed subject on `organization.member`, `project.member`, `issue.reporter`, and `issue.assignee`.
+- `member` is added to `project.can_edit` so that project members (including agents) can edit the project and its issues. In the original model, only `owner` and `admin` could edit.
+- No new permission types or hierarchies are needed - agents participate in the same structure as users.
+
+## Granting agent access
+
+Grant an agent membership on a specific project:
+
+```yaml
+tuples:
+  - user: agent:triage-bot
+    relation: member
+    object: project:alpha
+```
+
+Because the updated model includes `member` in both `can_read` and `can_edit`, this single tuple lets `agent:triage-bot` read and edit the project and its issues. The agent still cannot delete anything - `can_delete` requires `owner` or `admin`.
+
+## Checking permissions
+
+The examples below assume the issue is linked to its project:
+
+```yaml
+tuples:
+  - user: project:alpha
+    relation: project
+    object: issue:issue-123
+```
+
+Check whether the agent can read a specific issue. The agent's project membership grants access:
+
+<CheckRequestViewer
+  user={'agent:triage-bot'}
+  relation={'can_read'}
+  object={'issue:issue-123'}
+  allowed={true}
+  skipSetup={true}
+/>
+
+The agent cannot delete the issue because `can_delete` requires `reporter` or project-level `can_delete` (which requires `owner` or `admin`):
+
+<CheckRequestViewer
+  user={'agent:triage-bot'}
+  relation={'can_delete'}
+  object={'issue:issue-123'}
+  allowed={false}
+  skipSetup={true}
+/>
+
+## Direct assignment for fine-grained control
+
+Instead of granting project-wide access, you can assign the agent directly to a specific issue:
+
+```yaml
+tuples:
+  - user: agent:triage-bot
+    relation: assignee
+    object: issue:issue-456
+```
+
+Now the agent can edit `issue:issue-456` but has no access to other issues in the project.
+
+## Scoping agent access to an organization
+
+You can also grant an agent membership at the organization level. This gives it read access to all projects in the organization:
+
+```yaml
+tuples:
+  - user: agent:reporting-bot
+    relation: member
+    object: organization:acme
+```
+
+The agent inherits `can_read` on every project that belongs to `organization:acme`, and through that, can read all issues in those projects.
+
+## Migration strategy
+
+If your application already has a user-centric model:
+
+1. **Add the `agent` type** to your model.
+2. **Include `agent` in selected relations** where agents need access (`member`, `assignee`, `reporter`, etc.).
+3. **Write tuples** to grant agents access at the appropriate scope (organization, project, or issue).
+4. **Check permissions** using the same API calls you use for users - just with `agent:` as the subject. If you want to check for both user and agent permissions, perform a [batch check](../../interacting/relationship-queries.mdx#batch-check) call.
+
+## Recommendations
+
+- **Least privilege**: grant the narrowest scope possible. Prefer project-level membership over organization-level membership.
+- **Avoid wildcards**: do not use `agent:*` in production grants.
+
+## Related sections
+
+<RelatedSection
+  description="Take a look at the following sections for more information."
+  relatedLinks={[
+    {
+      title: 'Task-Based Authorization',
+      description: 'Grant agents access to perform specific actions only when necessary, with task-scoped permissions.',
+      link: '../../modeling/agents/task-based-authorization',
+    },
+    {
+      title: 'RAG Authorization',
+      description: 'Ensure AI agents only retrieve documents users are authorized to access.',
+      link: '../../modeling/agents/rag-authorization',
+    },
+    {
+      title: 'Authorization for MCP Servers',
+      description: 'Control which tools users can access on an MCP server.',
+      link: '../../modeling/agents/mcp-authorization',
+    },
+  ]}
+/>

--- a/docs/content/modeling/agents/agents-as-principals.mdx
+++ b/docs/content/modeling/agents/agents-as-principals.mdx
@@ -171,17 +171,17 @@ If your application already has a user-centric model:
     {
       title: 'Task-Based Authorization',
       description: 'Grant agents access to perform specific actions only when necessary, with task-scoped permissions.',
-      link: '../../modeling/agents/task-based-authorization',
+      link: './task-based-authorization',
     },
     {
       title: 'RAG Authorization',
       description: 'Ensure AI agents only retrieve documents users are authorized to access.',
-      link: '../../modeling/agents/rag-authorization',
+      link: './rag-authorization',
     },
     {
       title: 'Authorization for MCP Servers',
       description: 'Control which tools users can access on an MCP server.',
-      link: '../../modeling/agents/mcp-authorization',
+      link: './mcp-authorization',
     },
   ]}
 />

--- a/docs/content/modeling/agents/agents-as-principals.mdx
+++ b/docs/content/modeling/agents/agents-as-principals.mdx
@@ -1,8 +1,8 @@
 ---
-title: Add Agent Principals to Existing Models
-description: Extend a user-centric authorization model with agent principals and least-privilege delegation
+title: Modeling Agents as Principals
+description: Model agents as first-class principals in your authorization model so they inherit access through the same permission hierarchy as users
 sidebar_position: 4
-slug: /modeling/agents/agent-principals-in-existing-app
+slug: /modeling/agents/agents-as-principals
 ---
 
 import {
@@ -13,56 +13,19 @@ import {
   RelatedSection,
 } from '@components/Docs';
 
-# Add Agent Principals to Existing Models
+# Modeling Agents as Principals
 
 <DocumentationNotice />
 
-Most applications already have authorization models centered on human users. If you are building agents as part of your application, you can extend the existing model by adding `agent` as a first-class principal - the same way users are granted access to resources today.
+Most applications already have authorization models centered on human users. If you are building agents as part of your application, one common pattern is to model `agent` as a first-class principal - the same way users are granted access to resources today.
 
 This is orthogonal to patterns like [Task-Based Authorization](./task-based-authorization.mdx). Even if you use task-scoped permissions, you still want to constrain what an agent can do in general - beyond the permissions required for a specific task.
 
-This guide shows how to add agent principals to a <ProductName format={ProductNameFormat.ShortForm}/> model using an issue-tracking application as an example. The agent receives permissions on domain resources (projects, issues) and inherits access through the same hierarchy that users do.
+This guide shows how to model agents as principals in a <ProductName format={ProductNameFormat.ShortForm}/> authorization model using an issue-tracking application as an example. The agent receives permissions on domain resources (projects, issues) and inherits access through the same hierarchy that users do.
 
-## Before: user-centric model
+## Authorization model
 
-A typical issue-tracking model grants access to users and organization members:
-
-```dsl.openfga
-model
-  schema 1.1
-
-type user
-
-type organization
-  relations
-    define admin: [user]
-    define member: [user]
-
-type project
-  relations
-    define organization: [organization]
-    define owner: [user]
-    define member: [user]
-    define can_delete: owner or admin from organization
-    define can_edit: owner or admin from organization
-    define can_read: can_edit or member or member from organization
-    define can_create_issue: can_edit
-
-type issue
-  relations
-    define project: [project]
-    define reporter: [user]
-    define assignee: [user]
-    define can_delete: reporter or can_delete from project
-    define can_edit: assignee or can_edit from project
-    define can_read: reporter or can_edit or can_read from project
-```
-
-Users get access to issues through project membership, organization membership, or direct assignment. Agents have no place in this model yet.
-
-## After: adding agent principals
-
-Add an `agent` type and include it alongside `user` in the relations where agents need access:
+The following issue-tracking model treats `agent` as a first-class principal alongside `user`:
 
 ```dsl.openfga
 model
@@ -82,7 +45,7 @@ type project
     define owner: [user]
     define member: [user, agent]
     define can_delete: owner or admin from organization
-    define can_edit: owner or member or admin from organization
+    define can_edit: owner or admin from organization
     define can_read: can_edit or member or member from organization
     define can_create_issue: can_edit
 
@@ -96,13 +59,16 @@ type issue
     define can_read: reporter or can_edit or can_read from project
 ```
 
-The key changes:
+If your current model is user-centric, the main change is to allow `agent` anywhere you already allow `user` for the relationships an agent should hold.
+
+In this example:
 
 - `agent` is added as an allowed subject on `organization.member`, `project.member`, `issue.reporter`, and `issue.assignee`.
-- `member` is added to `project.can_edit` so that project members (including agents) can edit the project and its issues. In the original model, only `owner` and `admin` could edit.
 - No new permission types or hierarchies are needed - agents participate in the same structure as users.
 
-## Granting agent access
+This example keeps the original permission semantics intact. The only change is that `agent` can now appear in the same relations as `user`. If your application wants project members to edit projects or issues, that is a separate permission-model decision.
+
+## Granting access to agents
 
 Grant an agent membership on a specific project:
 
@@ -113,7 +79,7 @@ tuples:
     object: project:alpha
 ```
 
-Because the updated model includes `member` in both `can_read` and `can_edit`, this single tuple lets `agent:triage-bot` read and edit the project and its issues. The agent still cannot delete anything - `can_delete` requires `owner` or `admin`.
+Because `can_read` includes `member`, this single tuple lets `agent:triage-bot` read the project and its issues. The agent still cannot edit or delete anything - `can_edit` and `can_delete` retain the original `owner` and `admin` requirements.
 
 ## Checking permissions
 
@@ -159,7 +125,7 @@ tuples:
 
 Now the agent can edit `issue:issue-456` but has no access to other issues in the project.
 
-## Scoping agent access to an organization
+## Organization-level agent access
 
 You can also grant an agent membership at the organization level. This gives it read access to all projects in the organization:
 
@@ -171,6 +137,17 @@ tuples:
 ```
 
 The agent inherits `can_read` on every project that belongs to `organization:acme`, and through that, can read all issues in those projects.
+
+## When to use this pattern
+
+Modeling agents as principals works well when:
+
+1. Your application already has a user-centric authorization model.
+2. Agents act inside your application's own domain.
+3. You want agents to inherit access through the same resource hierarchy as users.
+4. You want to grant durable, non-task-specific permissions such as project membership or issue assignment.
+
+This pattern does not replace task-based authorization. It defines what an agent can do in general. Task-based authorization can then further constrain that access at runtime.
 
 ## Migration strategy
 

--- a/docs/content/modeling/agents/overview.mdx
+++ b/docs/content/modeling/agents/overview.mdx
@@ -12,6 +12,15 @@ import { CardGrid, DocumentationNotice, IntroCard, ProductName, ProductNameForma
 
 This section presents authorization patterns for AI agents and automated processes using <ProductName format={ProductNameFormat.LongForm}/>.
 
+AI agents interact with internal APIs on behalf of users, or with their own identity, and with third-party services on behalf of users or with service credentials. Without fine-grained authorization, agents often operate with broad credentials — accessing more than they should. The patterns in this section show how to use <ProductName format={ProductNameFormat.ShortForm}/> to scope agent permissions precisely.
+
+Agent authorization typically involves two domains:
+
+- **First-party authorization** — What can the agent do inside your own application? You extend your existing authorization model so agents participate in the same permission hierarchy as users. For example, an agent with project membership can read all issues in that project. See [Agent Principals in Existing Models](./agent-principals-in-existing-app.mdx).
+- **Third-party authorization** — What can the agent do in external systems (Slack, Jira, GitHub, etc.)? Because you do not control those systems, you model permissions around the tools and resources the agent can access, and narrow the scope beyond what the external credential allows. See [Authorization for MCP Servers](./mcp-authorization.mdx) and [RAG Authorization](./rag-authorization.mdx) — both patterns also apply to first-party resources.
+
+Cutting across both domains, [Task-Based Authorization](./task-based-authorization.mdx) constrains what an agent can do at runtime. Agents start with zero permissions and receive narrowly scoped grants for each task, with optional expiration, turn limits, and agent binding — regardless of whether the agent is acting on first-party or third-party resources.
+
 <IntroCard
   title="When to use"
   description="The content in this section is useful if you are building AI agents or automated systems that need fine-grained, scoped permissions to perform actions on behalf of users."
@@ -31,8 +40,13 @@ This section presents authorization patterns for AI agents and automated process
     },
     {
       title: 'Authorization for MCP Servers',
-      description: 'Control which tools users can access on an MCP server based on roles, groups, and temporal grants.',
+      description: 'Control which tools each user can access on an MCP server based on roles, group membership, and temporal grants.',
       to: 'agents/mcp-authorization',
+    },
+    {
+      title: 'Add Agent Principals to Existing Models',
+      description: 'Extend a user-centric authorization model with agent principals using the same permission structure as users.',
+      to: 'agents/agent-principals-in-existing-app',
     },
   ]}
 />

--- a/docs/content/modeling/agents/overview.mdx
+++ b/docs/content/modeling/agents/overview.mdx
@@ -16,7 +16,7 @@ AI agents interact with internal APIs on behalf of users, or with their own iden
 
 Agent authorization typically involves two domains:
 
-- **First-party authorization** — What can the agent do inside your own application? You extend your existing authorization model so agents participate in the same permission hierarchy as users. For example, an agent with project membership can read all issues in that project. See [Agent Principals in Existing Models](./agent-principals-in-existing-app.mdx).
+- **First-party authorization** — What can the agent do inside your own application? One common pattern is to model agents as first-class principals in your authorization model so they participate in the same permission hierarchy as users. For example, an agent with project membership can read all issues in that project. See [Modeling Agents as Principals](./agents-as-principals.mdx).
 - **Third-party authorization** — What can the agent do in external systems (Slack, Jira, GitHub, etc.)? Because you do not control those systems, you model permissions around the tools and resources the agent can access, and narrow the scope beyond what the external credential allows. See [Authorization for MCP Servers](./mcp-authorization.mdx) and [RAG Authorization](./rag-authorization.mdx) — both patterns also apply to first-party resources.
 
 Cutting across both domains, [Task-Based Authorization](./task-based-authorization.mdx) constrains what an agent can do at runtime. Agents start with zero permissions and receive narrowly scoped grants for each task, with optional expiration, turn limits, and agent binding — regardless of whether the agent is acting on first-party or third-party resources.
@@ -44,9 +44,9 @@ Cutting across both domains, [Task-Based Authorization](./task-based-authorizati
       to: 'agents/mcp-authorization',
     },
     {
-      title: 'Add Agent Principals to Existing Models',
-      description: 'Extend a user-centric authorization model with agent principals using the same permission structure as users.',
-      to: 'agents/agent-principals-in-existing-app',
+      title: 'Modeling Agents as Principals',
+      description: 'Model agents as first-class principals in a user-centric authorization model so they inherit access through the same permission hierarchy as users.',
+      to: 'agents/agents-as-principals',
     },
   ]}
 />

--- a/docs/content/modeling/agents/rag-authorization.mdx
+++ b/docs/content/modeling/agents/rag-authorization.mdx
@@ -22,6 +22,11 @@ Retrieval-Augmented Generation (RAG) enhances LLM responses by retrieving releva
 
 This guide shows how to model document permissions in <ProductName format={ProductNameFormat.ShortForm}/> and integrate authorization checks into a RAG pipeline, regardless of the framework or vector database you use.
 
+This pattern applies to both first-party and third-party scenarios:
+
+- **First-party** - Your application owns the documents and manages permissions directly. You write tuples to <ProductName format={ProductNameFormat.ShortForm}/> as part of your normal application flow (e.g., when a user creates a folder or shares a document).
+- **Third-party** - Documents and permissions live in an external system (Google Drive, Confluence, SharePoint, etc.). You synchronize content into your vector database and permissions into <ProductName format={ProductNameFormat.ShortForm}/>, keeping both in sync with the source system. The authorization model and filtering approaches are the same - the difference is that tuples come from a sync pipeline rather than your application.
+
 ## Authorization model
 
 A typical RAG knowledge base contains documents organized in folders, with access controlled at both levels. The following model represents this structure:
@@ -44,7 +49,7 @@ type document
     define viewer: [user] or owner or viewer from folder
 ```
 
-A `folder` has `owner` and `viewer` relations. A `document` belongs to a folder and inherits its viewers — anyone who can view the folder can view all documents inside it. You can also grant direct access to individual documents.
+A `folder` has `owner` and `viewer` relations. A `document` belongs to a folder and inherits its viewers - anyone who can view the folder can view all documents inside it. You can also grant direct access to individual documents.
 
 ## Writing tuples
 
@@ -88,7 +93,7 @@ With this setup:
 
 There are two main approaches to integrate <ProductName format={ProductNameFormat.ShortForm}/> into a RAG pipeline. Both ensure that the LLM only sees documents the user is authorized to access.
 
-### Retrieve then check
+### Post-filtering
 
 Query the vector database first, then filter results by checking permissions with <ProductName format={ProductNameFormat.ShortForm}/>. This is the most common approach and works well when the vector search returns a manageable number of candidates.
 
@@ -131,7 +136,7 @@ Use the [`BatchCheck`](../../interacting/relationship-queries.mdx#batch-check) A
 
 Only `document:roadmap` is returned as allowed. The pipeline filters out the other two documents before passing context to the LLM.
 
-### Build an authorized list, then retrieve
+### Pre-filtering
 
 Retrieve the list of documents the user can access first, then pass those IDs as a filter to the vector search. This approach works well when the user has access to a relatively small number of documents.
 
@@ -152,11 +157,11 @@ For example, to get all documents `user:carl` can view:
   skipSetup={true}
 />
 
-Pass the resulting document IDs as a filter to your vector database. Most vector databases support metadata filtering — use the document ID stored in each vector's metadata to restrict the search.
+Pass the resulting document IDs as a filter to your vector database. Most vector databases support metadata filtering - use the document ID stored in each vector's metadata to restrict the search.
 
 ## Choosing an approach
 
-| Criteria | Retrieve then check | Build list, then retrieve |
+| Criteria | Post-filtering | Pre-filtering |
 |---|---|---|
 | Vector search returns few candidates | Good fit | Works, but unnecessary overhead |
 | User has access to few documents | Works, but may discard many results | Good fit |
@@ -166,7 +171,7 @@ Pass the resulting document IDs as a filter to your vector database. Most vector
 For detailed guidance on choosing between these approaches and handling more complex scenarios, see [Search With Permissions](../../interacting/search-with-permissions.mdx).
 
 :::tip
-When using "retrieve then check", request more candidates than you need from the vector database (e.g., 2-3x your target count) to account for documents that will be filtered out.
+When using post-filtering, request more candidates than you need from the vector database (e.g., 2-3x your target count) to account for documents that will be filtered out.
 :::
 
 ## Framework integration

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -347,7 +347,7 @@ const sidebars = {
           type: 'doc',
           label: 'Modeling Agents as Principals',
           id: 'content/modeling/agents/agents-as-principals',
-        },        
+        },
         {
           type: 'doc',
           label: 'RAG Authorization',

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -345,8 +345,8 @@ const sidebars = {
       items: [
         {
           type: 'doc',
-          label: 'Agent Principals in Existing Models',
-          id: 'content/modeling/agents/agent-principals-in-existing-app',
+          label: 'Modeling Agents as Principals',
+          id: 'content/modeling/agents/agents-as-principals',
         },        
         {
           type: 'doc',

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -313,33 +313,6 @@ const sidebars = {
           type: 'category',
           collapsed: true,
           collapsible: true,
-          label: 'Authorization for Agents',
-          link: {
-            type: 'doc',
-            id: 'content/modeling/agents/overview',
-          },
-          items: [
-            {
-              type: 'doc',
-              label: 'Task-Based Authorization',
-              id: 'content/modeling/agents/task-based-authorization',
-            },
-            {
-              type: 'doc',
-              label: 'RAG Authorization',
-              id: 'content/modeling/agents/rag-authorization',
-            },
-            {
-              type: 'doc',
-              label: 'Authorization for MCP Servers',
-              id: 'content/modeling/agents/mcp-authorization',
-            },
-          ],
-        },
-        {
-          type: 'category',
-          collapsed: true,
-          collapsible: true,
           label: 'Migrations',
           link: {
             type: 'doc',
@@ -357,6 +330,38 @@ const sidebars = {
               id: 'content/modeling/migrating/migrating-models',
             },
           ],
+        },
+      ],
+    },
+    {
+      type: 'category',
+      collapsible: true,
+      collapsed: false,
+      label: 'Authorization for Agents',
+      link: {
+        type: 'doc',
+        id: 'content/modeling/agents/overview',
+      },
+      items: [
+        {
+          type: 'doc',
+          label: 'Agent Principals in Existing Models',
+          id: 'content/modeling/agents/agent-principals-in-existing-app',
+        },        
+        {
+          type: 'doc',
+          label: 'RAG Authorization',
+          id: 'content/modeling/agents/rag-authorization',
+        },
+        {
+          type: 'doc',
+          label: 'Authorization for MCP Servers',
+          id: 'content/modeling/agents/mcp-authorization',
+        },
+        {
+          type: 'doc',
+          label: 'Task-Based Authorization',
+          id: 'content/modeling/agents/task-based-authorization',
         },
       ],
     },


### PR DESCRIPTION

<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
- Added a new guide: Agent Principals in Existing Models
- Framed the Agents overview around:
   - first-party authorization inside applications you build
   - third-party authorization for external tools and systems
    - task-based authorization as a cross-cutting runtime control
- Added the new guide to the Agents landing page card grid
- Reordered the Agents docs sidebar and made the category more prominent
- Clarified the RAG authorization guide to explicitly cover both first-party and third-party scenarios
- Renamed the RAG filtering strategies to Post-filtering and Pre-filtering for clearer terminology

#### What problem is being solved?

#### How is it being solved?

#### What changes are made to solve it?

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * New guide on integrating agent principals into existing authorization models
  * Enhanced agent authorization overview clarifying first-party and third-party domains
  * Improved RAG authorization documentation with clearer terminology and filtering patterns
  * Reorganized documentation structure for better agent-related content navigation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->