### PR TITLE
fix: align search text with icon

### DIFF
--- a/static/css/openfga.css
+++ b/static/css/openfga.css
@@ -257,7 +257,7 @@ a:visited {
 @media screen and (min-width: 576px) {
   .navbar .navbar__search-input {
     background: transparent;
-    padding: 0 5rem 0 1rem;
+    padding: 0 5rem 0 2.25rem;
     width: unset;
   }
   .navbar__search-input::placeholder {


### PR DESCRIPTION
Fixes #1338

## Summary
- restore the standard 2.25rem left search-input padding while retaining room for the keyboard shortcut hint
- keep the placeholder and entered text clear of the local-search icon

## Testing
- npm run format:check
- npm run lint
- npm run typecheck
- npm run build:docusaurus

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved spacing in the desktop navigation search field for better visual alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->