### PR TITLE
fix: align the search icon

### DIFF
--- a/static/css/openfga.css
+++ b/static/css/openfga.css
@@ -257,7 +257,7 @@ a:visited {
 @media screen and (min-width: 576px) {
   .navbar .navbar__search-input {
     background: transparent;
-    padding: 0 5rem 0 1rem;
+    padding: 0 5rem 0 2.25rem;
     width: unset;
   }
   .navbar__search-input::placeholder {


### PR DESCRIPTION
<!-- Provide a brief summary of the changes -->
Fixes the search icon alignment in the navbar search input by adjusting left padding.

## Description

#### What problem is being solved?
The search icon in the navbar search input overlapped with the placeholder text due to insufficient left padding on the input field.

#### How is it being solved?
Increasing the left padding of the search input so there's enough space between the icon and the text/placeholder.

#### What changes are made to solve it?
Updated `padding` on `.navbar .navbar__search-input` in `static/css/openfga.css` from `0 5rem 0 1rem` to `0 5rem 0 2.25rem`.

## References
* closes https://github.com/openfga/openfga.dev/issues/1338

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev)
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the desktop navigation search field spacing for better visual alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->