### PR TITLE
chore: upgrade to TypeScript 6.0.3 and clean up legacy patterns

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "husky": "9.1.7",
         "markdown-link-check": "^3.14.2",
         "prettier": "3.9.1",
-        "typescript": "5.9.3"
+        "typescript": "6.0.3"
       }
     },
     "node_modules/@algolia/abtesting": {
@@ -22145,9 +22145,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "write-heading-ids": "docusaurus write-heading-ids",
     "docker:build": "docker build . -t openfga-docs-ui",
     "docker:run": "docker run -p ${PORT:-3000}:3000 openfga-docs-ui",
-    "typecheck": "tsc  --skipLibCheck",
-    "lint": "eslint . --ext .ts  --ext .tsx",
+    "typecheck": "tsc",
+    "lint": "eslint .",
     "lint:fix": "npm run lint -- --fix",
     "format:check": "prettier --check src/**",
     "format:fix": "prettier --write src/**"
@@ -61,7 +61,7 @@
     "husky": "9.1.7",
     "markdown-link-check": "^3.14.2",
     "prettier": "3.9.1",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   },
   "overrides": {
     "semver": "^7.7.1"

--- a/src/components/Docs/AuthorizationModel/SyntaxTransformer.ts
+++ b/src/components/Docs/AuthorizationModel/SyntaxTransformer.ts
@@ -9,18 +9,21 @@ export enum SyntaxFormat {
   Dsl = 'dsl',
 }
 
+const isTypeDefinition = (config: AuthorizationModel | TypeDefinition): config is TypeDefinition =>
+  !(config as AuthorizationModel).type_definitions && Boolean((config as TypeDefinition).type);
+
 export const loadSyntax = (
   configuration: AuthorizationModel,
   format: SyntaxFormat = SyntaxFormat.Json,
   skipVersion?: boolean,
 ) => {
-  let config = configuration;
+  let config: AuthorizationModel = configuration;
   switch (format) {
     case SyntaxFormat.Dsl:
-      if (!config.type_definitions && (config as unknown as TypeDefinition).type) {
+      if (isTypeDefinition(config)) {
         config = {
           schema_version: SchemaVersion.OneDotOne,
-          type_definitions: [config as unknown as TypeDefinition],
+          type_definitions: [config],
           id: '',
         };
         skipVersion = true;

--- a/src/components/Docs/RelationshipTuples/Viewer.tsx
+++ b/src/components/Docs/RelationshipTuples/Viewer.tsx
@@ -11,9 +11,7 @@ interface RelationshipTuple {
 
 export interface RelationshipCondition {
   name: string;
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  context?: Record<string, any>;
+  context?: Record<string, unknown>;
 }
 
 interface RelationshipTuplesViewerOpts {

--- a/src/components/Docs/SnippetViewer/BatchCheckRequestViewer.tsx
+++ b/src/components/Docs/SnippetViewer/BatchCheckRequestViewer.tsx
@@ -10,8 +10,7 @@ interface Check {
   correlation_id: string;
   allowed: boolean;
   contextualTuples?: TupleKey[];
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  context?: Record<string, any>;
+  context?: Record<string, unknown>;
 }
 interface BatchCheckRequestViewerOpts extends DefaultTabbedViewerOpts {
   authorizationModelId?: string;

--- a/src/components/Docs/SnippetViewer/CheckRequestViewer.tsx
+++ b/src/components/Docs/SnippetViewer/CheckRequestViewer.tsx
@@ -11,8 +11,7 @@ interface CheckRequestViewerOpts {
   allowed: boolean;
   contextualTuples?: TupleKey[];
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  context?: Record<string, any>;
+  context?: Record<string, unknown>;
   skipSetup?: boolean;
   pseudoCodeMode?: boolean;
   allowedLanguages?: SupportedLanguage[];

--- a/src/components/Docs/SnippetViewer/ExecuteApiRequestViewer.tsx
+++ b/src/components/Docs/SnippetViewer/ExecuteApiRequestViewer.tsx
@@ -6,8 +6,9 @@ import assertNever from 'assert-never/index';
 // Helpers – value serialisation per language
 // ---------------------------------------------------------------------------
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function jsValue(val: any, indent: number): string {
+type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue };
+
+function jsValue(val: JsonValue, indent: number): string {
   if (typeof val === 'string') return `"${val}"`;
   if (typeof val === 'number' || typeof val === 'boolean') return String(val);
   if (Array.isArray(val)) {
@@ -23,8 +24,7 @@ function jsValue(val: any, indent: number): string {
   return String(val);
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function pyValue(val: any, indent: number): string {
+function pyValue(val: JsonValue, indent: number): string {
   if (typeof val === 'string') return `"${val}"`;
   if (typeof val === 'number') return String(val);
   if (typeof val === 'boolean') return val ? 'True' : 'False';
@@ -41,8 +41,7 @@ function pyValue(val: any, indent: number): string {
   return String(val);
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function goValue(val: any, indent: number): string {
+function goValue(val: JsonValue, indent: number): string {
   if (typeof val === 'string') return `"${val}"`;
   if (typeof val === 'number' || typeof val === 'boolean') return String(val);
   if (typeof val === 'object' && val !== null) {
@@ -54,8 +53,7 @@ function goValue(val: any, indent: number): string {
   return String(val);
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function javaValue(val: any, indent: number): string {
+function javaValue(val: JsonValue, indent: number): string {
   if (typeof val === 'string') return `"${val}"`;
   if (typeof val === 'number' || typeof val === 'boolean') return String(val);
   if (typeof val === 'object' && val !== null) {
@@ -67,8 +65,7 @@ function javaValue(val: any, indent: number): string {
   return String(val);
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function csharpValue(val: any, indent: number): string {
+function csharpValue(val: JsonValue, indent: number): string {
   if (typeof val === 'string') return `"${val}"`;
   if (typeof val === 'number' || typeof val === 'boolean') return String(val).toLowerCase();
   if (typeof val === 'object' && val !== null) {
@@ -118,8 +115,7 @@ function buildCurlSnippet(opts: {
   path: string;
   pathParams?: Record<string, string>;
   queryParams?: Record<string, string>;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  body?: Record<string, any>;
+  body?: Record<string, JsonValue>;
   streaming?: boolean;
 }): string {
   const { method, path, pathParams, queryParams, body, streaming } = opts;
@@ -158,8 +154,7 @@ interface ExecuteApiRequestViewerOpts {
   /** Path parameter substitutions. */
   pathParams?: Record<string, string>;
   /** Request body (omit for GET). */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  body?: Record<string, any>;
+  body?: Record<string, JsonValue>;
   /** Query parameter key-value pairs. */
   queryParams?: Record<string, string>;
   /** Optional example response shown in a trailing comment. */

--- a/src/components/Docs/SnippetViewer/ListObjectsRequestViewer.tsx
+++ b/src/components/Docs/SnippetViewer/ListObjectsRequestViewer.tsx
@@ -10,8 +10,7 @@ interface ListObjectsRequestViewerOpts {
   objectType: string;
   contextualTuples?: TupleKey[];
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  context?: Record<string, any>;
+  context?: Record<string, unknown>;
   expectedResults: string[];
   skipSetup?: boolean;
   pseudoCodeMode?: boolean;

--- a/src/components/Docs/SnippetViewer/ListUsersRequestViewer.tsx
+++ b/src/components/Docs/SnippetViewer/ListUsersRequestViewer.tsx
@@ -12,8 +12,7 @@ interface ListUsersRequestViewerOpts {
   userFilterRelation?: string;
   contextualTuples?: TupleKey[];
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  context?: Record<string, any>;
+  context?: Record<string, unknown>;
   expectedResults: ListUsersResponse;
   skipSetup?: boolean;
   pseudoCodeMode?: boolean;

--- a/src/components/icons/animations/AnimatedIcon.tsx
+++ b/src/components/icons/animations/AnimatedIcon.tsx
@@ -1,16 +1,20 @@
 import * as React from 'react';
 import BrowserOnly from '@docusaurus/BrowserOnly';
 
+const Player = React.lazy(() =>
+  import('@lottiefiles/react-lottie-player').then((module) => ({ default: module.Player })),
+);
+
 type AnimatedIconProps = { element?: string | object };
 const AnimatedIcon: React.FC<AnimatedIconProps> = ({ element }) => {
   return (
     <div style={{ height: '100%' }}>
       <BrowserOnly>
-        {() => {
-          // eslint-disable-next-line @typescript-eslint/no-require-imports
-          const { Player } = require('@lottiefiles/react-lottie-player');
-          return <Player autoplay={true} loop={true} controls={true} src={element} />;
-        }}
+        {() => (
+          <React.Suspense fallback={null}>
+            <Player autoplay={true} loop={true} controls={true} src={element} />
+          </React.Suspense>
+        )}
       </BrowserOnly>
     </div>
   );

--- a/src/components/icons/animations/auth0.lottie.ts
+++ b/src/components/icons/animations/auth0.lottie.ts
@@ -1,5 +1,6 @@
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const auth0Lottie: any = {
+import type { LottieAnimationData } from './types';
+
+export const auth0Lottie: LottieAnimationData = {
   v: '5.7.4',
   fr: 60,
   ip: 0,

--- a/src/components/icons/animations/code.lottie.ts
+++ b/src/components/icons/animations/code.lottie.ts
@@ -1,5 +1,6 @@
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const codeLottie: any = {
+import type { LottieAnimationData } from './types';
+
+export const codeLottie: LottieAnimationData = {
   v: '5.7.4',
   fr: 60,
   ip: 0,

--- a/src/components/icons/animations/community.lottie.ts
+++ b/src/components/icons/animations/community.lottie.ts
@@ -1,5 +1,6 @@
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const communityLottie: any = {
+import type { LottieAnimationData } from './types';
+
+export const communityLottie: LottieAnimationData = {
   v: '5.7.4',
   fr: 60,
   ip: 0,

--- a/src/components/icons/animations/fast.lottie.ts
+++ b/src/components/icons/animations/fast.lottie.ts
@@ -1,5 +1,6 @@
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const fastLottie: any = {
+import type { LottieAnimationData } from './types';
+
+export const fastLottie: LottieAnimationData = {
   v: '5.7.4',
   fr: 60,
   ip: 0,

--- a/src/components/icons/animations/model.lottie.ts
+++ b/src/components/icons/animations/model.lottie.ts
@@ -1,5 +1,6 @@
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const modelLottie: any = {
+import type { LottieAnimationData } from './types';
+
+export const modelLottie: LottieAnimationData = {
   v: '5.7.4',
   fr: 60,
   ip: 0,

--- a/src/components/icons/animations/open.lottie.ts
+++ b/src/components/icons/animations/open.lottie.ts
@@ -1,5 +1,6 @@
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const openLottie: any = {
+import type { LottieAnimationData } from './types';
+
+export const openLottie: LottieAnimationData = {
   v: '5.7.4',
   fr: 60,
   ip: 0,

--- a/src/components/icons/animations/types.ts
+++ b/src/components/icons/animations/types.ts
@@ -1,0 +1,1 @@
+export type LottieAnimationData = Record<string, unknown>;

--- a/src/pages/api/service.tsx
+++ b/src/pages/api/service.tsx
@@ -4,6 +4,10 @@ import BrowserOnly from '@docusaurus/BrowserOnly';
 import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 
+const SwaggerUI = React.lazy(() =>
+  import('../../components/SwaggerUI/swagger-ui').then((module) => ({ default: module.SwaggerUI })),
+);
+
 const ApiService = () => {
   const { siteConfig } = useDocusaurusContext();
   const apiDocsBasePath = siteConfig.customFields?.apiDocsBasePath as string | undefined;
@@ -16,11 +20,11 @@ const ApiService = () => {
   return (
     <Layout title="Open FGA API Explorer">
       <BrowserOnly fallback={<div>Loading...</div>}>
-        {() => {
-          // eslint-disable-next-line @typescript-eslint/no-require-imports
-          const { SwaggerUI } = require('../../components/SwaggerUI/swagger-ui');
-          return <SwaggerUI apiDocsBasePath={apiDocsBasePath} />;
-        }}
+        {() => (
+          <React.Suspense fallback={<div>Loading...</div>}>
+            <SwaggerUI apiDocsBasePath={apiDocsBasePath} />
+          </React.Suspense>
+        )}
       </BrowserOnly>
     </Layout>
   );

--- a/src/theme/NavbarItem/NavbarNavLink.tsx
+++ b/src/theme/NavbarItem/NavbarNavLink.tsx
@@ -13,6 +13,19 @@ interface GithubStarsSessionStorage {
   retrievedTime: number;
 }
 
+function readCachedGithubStars(): GithubStarsSessionStorage | null {
+  try {
+    const raw = sessionStorage.getItem(GITHUB_STARS_SESSION_STORAGE_NAME);
+    if (!raw) {
+      return null;
+    }
+    const parsed = JSON.parse(raw);
+    return typeof parsed?.count === 'number' && typeof parsed?.retrievedTime === 'number' ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
 export default function NavbarNavLink({
   activeBasePath,
   activeBaseRegex,
@@ -35,9 +48,7 @@ export default function NavbarNavLink({
 
   useEffect(() => {
     const getData = async () => {
-      const cachedGithubStars = JSON.parse(
-        sessionStorage.getItem(GITHUB_STARS_SESSION_STORAGE_NAME),
-      ) as unknown as GithubStarsSessionStorage;
+      const cachedGithubStars = readCachedGithubStars();
       try {
         if (cachedGithubStars) {
           const cacheExpiryTime = new Date(cachedGithubStars.retrievedTime);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,8 +7,8 @@
       "@features/*": ["src/features/*"],
       "@static/*": ["static/*"]
     },
-    "module": "Node16",
-    "moduleResolution": "Node16",
-    "jsx": "react"
+    "jsx": "react-jsx",
+    "strict": false,
+    "ignoreDeprecations": "6.0"
   }
 }


### PR DESCRIPTION
  Summary

  Upgrades TypeScript from 5.9.3 → 6.0.3 (latest stable) and clears out the TS5-era patterns surfaced by the transition release. The goal was a clean upgrade with no strict-mode migration and no legacy
  mess left behind — all @typescript-eslint/no-explicit-any suppressions are now gone from src.

  No dependency bumps beyond typescript itself were required: @typescript-eslint 8.61.1 already declares support for typescript <6.1.0, and @tsconfig/docusaurus 2.0.9 is already the latest.

  Configuration changes

  - Bump typescript 5.9.3 → 6.0.3.
  - Drop the stale module/moduleResolution: "Node16" override — now inherits the modern esnext / bundler settings from @tsconfig/docusaurus, which is correct for a webpack-bundled Docusaurus site.
  - jsx "react" → "react-jsx" to align with the ESLint jsx-runtime config already in use.
  - Pin "strict": false explicitly. TS6 flips strict on by default; the codebase was written against non-strict TS5, so this preserves the existing contract (~50 null-check errors would otherwise appear).
  A full strict migration was intentionally out of scope for this PR.
  - Add "ignoreDeprecations": "6.0" for the inherited baseUrl option, which TS6 deprecates (hard-removed in TS7). baseUrl comes from the base config we don't control, so this is the officially documented
  bridge.
  - Simplify scripts: tsc --skipLibCheck → tsc (skipLibCheck is already set in the base config) and eslint . --ext .ts --ext .tsx → eslint . (--ext is deprecated under the ESLint 9 flat config).

  Code cleanup (no behavior change)

  - Lottie data: replace any with a shared LottieAnimationData type (6 *.lottie.ts files + new types.ts).
  - Snippet serializer: introduce a JsonValue union in ExecuteApiRequestViewer and thread it through the per-language value serializers and body fields.
  - Viewer context fields: type as Record<string, unknown> instead of any across the Check / BatchCheck / ListUsers / ListObjects / RelationshipTuples viewers.
  - Casts removed: replace as unknown as TypeDefinition with an isTypeDefinition type guard in SyntaxTransformer; replace the JSON.parse(...) as unknown as sessionStorage cast with a validating
  readCachedGithubStars helper in NavbarNavLink.
  - require() → ESM: convert the SwaggerUI page and AnimatedIcon to React.lazy + dynamic import() inside their existing BrowserOnly guards (also produces proper code-split chunks).

  The dynamic, variable-path require() in prism-include-languages.ts is intentionally retained — it's a legitimate synchronous side-effect import that ESM import() can't replace without changing
  language-registration timing.

  Test plan

  - [x] npm run typecheck — passes (0 errors)
  - [x] npm run lint — passes (0 errors; zero no-explicit-any suppressions remain in src)
  - [x] npm run format:check — clean
  - [x] npx madge --circular . --extensions ts,js,jsx,tsx — no circular dependencies
  - [x] npm run build — full Docusaurus build succeeds; SSR-renders all pages
  - [x] Runtime spot-checks: /api/service (SwaggerUI) serves 200 and renders its Loading... fallback before client hydration; landing-page animated icons render; both lazy components emit as separate JS
  chunks; ABAC conditions page still renders context values into snippets

  Notes for reviewers

  - This is a type-only cleanup on top of the version bump — no runtime logic changed, so generated code snippets and rendered output are unchanged.
  - static/llms.txt was deliberately excluded: npm run build regenerates it and it had drifted (a new "Adopters" section), but that's an unrelated docs-content change and belongs in its own PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loading behavior for some documentation and API preview views, helping pages open more smoothly.
  * Tightened data handling in several docs snippets and viewers for more reliable rendering.

* **Chores**
  * Updated TypeScript and project checks to use newer defaults.
  * Strengthened internal type safety across animation assets and request examples.
  * Adjusted app configuration to align with the latest TypeScript settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->