### PR TITLE
chore: update podcast link to Podcast Index

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -44,7 +44,7 @@ const config = {
       },
       {
         text: 'Podcast - Authorization in Software →',
-        href: 'https://authorizationinsoftware.auth0.com/',
+        href: 'https://podcastindex.org/podcast/4368675',
         icon: 'PodcastIcon',
       },
     ],


### PR DESCRIPTION
Update the podcast link in the site navigation from the old Auth0-hosted page to the canonical Podcast Index listing.

## Description

#### What problem is being solved?
The podcast was previously linked to `https://authorizationinsoftware.auth0.com/`, which is an Auth0-hosted page. The canonical and more up-to-date home for the "Authorization in Software" podcast is now on Podcast Index.

#### How is it being solved?
Replace the `href` value for the podcast entry in `docusaurus.config.js` with the new Podcast Index URL.

#### What changes are made to solve it?
- `docusaurus.config.js`: updated podcast `href` from `https://authorizationinsoftware.auth0.com/` to `https://podcastindex.org/podcast/4368675`

## References

N/A

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the podcast resource link to point to the new podcast website.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->