### PR TITLE
feat: add production adopter case studies

### DIFF
--- a/docs/content/adopters/agicap.mdx
+++ b/docs/content/adopters/agicap.mdx
@@ -50,4 +50,4 @@ When the team filed a critical performance issue, the upstream maintainers shipp
 
 ## Source
 
-This case study is based on the public CNCF TOC adopter interview with Pauline Jamin, Head of Engineering – Finance and Core at Agicap, available in the [`cncf/toc` repository](https://github.com/cncf/toc/tree/main/projects/openfga), and a [presentation in the OpenFGA community meeting on Agicap's OpenFGA deployment](https://www.youtube.com/watch?v=XBHqGFfe-K4).
+This case study is based on the public CNCF TOC adopter interview with Pauline Jamin, Head of Engineering - Finance and Core at Agicap, available in the [`cncf/toc` repository](https://github.com/cncf/toc/tree/main/projects/openfga), and a [presentation in the OpenFGA community meeting on Agicap's OpenFGA deployment](https://www.youtube.com/watch?v=XBHqGFfe-K4).

--- a/docs/content/adopters/agicap.mdx
+++ b/docs/content/adopters/agicap.mdx
@@ -1,0 +1,53 @@
+---
+title: Agicap Case Study
+description: How European fintech Agicap runs OpenFGA in production for 8,000+ customers at 250 RPS with conditional ReBAC across every backend service.
+sidebar_position: 2
+slug: /adopters/agicap
+---
+
+# Agicap: Fine-grained authorization for a European fintech platform
+
+[Agicap](https://agicap.com) is a European fintech that helps small, medium, and large enterprises manage cash flow in real time. Its SaaS platform serves more than 8,000 customers across industries, and every backend service in the platform validates access through OpenFGA.
+
+## At a glance
+
+| | |
+| --- | --- |
+| **Industry** | Fintech / cash flow management |
+| **In production since** | April 2023 |
+| **Scale** | ~250 requests per second, 8,000+ customers |
+| **Deployment** | Self-hosted, on-premises |
+| **Key features used** | ReBAC, conditional relationships |
+
+## Why OpenFGA
+
+Agicap needed an open-source authorization layer with a strong community, on-premises deployment for compliance, and a model flexible enough to express financial-product permissions that pure RBAC could not. They evaluated alternatives such as Oso and concluded OpenFGA was the most stable option that fit those requirements, with approachable maintainers and clear documentation.
+
+The team specifically chose ReBAC over an RBAC redesign because it let them express fine-grained relationships without re-inventing authorization logic inside every service. Learn more about that trade-off in [RBAC vs ReBAC](/docs/authorization-concepts).
+
+## Architecture and scale
+
+- All backend services call OpenFGA via an internal **secure facade** rather than the OpenFGA API directly. The facade enforces application-level rules on top of OpenFGA so the data plane is never exposed.
+- Authorization is enforced consistently across development, pre-production, load-test, and production environments.
+- Performance work over time pushed Agicap from a deeper hierarchy to a flatter authorization model, which improved both query latency and scalability — a pattern documented in the [performance best practices](/docs/best-practices).
+
+## Engineering with the community
+
+Agicap is an active upstream contributor:
+
+- Engineers from the platform and SRE teams open pull requests against `openfga/openfga` to fix bugs and tune performance.
+- The team participates in the monthly OpenFGA community call.
+- Agicap has co-presented OpenFGA talks with maintainers at KubeCon EU 2024 (Paris) and KubeCon NA 2024 (Salt Lake City).
+
+When the team filed a critical performance issue, the upstream maintainers shipped a fix within 24 hours.
+
+## Outcomes
+
+- A single, evolvable authorization layer behind every backend service.
+- Faster delivery of new permissions — schema changes replace code changes.
+- Cost savings from running self-hosted instead of a proprietary alternative.
+- Confidence at production scale with 8,000+ customers and continuous traffic.
+
+## Source
+
+This case study is based on the public CNCF TOC adopter interview with Pauline Jamin, Head of Engineering – Finance and Core at Agicap, available in the [`cncf/toc` repository](https://github.com/cncf/toc/tree/main/projects/openfga), and a [presentation in the OpenFGA community meeting on Agicap's OpenFGA deployment](https://www.youtube.com/watch?v=XBHqGFfe-K4).

--- a/docs/content/adopters/docker.mdx
+++ b/docs/content/adopters/docker.mdx
@@ -1,0 +1,46 @@
+---
+title: Docker Case Study
+description: How Docker migrated to OpenFGA with a parallel-run strategy and now uses ReBAC to centralize permissions across products.
+sidebar_position: 3
+slug: /adopters/docker
+---
+
+# Docker: Centralizing permissions with ReBAC
+
+[Docker](https://www.docker.com) provides tools that help developers build, share, run, and verify applications across environments. Docker adopted OpenFGA in early 2024 and uses it to centralize authorization across an expanding set of products.
+
+## At a glance
+
+| | |
+| --- | --- |
+| **Industry** | Developer tools / platform |
+| **In production since** | March 2024 |
+| **Scale** | 100-150 requests per second |
+| **Deployment** | Self-hosted |
+| **Key features used** | ReBAC, DSL, SDKs and CLI |
+
+## Why OpenFGA
+
+Docker evaluated several access-control systems before choosing OpenFGA. The decision came down to:
+
+- **ReBAC** as a more flexible model than RBAC for the products Docker builds.
+- **Self-hosted, open source**, easy to run locally (a working stack via Docker Compose in under five minutes).
+- **CNCF backing** and contributors with strong security pedigree.
+- Mature **SDKs, APIs, and testing tools**.
+- A responsive maintainer community.
+
+## Migration approach
+
+Docker ran OpenFGA in **parallel with the existing authorization system**: every permission check went to both engines, and results were compared. Once both systems consistently agreed, traffic was incrementally cut over to OpenFGA. The parallel-run pattern is one we recommend for any production migration — see the [adoption patterns guide](/docs/best-practices).
+
+## Outcomes
+
+- Permission changes that previously required code changes are now centralized in the authorization model file.
+- New Docker products integrate into the access-control system faster.
+- Operational overhead for permission updates dropped substantially.
+
+The early scaling pain points the team hit — particularly batch checks across many records — were addressed quickly by upstream releases.
+
+## Source
+
+This case study is based on the public CNCF TOC adopter interview with Gurleen Sethi, Senior Software Engineer at Docker, Inc., available in the [`cncf/toc` repository](https://github.com/cncf/toc/tree/main/projects/openfga).

--- a/docs/content/adopters/grafana.mdx
+++ b/docs/content/adopters/grafana.mdx
@@ -1,0 +1,54 @@
+---
+title: Grafana Labs Case Study
+description: Why Grafana Labs replaced its single-tenant access control engine with OpenFGA to power multi-tenant Grafana Cloud and embedded OSS deployments.
+sidebar_position: 4
+slug: /adopters/grafana
+---
+
+# Grafana Labs: From single-tenant engine to multi-tenant ReBAC
+
+[Grafana Labs](https://grafana.com) is the company behind Grafana, Loki, Tempo, Mimir, and the LGTM observability stack. Grafana adopted OpenFGA to replace an internal single-tenant access-control engine that no longer fit the multi-tenant architecture of Grafana Cloud.
+
+## At a glance
+
+| | |
+| --- | --- |
+| **Industry** | Observability |
+| **First experiments** | February 2024 |
+| **Mainline integration** | August 2024 |
+| **Version** | v1.10.0 |
+| **Deployment** | Multi-tenant SaaS, embedded OSS, on-premises |
+
+## Why OpenFGA
+
+Grafana needed an engine that did **two** things competitors did not bundle:
+
+1. **Authorization evaluation** — like an OPA-style policy engine.
+2. **A storage layer for permissions** — a tuple store with a per-tenant schema.
+
+That combination, plus OpenFGA's **CNCF affiliation** and explicit governance policy, made it preferable to building yet another in-house system or adopting a project that could change its license later.
+
+## Architecture and scale
+
+OpenFGA runs in three Grafana environments:
+
+- **Development and staging** — already serving internal production workloads.
+- **External production** — deployed to a single cluster in a pre-production capacity, shadowing real traffic to validate consistency and performance before broader rollout.
+
+The team standardized on the **PostgreSQL adapter** after finding the MySQL adapter less mature. Refactoring Grafana's legacy schema toward OpenFGA-native modeling produced significant performance gains — an outcome echoed by the [source-of-truth best practice](/docs/best-practices).
+
+## Upstream investment
+
+- Grafana **maintains the SQLite adapter**, which was contributed back to OpenFGA so it can ship with embedded Grafana.
+- Future areas of contribution include **pluggable storage** (so non-core storage adapters work without rebuilding OpenFGA) and **observability** improvements.
+- KubeCon EU 2025 talk: *From Chaos To Control: Migrating Access Control* by Jo Guerreiro and Poovamraj Thanganadar Thiagarajan.
+
+## Outcomes
+
+- One authorization platform spans Grafana Cloud (multi-tenant SaaS) and Grafana OSS (embedded), removing the need to maintain separate engines.
+- Schema-driven iteration replaced engine-tuning work the team used to do manually.
+- The team is targeting **list-users** to enable reverse permission search — showing all users who can access a given resource — a capability the legacy engine never had.
+
+## Source
+
+This case study is based on the public CNCF TOC adopter interview with Joao Guerreiro, Senior Engineering Manager at Grafana Labs, available in the [`cncf/toc` repository](https://github.com/cncf/toc/tree/main/projects/openfga).

--- a/docs/content/adopters/headspace.mdx
+++ b/docs/content/adopters/headspace.mdx
@@ -1,0 +1,46 @@
+---
+title: Headspace Case Study
+description: How Headspace authorizes Ebb, its empathetic AI companion, with OpenFGA — driving end-to-end checks down from 10–15 seconds to 10–15 milliseconds.
+sidebar_position: 6
+slug: /adopters/headspace
+---
+
+# Headspace: Authorizing an empathetic AI companion at consumer scale
+
+[Headspace](https://www.headspace.com) is a global mental-health platform with over 105 million app downloads and 90 million lives reached. Its AI companion, Ebb, has handled more than 6 million conversations since launching, and every message Ebb processes runs through an OpenFGA authorization check.
+
+## At a glance
+
+| | |
+| --- | --- |
+| **Industry** | Mental health / consumer health |
+| **Use case** | AI companion (Ebb) gating |
+| **Scale** | 90M+ lives, 105M+ downloads, 6M+ Ebb messages |
+| **Deployment** | Self-hosted |
+| **Key features used** | BatchCheck, contextual tuples, graph design, Terraform-managed model |
+
+## Why OpenFGA
+
+Ebb is gated on a combination of business rules: who the member is contracted through, which country they are messaging from, which language their app is set to, and whether their employer has opted them out. A pure RBAC system could not express this without exploding into a role per combination, and a hand-rolled SQL check ran 10–15 seconds in the worst case — unacceptable for a chat experience.
+
+The Headspace team chose OpenFGA so the AI gating rules could live in a single relationship graph the platform team owned, with the same model evaluated from every service that fronts Ebb.
+
+## Architecture
+
+- **Wrapper API in front of OpenFGA.** Application services do not call the OpenFGA store directly. They call an internal authorization service that fans out **four parallel [BatchCheck](/docs/interacting/relationship-queries) requests** — assigned-to-Ebb, country-allowed, language-allowed, and not-blocked-by-org — and combines the results.
+- **Inverted graph for performance.** The original model put the AI feature at the top with users below; a check meant traversing the entire user population. Flipping the direction so the user is the object and Ebb access is reached through unions of small relations dropped end-to-end latency from 10–15 seconds to 10–15 milliseconds.
+- **Bidirectional tuple writes.** When a member-to-feature relationship is written, the inverse tuple is written at the same time, keeping reads cheap in either direction.
+- **Terraform-managed model and static tuples.** The authorization model and the static enablement tuples (countries, languages, default org policies) ship through the Headspace [OpenFGA Terraform provider](https://github.com/openfga/terraform-provider-openfga), so model changes go through the same review pipeline as infrastructure.
+- **Hidden model version.** The wrapper API does not expose the OpenFGA model ID to consumers; rolling forward to a new model version is a deploy of the wrapper, not a coordinated change across every caller.
+- **SDK 1.10 conflict resolution.** The team adopted the conflict-resolution behavior shipped in SDK 1.10 to safely handle concurrent tuple writes during high-traffic enrollment events.
+
+## Outcomes
+
+- **End-to-end Ebb authorization in 10-15 ms**, down from 10-15 seconds.
+- **Per-user blocking added without touching call sites** — a new relation in the model and a tuple write was enough; no service had to ship code.
+- **Single source of truth** for AI gating rules, owned by the platform team and reviewed in Terraform.
+- **Operational headroom** to extend Ebb gating (new languages, new contracts, new opt-out criteria) without rewriting application code.
+
+## Source
+
+This case study is based on a [presentation in the OpenFGA community meeting by Jeremy, principal engineer at Headspace](https://www.youtube.com/watch?v=xCu39aG7B1A). Supporting public material on Ebb is available at [headspace.com](https://www.headspace.com).

--- a/docs/content/adopters/headspace.mdx
+++ b/docs/content/adopters/headspace.mdx
@@ -1,6 +1,6 @@
 ---
 title: Headspace Case Study
-description: How Headspace authorizes Ebb, its empathetic AI companion, with OpenFGA — driving end-to-end checks down from 10–15 seconds to 10–15 milliseconds.
+description: How Headspace authorizes Ebb, its empathetic AI companion, with OpenFGA — driving end-to-end checks down from 10-15 seconds to 10-15 milliseconds.
 sidebar_position: 6
 slug: /adopters/headspace
 ---
@@ -21,14 +21,14 @@ slug: /adopters/headspace
 
 ## Why OpenFGA
 
-Ebb is gated on a combination of business rules: who the member is contracted through, which country they are messaging from, which language their app is set to, and whether their employer has opted them out. A pure RBAC system could not express this without exploding into a role per combination, and a hand-rolled SQL check ran 10–15 seconds in the worst case — unacceptable for a chat experience.
+Ebb is gated on a combination of business rules: who the member is contracted through, which country they are messaging from, which language their app is set to, and whether their employer has opted them out. A pure RBAC system could not express this without exploding into a role per combination, and a hand-rolled SQL check ran 10-15 seconds in the worst case — unacceptable for a chat experience.
 
 The Headspace team chose OpenFGA so the AI gating rules could live in a single relationship graph the platform team owned, with the same model evaluated from every service that fronts Ebb.
 
 ## Architecture
 
 - **Wrapper API in front of OpenFGA.** Application services do not call the OpenFGA store directly. They call an internal authorization service that fans out **four parallel [BatchCheck](/docs/interacting/relationship-queries) requests** — assigned-to-Ebb, country-allowed, language-allowed, and not-blocked-by-org — and combines the results.
-- **Inverted graph for performance.** The original model put the AI feature at the top with users below; a check meant traversing the entire user population. Flipping the direction so the user is the object and Ebb access is reached through unions of small relations dropped end-to-end latency from 10–15 seconds to 10–15 milliseconds.
+- **Inverted graph for performance.** The original model put the AI feature at the top with users below; a check meant traversing the entire user population. Flipping the direction so the user is the object and Ebb access is reached through unions of small relations dropped end-to-end latency from 10-15 seconds to 10-15 milliseconds.
 - **Bidirectional tuple writes.** When a member-to-feature relationship is written, the inverse tuple is written at the same time, keeping reads cheap in either direction.
 - **Terraform-managed model and static tuples.** The authorization model and the static enablement tuples (countries, languages, default org policies) ship through the Headspace [OpenFGA Terraform provider](https://github.com/openfga/terraform-provider-openfga), so model changes go through the same review pipeline as infrastructure.
 - **Hidden model version.** The wrapper API does not expose the OpenFGA model ID to consumers; rolling forward to a new model version is a deploy of the wrapper, not a coordinated change across every caller.

--- a/docs/content/adopters/openlane.mdx
+++ b/docs/content/adopters/openlane.mdx
@@ -1,5 +1,5 @@
 ---
-title: OpenLane Case Study
+title: Openlane Case Study
 description: How compliance-automation startup OpenLane wires OpenFGA into ent at the data-access layer, with overfetch + BatchCheck replacing slow ListObjects.
 sidebar_position: 7
 slug: /adopters/openlane
@@ -7,7 +7,7 @@ slug: /adopters/openlane
 
 # OpenLane: Authorization at the data-access layer for compliance automation
 
-[OpenLane](https://theopenlane.io) is an open-source compliance automation platform that helps teams achieve and maintain SOC 2, ISO 27001, and similar attestations. OpenFGA is wired into its data-access layer, so every GraphQL query and mutation is authorized without each resolver having to remember to ask.
+[Openlane](https://theopenlane.io) is an open-source compliance automation platform that helps teams achieve and maintain SOC 2, ISO 27001, and similar attestations. OpenFGA is wired into its data-access layer, so every GraphQL query and mutation is authorized without each resolver having to remember to ask.
 
 ## At a glance
 
@@ -20,16 +20,16 @@ slug: /adopters/openlane
 
 ## Why OpenFGA
 
-OpenLane builds the kind of platform whose customers will themselves be audited. Authorization had to be defensible end-to-end — every read, every write, every export — and could not live in a `if user.role == "admin"` switch sprinkled across resolvers. The team picked OpenFGA so authorization decisions were centralized, modeled as relationships, and could evolve without code changes in every service.
+Openlane builds the kind of platform whose customers will themselves be audited. Authorization had to be defensible end-to-end — every read, every write, every export — and could not live in a `if user.role == "admin"` switch sprinkled across resolvers. The team picked OpenFGA so authorization decisions were centralized, modeled as relationships, and could evolve without code changes in every service.
 
-A second motivation was packaging: OpenLane sells modules, and the same engine that grants access to a record can grant access to a feature. OpenFGA is the source of truth for **both**.
+A second motivation was packaging: Openlane sells modules, and the same engine that grants access to a record can grant access to a feature. OpenFGA is the source of truth for **both**.
 
 ## Architecture
 
-- **Authorization as ent middleware.** OpenLane uses [ent](https://entgo.io/) hooks to write tuples on every mutation and interceptors plus policies to evaluate every query. Resolvers do not call the OpenFGA SDK directly; the data-access layer does.
+- **Authorization as ent middleware.** Openlane uses [ent](https://entgo.io/) hooks to write tuples on every mutation and interceptors plus policies to evaluate every query. Resolvers do not call the OpenFGA SDK directly; the data-access layer does.
 - **Object-owned mixin.** A reusable ent mixin attaches `owner` and parent relations to any record type, so cascading permissions ("an editor of the parent program can edit each control") are declared once and applied uniformly.
 - **Overfetch + BatchCheck instead of ListObjects.** An early implementation used [ListObjects](/docs/interacting/relationship-queries) and saw ~8-second worst-case latency for large result sets. The team switched to overfetching candidates from Postgres (capped at 100 per page, up to 1,000 overfetched) and running [BatchCheck](/docs/interacting/relationship-queries) to filter in a single round trip. Total counts are computed via a separate query that short-circuits when the user is an admin.
-- **In-house wrapper packages.** Three small Go packages — `FGX` (typed helpers around the OpenFGA SDK), `NFGA` (no-op fakes for unit tests), and `access-map` (declarative relation registration) — keep callers honest and make adding a new entity type a few lines of mixin configuration.
+- **In-house wrapper packages.** Three small Go packages — `FGAX` (typed helpers around the OpenFGA SDK), [`entfga`](https://github.com/theopenlane/iam/tree/main/entfga) (ent hooks that write tuples), and `access-map` (declarative relation registration) — keep callers honest and make adding a new entity type a few lines of mixin configuration.
 - **OpenFGA-as-feature-flags.** Module entitlements ("does this tenant have the policy module?") live in the same OpenFGA store as record-level permissions, so a check that returns `false` because the user is not an editor and a check that returns `false` because the tenant did not buy the module use the same call site.
 
 ## Outcomes
@@ -41,4 +41,4 @@ A second motivation was packaging: OpenLane sells modules, and the same engine t
 
 ## Source
 
-This case study is based on a [presentation in the OpenFGA community meeting by Sarah Funkhouser, co-founder and head of engineering at OpenLane](https://www.youtube.com/watch?v=ZdlftEKQ0UA). The OpenLane platform itself is open source — the integration patterns above are visible in the [theopenlane GitHub organization](https://github.com/theopenlane).
+This case study is based on a [presentation in the OpenFGA community meeting by Sarah Funkhouser, co-founder and head of engineering at Openlane](https://www.youtube.com/watch?v=ZdlftEKQ0UA). The Openlane platform itself is open source — the integration patterns above are visible in the [theopenlane GitHub organization](https://github.com/theopenlane).

--- a/docs/content/adopters/openlane.mdx
+++ b/docs/content/adopters/openlane.mdx
@@ -1,0 +1,44 @@
+---
+title: OpenLane Case Study
+description: How compliance-automation startup OpenLane wires OpenFGA into ent at the data-access layer, with overfetch + BatchCheck replacing slow ListObjects.
+sidebar_position: 7
+slug: /adopters/openlane
+---
+
+# OpenLane: Authorization at the data-access layer for compliance automation
+
+[OpenLane](https://theopenlane.io) is an open-source compliance automation platform that helps teams achieve and maintain SOC 2, ISO 27001, and similar attestations. OpenFGA is wired into its data-access layer, so every GraphQL query and mutation is authorized without each resolver having to remember to ask.
+
+## At a glance
+
+| | |
+| --- | --- |
+| **Industry** | Compliance automation (GRC) |
+| **Stack** | Go, GraphQL (gqlgen), [ent](https://entgo.io/) ORM, PostgreSQL, Kubernetes |
+| **Deployment** | Self-hosted; separate Postgres databases for application data and OpenFGA |
+| **Key features used** | BatchCheck, contextual tuples, object-owned cascading permissions, FGA-driven feature flags |
+
+## Why OpenFGA
+
+OpenLane builds the kind of platform whose customers will themselves be audited. Authorization had to be defensible end-to-end — every read, every write, every export — and could not live in a `if user.role == "admin"` switch sprinkled across resolvers. The team picked OpenFGA so authorization decisions were centralized, modeled as relationships, and could evolve without code changes in every service.
+
+A second motivation was packaging: OpenLane sells modules, and the same engine that grants access to a record can grant access to a feature. OpenFGA is the source of truth for **both**.
+
+## Architecture
+
+- **Authorization as ent middleware.** OpenLane uses [ent](https://entgo.io/) hooks to write tuples on every mutation and interceptors plus policies to evaluate every query. Resolvers do not call the OpenFGA SDK directly; the data-access layer does.
+- **Object-owned mixin.** A reusable ent mixin attaches `owner` and parent relations to any record type, so cascading permissions ("an editor of the parent program can edit each control") are declared once and applied uniformly.
+- **Overfetch + BatchCheck instead of ListObjects.** An early implementation used [ListObjects](/docs/interacting/relationship-queries) and saw ~8-second worst-case latency for large result sets. The team switched to overfetching candidates from Postgres (capped at 100 per page, up to 1,000 overfetched) and running [BatchCheck](/docs/interacting/relationship-queries) to filter in a single round trip. Total counts are computed via a separate query that short-circuits when the user is an admin.
+- **In-house wrapper packages.** Three small Go packages — `FGX` (typed helpers around the OpenFGA SDK), `NFGA` (no-op fakes for unit tests), and `access-map` (declarative relation registration) — keep callers honest and make adding a new entity type a few lines of mixin configuration.
+- **OpenFGA-as-feature-flags.** Module entitlements ("does this tenant have the policy module?") live in the same OpenFGA store as record-level permissions, so a check that returns `false` because the user is not an editor and a check that returns `false` because the tenant did not buy the module use the same call site.
+
+## Outcomes
+
+- **Authorization can't be forgotten.** Hooks and interceptors mean a new entity type inherits authorization automatically.
+- **List-style endpoints went from ~8 s worst case to comfortably under a second** at expected page sizes, without changing the public API.
+- **One store, two jobs.** Record permissions and feature entitlements live in OpenFGA, so packaging changes don't require a second policy system.
+- **Auditable end-to-end.** Tuple writes happen in the same transaction boundary as the underlying data mutation, so the access graph and the data it protects don't drift.
+
+## Source
+
+This case study is based on a [presentation in the OpenFGA community meeting by Sarah Funkhouser, co-founder and head of engineering at OpenLane](https://www.youtube.com/watch?v=ZdlftEKQ0UA). The OpenLane platform itself is open source — the integration patterns above are visible in the [theopenlane GitHub organization](https://github.com/theopenlane).

--- a/docs/content/adopters/openlane.mdx
+++ b/docs/content/adopters/openlane.mdx
@@ -5,7 +5,7 @@ sidebar_position: 7
 slug: /adopters/openlane
 ---
 
-# OpenLane: Authorization at the data-access layer for compliance automation
+# Openlane: Authorization at the data-access layer for compliance automation
 
 [Openlane](https://theopenlane.io) is an open-source compliance automation platform that helps teams achieve and maintain SOC 2, ISO 27001, and similar attestations. OpenFGA is wired into its data-access layer, so every GraphQL query and mutation is authorized without each resolver having to remember to ask.
 
@@ -28,7 +28,7 @@ A second motivation was packaging: Openlane sells modules, and the same engine t
 
 - **Authorization as ent middleware.** Openlane uses [ent](https://entgo.io/) hooks to write tuples on every mutation and interceptors plus policies to evaluate every query. Resolvers do not call the OpenFGA SDK directly; the data-access layer does.
 - **Object-owned mixin.** A reusable ent mixin attaches `owner` and parent relations to any record type, so cascading permissions ("an editor of the parent program can edit each control") are declared once and applied uniformly.
-- **Overfetch + BatchCheck instead of ListObjects.** An early implementation used [ListObjects](/docs/interacting/relationship-queries) and saw ~8-second worst-case latency for large result sets. The team switched to overfetching candidates from Postgres (capped at 100 per page, up to 1,000 overfetched) and running [BatchCheck](/docs/interacting/relationship-queries) to filter in a single round trip. Total counts are computed via a separate query that short-circuits when the user is an admin.
+- **Overfetch + BatchCheck instead of ListObjects.** An early implementation used [ListObjects](/docs/getting-started/perform-list-objects) and saw ~8-second worst-case latency for large result sets. The team switched to overfetching candidates from Postgres (capped at 100 per page, up to 1,000 overfetched) and running [BatchCheck](/docs/getting-started/perform-check#03-calling-batch-check-api) to filter in a single round trip. Total counts are computed via a separate query that short-circuits when the user is an admin.
 - **In-house wrapper packages.** Three small Go packages — `FGAX` (typed helpers around the OpenFGA SDK), [`entfga`](https://github.com/theopenlane/iam/tree/main/entfga) (ent hooks that write tuples), and `access-map` (declarative relation registration) — keep callers honest and make adding a new entity type a few lines of mixin configuration.
 - **OpenFGA-as-feature-flags.** Module entitlements ("does this tenant have the policy module?") live in the same OpenFGA store as record-level permissions, so a check that returns `false` because the user is not an editor and a check that returns `false` because the tenant did not buy the module use the same call site.
 

--- a/docs/content/adopters/overview.mdx
+++ b/docs/content/adopters/overview.mdx
@@ -1,0 +1,38 @@
+---
+title: OpenFGA Adopters and Case Studies
+description: Production OpenFGA case studies from Agicap, Docker, Grafana Labs, Headspace, OpenLane, Read AI, Vitrolife, Zuplo and other adopters running fine-grained authorization at scale.
+sidebar_position: 1
+slug: /adopters
+---
+
+# OpenFGA in production
+
+OpenFGA is deployed in production at fintechs, observability platforms, AI products, developer-tool companies, and API platforms. The case studies below are based on public [CNCF TOC adopter interviews](https://github.com/cncf/toc/tree/main/projects/openfga).
+
+## Featured case studies
+
+| Adopter | Industry | In production since | Scale |
+| --- | --- | --- | --- |
+| [Read AI](/docs/adopters/read-ai) | AI meeting intelligence | April 2023 | 5,200 RPS peak, 5.3B+ tuples |
+| [Agicap](/docs/adopters/agicap) | Fintech | April 2023 | ~250 RPS, 8,000+ customers |
+| [Zuplo](/docs/adopters/zuplo) | API management | 2024 | 500+ RPS spikes, multi-region edge |
+| [Grafana Labs](/docs/adopters/grafana) | Observability | 2024 | Multi-tenant SaaS + embedded OSS |
+| [Docker](/docs/adopters/docker) | Developer tools | March 2024 | 100–150 RPS |
+| [Headspace](/docs/adopters/headspace) | Mental health & consumer | 2024 | 90M lives, 6M Ebb messages, 10-15 ms p99 |
+| [OpenLane](/docs/adopters/openlane) | Compliance SaaS | 2024 | ent ORM hooks, BatchCheck overfetch (100/1000) |
+| [Vitrolife Group](/docs/adopters/vitrolife) | Healthcare | 2025 | Hybrid Entra + OpenFGA, hourly differential sync |
+
+## What these adopters have in common
+
+- **Self-hosted, open source.** Every adopter cited the ability to run OpenFGA themselves as a key reason for choosing it over proprietary offerings.
+- **PostgreSQL at scale.** Production deployments are running on Postgres, with billions of tuples in the largest case.
+- **ReBAC over RBAC.** Each team chose relationship-based access control for the flexibility it gives over flat role models. See [authorization concepts](/docs/authorization-concepts) for a refresher.
+- **CNCF governance** matters. Teams explicitly contrasted CNCF stewardship with the licensing risk of source-available alternatives.
+
+## Adopter list
+
+OpenFGA is also publicly used by organizations including [Twilio](https://www.twilio.com), [Italia.it (Italian Government)](https://www.pagopa.gov.it/), [Mercado Libre](https://www.mercadolibre.com), [Wolt](https://wolt.com), [Canonical](https://canonical.com), and many more. The full, machine-readable list is maintained in the [`openfga/community` repository](https://github.com/openfga/community/blob/main/ADOPTERS.md).
+
+## Add your story
+
+If your team runs OpenFGA in production and wants to share lessons learned, open a pull request against the [`openfga/community` ADOPTERS file](https://github.com/openfga/community/blob/main/ADOPTERS.md) or join the [CNCF Slack `#openfga` channel](https://cloud-native.slack.com/archives/C06G1NNH47N).

--- a/docs/content/adopters/overview.mdx
+++ b/docs/content/adopters/overview.mdx
@@ -7,7 +7,7 @@ slug: /adopters
 
 # OpenFGA in production
 
-OpenFGA is deployed in production at fintechs, observability platforms, AI products, developer-tool companies, and API platforms. The case studies below are based on public [CNCF TOC adopter interviews](https://github.com/cncf/toc/tree/main/projects/openfga).
+OpenFGA is deployed in production at fintechs, observability platforms, AI products, developer-tool companies, and API platforms. The case studies below are based on public [CNCF TOC adopter interviews](https://github.com/cncf/toc/tree/main/projects/openfga) and OpenFGA community meeting presentations.
 
 ## Featured case studies
 
@@ -17,7 +17,7 @@ OpenFGA is deployed in production at fintechs, observability platforms, AI produ
 | [Agicap](/docs/adopters/agicap) | Fintech | April 2023 | ~250 RPS, 8,000+ customers |
 | [Zuplo](/docs/adopters/zuplo) | API management | 2024 | 500+ RPS spikes, multi-region edge |
 | [Grafana Labs](/docs/adopters/grafana) | Observability | 2024 | Multi-tenant SaaS + embedded OSS |
-| [Docker](/docs/adopters/docker) | Developer tools | March 2024 | 100–150 RPS |
+| [Docker](/docs/adopters/docker) | Developer tools | March 2024 | 100-150 RPS |
 | [Headspace](/docs/adopters/headspace) | Mental health & consumer | 2024 | 90M lives, 6M Ebb messages, 10-15 ms p99 |
 | [OpenLane](/docs/adopters/openlane) | Compliance SaaS | 2024 | ent ORM hooks, BatchCheck overfetch (100/1000) |
 | [Vitrolife Group](/docs/adopters/vitrolife) | Healthcare | 2025 | Hybrid Entra + OpenFGA, hourly differential sync |

--- a/docs/content/adopters/read-ai.mdx
+++ b/docs/content/adopters/read-ai.mdx
@@ -1,0 +1,48 @@
+---
+title: Read AI Case Study
+description: How Read AI runs OpenFGA at 5,200 requests per second with 20ms p99 latency over more than 5 billion relationship tuples.
+sidebar_position: 5
+slug: /adopters/read-ai
+---
+
+# Read AI: 5 billion tuples, 20ms p99 latency
+
+[Read AI](https://www.read.ai) is the AI meeting notetaker and assistant trusted by more than 100,000 organizations and 75% of the Fortune 500, adding more than one million new customers every month. OpenFGA backs the authorization layer that lets Read AI safely share intelligence across meetings, messages, email, and documents.
+
+## At a glance
+
+| | |
+| --- | --- |
+| **Industry** | AI productivity / meeting intelligence |
+| **In production since** | April 28, 2023 |
+| **Peak load** | 5,200 RPS |
+| **Latency** | 20ms p99 / 1.8ms average |
+| **Tuple count** | 5,323,283,829 (and growing) |
+| **Version** | v1.8.16 |
+| **Storage** | PostgreSQL |
+
+## Why OpenFGA
+
+Read AI ran a proprietary, organically built authorization system that hit performance and scalability ceilings as the platform grew. The team evaluated alternatives such as Authzed before choosing OpenFGA, citing:
+
+- **Zanzibar foundations** that aligned with the sharing semantics the product needed.
+- **Documentation clarity**, especially the practical examples and modeling guides.
+- The ability to **self-host** with predictable cost.
+- Approachable, responsive maintainers.
+
+## Production at scale
+
+The self-hosted OpenFGA service handles peak load of **5,200 requests per second** with a **20ms p99 latency** and **1.8ms average latency**. The data store holds more than **5.3 billion tuples** and grows daily.
+
+OpenFGA upgrades are folded into a monthly cadence. The OpenFGA release pace is faster than Read AI's, but upgrades have been smooth with no significant backward-compatibility issues.
+
+## Outcomes
+
+- Confidence in secure data authorization across the entire product surface.
+- Adoption of ReBAC best practices improved internal design decisions.
+- Compute and hosting costs dropped versus the prior solution.
+- OpenFGA has not been the bottleneck even at peak.
+
+## Source
+
+This case study is based on the public CNCF TOC adopter interview with Andrew Powers, Software Engineering Manager at Read AI, available in the [`cncf/toc` repository](https://github.com/cncf/toc/tree/main/projects/openfga).

--- a/docs/content/adopters/vitrolife.mdx
+++ b/docs/content/adopters/vitrolife.mdx
@@ -1,0 +1,47 @@
+---
+title: Vitrolife Group Case Study
+description: How Vitrolife combines Microsoft Entra ID app roles with OpenFGA fine-grained ReBAC for a .NET 10 metadata platform serving IVF clinics worldwide.
+sidebar_position: 8
+slug: /adopters/vitrolife
+---
+
+# Vitrolife Group: Hybrid Entra + OpenFGA authorization for a .NET healthcare platform
+
+The [Vitrolife Group](https://www.vitrolife.com) is a Swedish medical-device and software company serving IVF clinics worldwide. Its internal metadata platform — built on .NET 10 to organize landing zones, domains, platforms, and teams — uses a hybrid authorization design: Microsoft Entra ID app roles for coarse-grained access and OpenFGA for fine-grained, per-resource decisions.
+
+## At a glance
+
+| | |
+| --- | --- |
+| **Industry** | Healthcare / medical devices (IVF) |
+| **Stack** | .NET 10, ASP.NET Core, Microsoft Entra ID, [Wolverine](https://wolverinefx.net/), Aspire |
+| **Use case** | Internal metadata platform: landing zones, domains, platforms, teams |
+| **Deployment** | Self-hosted alongside the .NET API |
+| **Key features used** | Contextual tuples, intersections, conditions, full + differential sync from OpenFGA |
+
+## Why OpenFGA
+
+Entra ID gave Vitrolife a managed identity layer for both human users and service principals, but app roles alone could not express *per-resource* permissions ("can edit *this* landing zone, not all of them"). The platform team layered OpenFGA underneath to model ownership and group membership without inventing a parallel directory.
+
+Crucially, the team wanted OpenFGA — not Entra — to be the **source of truth** for access groups, so that the application's own model of "who has access to what" did not depend on a directory operation in a separate system.
+
+## Architecture
+
+- **App-role grammar.** Every Entra app role follows `<api>.<resource>.<capability>.<qualifier>`. Capabilities are `viewer` / `editor` / `admin`. The qualifier is either `all` (the principal may act on every record of that resource) or `self` (the principal may act only on records they have an OpenFGA relationship with). `all` injects a contextual tuple at request time; `self` falls through to a normal [Check](/docs/interacting/relationship-queries) against the relationship graph.
+- **Users and service principals are uniform.** Because both human users and service principals carry app roles, the application code never branches on principal type — the OpenFGA tuple set treats them identically.
+- **Type-safe C# wrappers.** `FGAObjectId` enforces `<type>:<id>` shape at compile time. An `FGATuple` builder makes tuple construction explicit, and relations are modeled as `snake_case` enums to match the OpenFGA wire format without stringly-typed bugs.
+- **Group memberships as contextual tuples.** Entra group memberships are surfaced into OpenFGA via contextual tuples on each request, intersected with FGA group definitions so a principal must satisfy *both* the Entra group and the FGA relationship to gain access.
+- **Atomic writes via transactional outbox.** SQL writes and OpenFGA tuple writes are coordinated through a [Wolverine](https://wolverinefx.net/) outbox: the database row and the queued FGA mutation commit together; consumers process the outbox to make the tuple change visible. This is eventually consistent within a small, bounded window.
+- **OpenFGA → Entra sync.** A scheduled job reads OpenFGA as the source of truth and reconciles Entra access groups: an hourly **full sync** plus a **differential sync** triggered by outbox events. If a tuple is removed in OpenFGA, the corresponding Entra membership is removed on the next pass.
+- **Vertical slices and Aspire local dev.** Features are organized as vertical slices; .NET Aspire orchestrates a local environment with a mocked Microsoft Graph and a local OpenFGA, so the team can run the full authorization path end-to-end on a developer laptop.
+
+## Outcomes
+
+- **One mental model for authorization** that spans humans, service principals, and resources, with Entra handling identity and OpenFGA handling relationships.
+- **Per-resource permissions** without a custom directory — the existing Entra investment stays in place.
+- **OpenFGA as the durable source of truth** for access groups, with Entra reconciled on a schedule rather than the other way around.
+- **Atomic SQL + tuple writes** through the Wolverine outbox, removing the class of bugs where the application data and the access graph drift apart.
+
+## Source
+
+This case study is based on a [presentation in the OpenFGA community meeting by Simon Gottschlag, CTO at Co-native, working with the Vitrolife Group on its platform](https://www.youtube.com/watch?v=nwu5SiiMpM8).

--- a/docs/content/adopters/zuplo.mdx
+++ b/docs/content/adopters/zuplo.mdx
@@ -14,7 +14,7 @@ slug: /adopters/zuplo
 | | |
 | --- | --- |
 | **Industry** | API management |
-| **In production since** | ~2024 (12 months in production after 18 months total adoption) |
+| **In production since** | 2024 |
 | **Scale** | Several hundred RPS, with spikes above 500 RPS |
 | **Version** | v1.8.x |
 | **Storage** | PostgreSQL with global replication |

--- a/docs/content/adopters/zuplo.mdx
+++ b/docs/content/adopters/zuplo.mdx
@@ -1,0 +1,54 @@
+---
+title: Zuplo Case Study
+description: How API management platform Zuplo runs OpenFGA across multiple data centers with PostgreSQL global replication for edge authorization.
+sidebar_position: 6
+slug: /adopters/zuplo
+---
+
+# Zuplo: Edge authorization across multiple data centers
+
+[Zuplo](https://zuplo.com) is a developer-first API management platform that helps teams build, deploy, and scale APIs globally. Zuplo uses OpenFGA to enforce fine-grained authorization at the edge across every region the platform runs in.
+
+## At a glance
+
+| | |
+| --- | --- |
+| **Industry** | API management |
+| **In production since** | ~2024 (12 months in production after 18 months total adoption) |
+| **Scale** | Several hundred RPS, with spikes above 500 RPS |
+| **Version** | v1.8.x |
+| **Storage** | PostgreSQL with global replication |
+| **Deployment** | Multi-region edge |
+
+## Why OpenFGA
+
+As Zuplo's customer base shifted toward larger enterprises, simple project-membership rules were no longer enough. The team evaluated:
+
+- Axiomatics (AuthZEN-based)
+- Aserto (AuthZEN-based)
+- Auth0 FGA
+- Building a custom solution in-house
+
+They chose OpenFGA because it is **open source and self-hostable**, and because **PostgreSQL as a backend** let Zuplo replicate authorization data globally and run checks at the edge — exactly the topology API management requires.
+
+## Architecture
+
+- **One authorization model** governs the entire product, single-tenant.
+- The same model handles **user access and API key access** to product features.
+- OpenFGA is deployed in production across multiple data centers worldwide.
+- Performance work for major upgrades uses k6-based end-to-end load tests.
+
+## Outcomes
+
+- Updating and versioning the authorization model independently of the application code accelerated development cycles.
+- Roles and permissions can be tested and refined without code changes.
+- Authorization is centralized across teams while keeping concerns separate.
+- Caching introduced upstream replaced a homegrown cache layer Zuplo had built before OpenFGA shipped its own.
+
+## Outlook
+
+Zuplo continues to file feature requests upstream and has expressed interest in publicly sharing more details about how it implements authorization at the edge.
+
+## Source
+
+This case study is based on the public CNCF TOC adopter interview with Nate Totten, Co-founder & CTO of Zuplo, available in the [`cncf/toc` repository](https://github.com/cncf/toc/tree/main/projects/openfga).

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -513,7 +513,7 @@ const sidebars = {
         { type: 'doc', label: 'Read AI', id: 'content/adopters/read-ai' },
         { type: 'doc', label: 'Headspace', id: 'content/adopters/headspace' },
         { type: 'doc', label: 'Zuplo', id: 'content/adopters/zuplo' },
-        { type: 'doc', label: 'OpenLane', id: 'content/adopters/openlane' },
+        { type: 'doc', label: 'Openlane', id: 'content/adopters/openlane' },
         { type: 'doc', label: 'Vitrolife Group', id: 'content/adopters/vitrolife' },
       ],
     },

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -504,6 +504,23 @@ const sidebars = {
       type: 'category',
       collapsible: true,
       collapsed: true,
+      label: 'Adopters',
+      link: { type: 'doc', id: 'content/adopters/overview' },
+      items: [
+        { type: 'doc', label: 'Agicap', id: 'content/adopters/agicap' },
+        { type: 'doc', label: 'Docker', id: 'content/adopters/docker' },
+        { type: 'doc', label: 'Grafana Labs', id: 'content/adopters/grafana' },
+        { type: 'doc', label: 'Read AI', id: 'content/adopters/read-ai' },
+        { type: 'doc', label: 'Headspace', id: 'content/adopters/headspace' },
+        { type: 'doc', label: 'Zuplo', id: 'content/adopters/zuplo' },
+        { type: 'doc', label: 'OpenLane', id: 'content/adopters/openlane' },
+        { type: 'doc', label: 'Vitrolife Group', id: 'content/adopters/vitrolife' },
+      ],
+    },
+    {
+      type: 'category',
+      collapsible: true,
+      collapsed: true,
       label: 'Learn',
       link: { type: 'doc', id: 'content/learn/overview' },
       items: [


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description

Adds an Adopters section to the documentation with eight production case studies based on CNCF TOC adopter interviews: Agicap, Docker, Grafana Labs, Read AI, Headspace, Zuplo, OpenLane, and Vitrolife Group.

The sidebar gains a new top-level Adopters category linking to the overview and all eight individual pages.

#### What problem is being solved?

#### How is it being solved?

#### What changes are made to solve it?

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive adopter case studies featuring production implementations from eight leading companies: Agicap, Docker, Grafana Labs, Headspace, OpenLane, Read AI, Vitrolife Group, and Zuplo. Each case study details their authorization architecture, outcomes, and deployment scale.
  * Added Adopters section to documentation navigation providing an overview and links to individual company case studies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->