### PR TITLE
feat: expose Kapa MCP server in widget

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -341,6 +341,8 @@ if (process.env.KAPA_WEBSITE_ID) {
     "data-button-hide": "true",
     "data-modal-override-open-selector": ".ask-ai-button",
     "data-modal-open-on-command-k": "true",
+    "data-mcp-enabled": "true",
+    "data-mcp-server-url": "https://openfga.mcp.kapa.ai",
     "data-modal-disclaimer": "This OpenFGA chatbot is powered by kapa.ai and uses AI to answer questions about OpenFGA based on OpenFGA's documentation, OpenFGA's GitHub, and other resources. Please do not input any sensitive or private information. Responses are for informational purposes and may be inaccurate. Please verify for accuracy. By using this chatbot, you agree to the Linux Foundation's Privacy Policy and Terms.",
     async: true,
   });


### PR DESCRIPTION
## Description

Enable MCP discovery in the Kapa website widget and configure the OpenFGA MCP server URL as `https://openfga.mcp.kapa.ai`.

https://github.com/user-attachments/assets/9af68267-1a7d-48da-b2f8-dfce646c0bc4


**Preview note:** the Kapa widget and **Use MCP** menu render correctly, but submitting chat questions from the temporary non-production preview fails because Kapa’s chat endpoint does not allow that preview origin via CORS. This should not affect production on `openfga.dev`; enabling chat in the preview would require adding the exact preview origin to the Kapa project’s allowed domains.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled MCP integration for the Kapa.ai widget.
  * Connected the widget to the OpenFGA MCP endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->