### PR TITLE
docs: add truncation markers to blog posts

### DIFF
--- a/blog/conditional-tuples-announcement.md
+++ b/blog/conditional-tuples-announcement.md
@@ -19,6 +19,8 @@ Although ReBAC offers a highly flexible method for structuring permissions, it e
 
 In our ongoing efforts to expand OpenFGA’s capacity for articulating a broader range of authorization policies, we are introducing **Conditional Relationship Tuples**. These allow for the specification of conditions under which a particular tuple is relevant when evaluating an authorization query.
 
+<!-- truncate -->
+
 Consider the following example, where we utilize Conditional Tuples to grant access for a user over a specified time duration. We stipulate that a user may be granted either unconditional access or access constrained to a certain time period:
 
 ```dsl.openfga
@@ -129,4 +131,3 @@ This won’t scale to a large number of documents, but would be useful in some s
 We want to learn how you use this feature and how we can improve it! 
 
 Please reach out through our [community channels](https://openfga.dev/community) with any questions or feedback.
-

--- a/blog/fine-grained-news-2023-12.md
+++ b/blog/fine-grained-news-2023-12.md
@@ -17,6 +17,8 @@ We've been publishing a monthly internal newsletter we called **Fine-Grained New
 
 You can expect to find here a summary of what we've been up to, what we are planning to do, and some other random stuff we think you might find interesting.
 
+<!-- truncate -->
+
 ## Team News
 
 We always start our Monthly Community Meetings presenting the team. If you attended the last one, you've seen that the size of the team has grown quite a bit! We are pretty excited about the impact it will have in OpenFGA and the authorization space in general. 

--- a/blog/fine-grained-news-2024-01.md
+++ b/blog/fine-grained-news-2024-01.md
@@ -13,6 +13,8 @@ hide_table_of_contents: false
 
 Welcome to the 2nd edition of Fine-Grained News! 
 
+<!-- truncate -->
+
 ## Team News
 
 The OpenFGA team got bigger, and we met in person in Toronto for the first time! We got to know each other better, helped new team members to get familiar with the project, hacked some code, had some fun with ax throwing, and loved Toronto's weather!

--- a/blog/fine-grained-news-2024-02.md
+++ b/blog/fine-grained-news-2024-02.md
@@ -13,6 +13,8 @@ hide_table_of_contents: false
 
 Welcome to the 3rd edition of Fine-Grained News! 
 
+<!-- truncate -->
+
 ## KubeCon Europe 2024 is getting closer!
 
 We'll be pretty busy during [KubeCon Europe 2024](https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/):

--- a/blog/fine-grained-news-2024-03.md
+++ b/blog/fine-grained-news-2024-03.md
@@ -13,6 +13,8 @@ hide_table_of_contents: false
 
 Welcome to Fine-Grained News, KubeCon Edition!
 
+<!-- truncate -->
+
 ## KubeCon Europe 2024 was super-busy!
 
 You can now watch online:

--- a/blog/fine-grained-news-2024-04.md
+++ b/blog/fine-grained-news-2024-04.md
@@ -13,6 +13,8 @@ hide_table_of_contents: false
 
 Welcome to Fine-Grained News, April edition!
 
+<!-- truncate -->
+
 ## New Releases!
 
 - [Modular Models](https://openfga.dev/blog/modular-models-announcement) is now part of the OpenFGA core, making it easy for multiple teams to collaborate on a single OpenFGA model. Check it out, we love the feature! :)

--- a/blog/fine-grained-news-2024-05.md
+++ b/blog/fine-grained-news-2024-05.md
@@ -13,6 +13,8 @@ hide_table_of_contents: false
 
 Welcome to Fine-Grained News, May edition!
 
+<!-- truncate -->
+
 ## New Releases!
 
 - We shipped the [a ListUsers API](https://openfga.dev/blog/list-users-announcement). ListUsers allows you to retrieve all the users that have a specific relation with a resource (e.g. all users that can view a document).

--- a/blog/fine-grained-news-2024-06.md
+++ b/blog/fine-grained-news-2024-06.md
@@ -15,6 +15,8 @@ Welcome to Fine-Grained News, June 2024 edition!
 
 This is where we share what has been going on in the OpenFGA community during the last 30 days :).
 
+<!-- truncate -->
+
 ## What are we working on?
 
 - We started adding [OpenTelemetry instrumentation](https://github.com/openfga/roadmap/issues/41) to our SDKs. We just shipped metrics support for Python and Javascript. We'll continue with tracing and logging, and we'll be adding support for Java, Go and .NET next.

--- a/blog/fine-grained-news-2024-07.md
+++ b/blog/fine-grained-news-2024-07.md
@@ -17,6 +17,8 @@ Welcome to the July 2024 edition of Fine-Grained News! We are thrilled to bring 
 
 We value your feedback and invite you to participate in our [2024 OpenFGA Community Survey](https://www.surveymonkey.com/r/OPENFGA2024). Your insights help us understand your needs better and improve our offerings. Please take a few minutes to complete the survey and let your voice be heard.
 
+<!-- truncate -->
+
 
 ## Improvements
 
@@ -102,4 +104,3 @@ As a reminder, we transitioned out from Discord for OpenFGA and are now using th
 
 
 Fine-Grained News is published every month. If you have any feedback, want to share your OpenFGA story, or have a noteworthy update, please let us know on any of our [community channels](https://openfga.dev/community) or at [community@openfga.dev](mailto:community@openfga.dev).
-

--- a/blog/fine-grained-news-2024-08.md
+++ b/blog/fine-grained-news-2024-08.md
@@ -13,6 +13,8 @@ hide_table_of_contents: false
 
 Welcome to the August 2024 edition of Fine-Grained News! We are excited to bring you the latest updates, features, and community highlights from OpenFGA. 
 
+<!-- truncate -->
+
 ## Just Shipped!
 
 * **OpenFGA v1.6.0:** The [latest OpenFGA release](https://github.com/openfga/openfga/releases/tag/v1.6.0) enables support for [query consistency options](https://openfga.dev/docs/interacting/consistency) and includes additional performance enhancements.

--- a/blog/fine-grained-news-2024-09.md
+++ b/blog/fine-grained-news-2024-09.md
@@ -12,6 +12,8 @@ hide_table_of_contents: false
 # Fine-Grained News
 Welcome to the September edition of Fine-Grained News! As we transition into the fall season, we’re excited to bring you the latest updates on the progress of OpenFGA.
 
+<!-- truncate -->
+
 ## **Just Shipped**
 
 * We shipped [OpenFGA v1.6.1](https://github.com/openfga/openfga/releases/tag/v1.6.1) with performance fixes, bug fixes, and a new SQLite storage adapter contributed by [Grafana](https://grafana.com/). Thanks [@DanCech](https://github.com/DanCech)! 

--- a/blog/fine-grained-news-2024-10.md
+++ b/blog/fine-grained-news-2024-10.md
@@ -15,6 +15,8 @@ Welcome to the October edition of Fine-Grained News! As we approach the end of t
 
 As always, if you’re finding the OpenFGA project to be a valuable resource, we would greatly appreciate if you would [star our repo](https://github.com/openfga/openfga) on GitHub to show your support!⭐
 
+<!-- truncate -->
+
 ## Just Shipped
 
 * **OpenFGA v1.7.0:** In our latest release, we’ve introduced Access Control. This experimental feature allows you to control access to your OpenFGA server, and of course, we built it using OpenFGA! We’ve updated our Docs to show you [how to enable this feature](https://openfga.dev/docs/getting-started/setup-openfga/access-control); please share your feedback in the [GitHub Discussions](https://github.com/orgs/openfga/discussions/382)! 

--- a/blog/fine-grained-news-2024-11.md
+++ b/blog/fine-grained-news-2024-11.md
@@ -13,6 +13,8 @@ hide_table_of_contents: false
 
 Welcome to the November edition of Fine-Grained News! As we enter the final stretch of 2024, there are exciting developments in the OpenFGA to share.
 
+<!-- truncate -->
+
 🌟 **We hit 3,000 stars on the OpenFGA repo!:** 🌟 Because of this great community, we've just this incredible milestone! Thank you so much for all the support you've shown this project. Let's keep the momentum going! If you haven't yet, we'd greatly appreciate you [starring the repo](https://github.com/openfga/openfga) to help push us toward 4,000 stars and grow our amazing community! 
 
 ![Celebrating OpenFGA reaching 3,000 GitHub stars](../static/img/blog/fgn-2024-11-stars.png)

--- a/blog/fine-grained-news-2025-01.md
+++ b/blog/fine-grained-news-2025-01.md
@@ -14,6 +14,8 @@ hide_table_of_contents: false
 
 Welcome to the first Fine-Grained News edition of 2025! January is always a good month to look back at what the OpenFGA community accomplished over the past year.
 
+<!-- truncate -->
+
 ## Major features
 
 Below is a list of the major features that were shipped in 2024:
@@ -74,4 +76,3 @@ We are very grateful with the OpenFGA community, who helped shipping **126** rel
 ## **See You Next Month:**
 
 Fine-Grained News is published every month. If you have any feedback, want to share your OpenFGA story, or have a noteworthy update, please let us know on any of our [community channels](https://openfga.dev/community) or at [community@openfga.dev](mailto:community@openfga.dev).
-

--- a/blog/fine-grained-news-2025-02.md
+++ b/blog/fine-grained-news-2025-02.md
@@ -13,6 +13,8 @@ hide_table_of_contents: false
 
 Welcome to the second Fine-Grained News edition of 2025! 
 
+<!-- truncate -->
+
 ## Just Shipped!
 
 - We shipped 3 minor versions of OpenFGA which include:
@@ -74,5 +76,4 @@ OpenFGA will be present in two high-profile events in London:
 ## **See You Next Month:**
 
 Fine-Grained News is published every month. If you have any feedback, want to share your OpenFGA story, or have a noteworthy update, please let us know on any of our [community channels](https://openfga.dev/community) or at [community@openfga.dev](mailto:community@openfga.dev).
-
 

--- a/blog/fine-grained-news-2025-09.md
+++ b/blog/fine-grained-news-2025-09.md
@@ -15,6 +15,8 @@ After a long hiatus, we are back with Fine Grained News! The best way to keep up
 
 First of all, we want to thank the OpenFGA community for helping the [OpenFGA Repository](https://github.com/openfga/) get beyond 4k stars!
 
+<!-- truncate -->
+
 ## What have we been up to
 
 ### OpenFGA Performance
@@ -116,4 +118,3 @@ OpenFGA will also have a kiosk at the KubeCon Project Pavilion. [Tyler Nix](http
 ## **See you soon!**
 
 Fine Grained News used to be published every month, and we plan to go back to our monthly cadence! :) If you have any feedback, want to share your OpenFGA story, or have a noteworthy update, please let us know on any of our [community channels](https://openfga.dev/community) or at [community@openfga.dev](mailto:community@openfga.dev).
-

--- a/blog/fine-grained-news-2025-10.md
+++ b/blog/fine-grained-news-2025-10.md
@@ -13,6 +13,8 @@ hide_table_of_contents: false
 
 Welcome to OpenFGA's Fine-Grained News, October edition!
 
+<!-- truncate -->
+
 ## 🎉 OpenFGA to CNCF Incubation!
 
 The CNCF completed the Due Diligence process to approve moving OpenFGA to the CNCF Incubation stage, and it's now [open for comments](https://github.com/cncf/toc/pull/1923). Support emojis are appreciated! 🚀 ❤️!
@@ -71,4 +73,3 @@ The OpenFGA community submitted six proposals to present at KubeCon Europe! A gr
 ## **See you soon!**
 
 Fine-Grained News is published monthly. If you have any feedback, want to share your OpenFGA story, or have a noteworthy update, please let us know on any of our [community channels](https://openfga.dev/community) or at [community@openfga.dev](mailto:community@openfga.dev).
-

--- a/blog/ignore-duplicate-writes-announcement.md
+++ b/blog/ignore-duplicate-writes-announcement.md
@@ -19,6 +19,8 @@ import {
 
 We've added two new optional parameters to the Write API endpoint to improve the experience of writing data to FGA. You can now gracefully ["ignore" duplicate writes and missing deletes](https://openfga.dev/docs/getting-started/update-tuples#05-ignoring-duplicate-or-missing-tuples).
 
+<!-- truncate -->
+
 ## The Problem
 
 When you're writing tuples to OpenFGA, it's almost inevitable that you'll try to write a relationship tuple that already exists (e.g., `user:anne` is already a `viewer` of `document:123`) or try to delete one that's already gone. In the past, OpenFGA would reject the entire Write request containing that single duplicate operation.

--- a/blog/incubation-announcement.md
+++ b/blog/incubation-announcement.md
@@ -13,6 +13,8 @@ hide_table_of_contents: false
 
 OpenFGA has been accepted as a CNCF **Incubation** project! The Cloud Native Computing Foundation (CNCF) Technical Oversight Committee (TOC) [voted to advance OpenFGA](https://github.com/cncf/toc/issues/1287#issuecomment-3458442973) from Sandbox to Incubation status, recognizing years of community work and real-world adoption. This places OpenFGA on the same maturity path as other CNCF projects like OpenTelemetry, Keycloak, Artifact Hub, and Backstage. Learn more at the CNCF joint announcement: [OpenFGA becomes a CNCF Incubating Project](https://www.cncf.io/blog/2025/11/11/openfga-becomes-a-cncf-incubating-project/).
 
+<!-- truncate -->
+
 ## Why Incubation Matters
 
 Incubation signals that OpenFGA is production-ready with a healthy, diverse contributor base and real-world adoption at scale. For organizations evaluating OpenFGA, this milestone validates the project's maturity, governance, and long-term sustainability. The CNCF due diligence process assessed our security posture, documentation, community health, and adoption metrics—all meeting the standards required for broad enterprise use.
@@ -93,5 +95,4 @@ This achievement belongs to every contributor, user, and community member who ha
 - [Star the repo](https://github.com/openfga/openfga) and follow development
 - Share your adoption story—add your organization to our [ADOPTERS.md](https://github.com/openfga/community/blob/main/ADOPTERS.md)
 - Check out the [roadmap](https://github.com/orgs/openfga/projects/1) and contribute to upcoming features
-
 

--- a/blog/kubecon-na-2023.md
+++ b/blog/kubecon-na-2023.md
@@ -12,10 +12,9 @@ hide_table_of_contents: false
 # Join the OpenFGA team at KubeCon NA 2023!
 
 As you'd expect, the OpenFGA team will be at KubeCon NA 2023 in Chicago, IL!
+<!-- truncate -->
 
 We'll have a packed agenda for the week:
-
-<!-- truncate -->
 
 - [Jonathan Whitaker](https://www.linkedin.com/in/jonathan-whitaker-5a8b2484/) and [Lucas Käldström](https://www.linkedin.com/in/luxas/) will be presenting in [Could_Native Rejects](https://cloud-native.rejekts.io/) on how to use OpenFGA to manage and extend authorization in Kubernetes. Learn more [here](https://cfp.cloud-native.rejekts.io/cloud-native-rejekts-na-chicago-2023/speaker/XB7EUR/).
 

--- a/blog/kubecon-na-2023.md
+++ b/blog/kubecon-na-2023.md
@@ -15,6 +15,8 @@ As you'd expect, the OpenFGA team will be at KubeCon NA 2023 in Chicago, IL!
 
 We'll have a packed agenda for the week:
 
+<!-- truncate -->
+
 - [Jonathan Whitaker](https://www.linkedin.com/in/jonathan-whitaker-5a8b2484/) and [Lucas Käldström](https://www.linkedin.com/in/luxas/) will be presenting in [Could_Native Rejects](https://cloud-native.rejekts.io/) on how to use OpenFGA to manage and extend authorization in Kubernetes. Learn more [here](https://cfp.cloud-native.rejekts.io/cloud-native-rejekts-na-chicago-2023/speaker/XB7EUR/).
 
 - [Maria Ines Parnisari](https://www.linkedin.com/in/miparnisari/) and [Andres Aguiar](https://www.linkedin.com/in/aaguiar/) will be presenting in [AppDeveloperCon](https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/co-located-events/appdevelopercon/) about modernizing authorization for cloud native applications using OpenFGA. Learn more [here](https://colocatedeventsna2023.sched.com/event/1Rj2j/modernizing-authorization-for-cloud-native-applications-using-openfga-andres-aguiar-maria-ines-parnisari-okta).
@@ -29,4 +31,3 @@ We'll have a packed agenda for the week:
 If you want to meet with the team outside of these events, please pick any spot that works for you in our [calendar](https://calendar.app.google/GonEwLboKvPkG8pL6).
 
 See you in Chicago!
-

--- a/blog/list-users-announcement.md
+++ b/blog/list-users-announcement.md
@@ -17,6 +17,8 @@ This API will answer the question "what users have relation X with object Y?". T
 
 You can read more about it in the [API docs](https://openfga.dev/api/service#/Relationship%20Queries/ListUsers) and the [product documentation](https://openfga.dev/docs/getting-started/perform-list-users).
 
+<!-- truncate -->
+
 ## How to use it?
 
 ListUsers is available in OpenFGA starting with [v1.5.4](https://github.com/openfga/openfga/releases/tag/v1.5.4).

--- a/blog/modular-models-announcement.md
+++ b/blog/modular-models-announcement.md
@@ -18,6 +18,8 @@ Modular models aims to improve the model authoring experience when multiple team
 
 With modular models, a single model can be separated across multiple files allow grouping of types and conditions into modules. This means that a model can be organized more easily in terms of team or organizational structure. Used in conjunction with features such as [GitHub](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners), [GitLab](https://docs.gitlab.com/ee/user/project/codeowners/) or [Gitea's](https://docs.gitea.com/usage/repository/code-owners) code owners, it should become easier to ensure the owners of a portion of your model are correctly assigned to review it.
 
+<!-- truncate -->
+
 ## How to use it?
 
 Modular models is available in the latest version of OpenFGA. To use it you need to:

--- a/blog/query-consistency-options-announcement.md
+++ b/blog/query-consistency-options-announcement.md
@@ -15,6 +15,8 @@ OpenFGA query APIs now allow specifying the desired consistency of query results
 
 The community expressed the need for flexibility in using the cache on a per-request basis. In response, starting with [OpenFGA v1.5.7](https://github.com/openfga/openfga/releases/tag/v1.5.7), all query APIs can accept a consistency parameter with the following values:
 
+<!-- truncate -->
+
 | Name                        | Description                                                                                                   |  
 |-----------------------------|---------------------------------------------------------------------------------------------------------------|
 | MINIMIZE_LATENCY (default)  | OpenFGA will try to minimize latency (e.g. by making use of the cache)  | 


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description

Adds explicit truncation markers to OpenFGA blog posts so the blog index displays a concise introduction and a Read more link for every post.
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?
Blog posts without explicit truncation markers may display too much content on the blog index. This makes the listing harder to scan and does not provide a consistent preview experience across posts.

#### How is it being solved?
An invisible <!-- truncate --> marker is placed after each post’s introductory content. Docusaurus uses this marker to determine where the preview ends without changing the complete article.


#### What changes are made to solve it?
- Added truncation markers to the 23 blog posts that did not already contain one.
- Kept the existing marker unchanged.
- Placed each marker at a natural boundary after the post introduction.
- Preserved the full content and formatting of every article.

## References
- closes https://github.com/openfga/openfga.dev/issues/1026
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved blog listing previews by defining consistent excerpt boundaries across announcements and Fine-Grained News posts.
  * Cleaned up trailing whitespace in several blog articles without changing their published content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->