### PR TITLE
docs: organize API reference navigation

### DIFF
--- a/mintlify-native/docs.json
+++ b/mintlify-native/docs.json
@@ -270,7 +270,64 @@
       {
         "tab": "API",
         "icon": "square-terminal",
-        "openapi": "/api/openfga-openapi3.json"
+        "openapi": "/api/openfga-openapi3.json",
+        "groups": [
+          {
+            "group": "Stores",
+            "pages": [
+              "GET /stores",
+              "POST /stores",
+              "GET /stores/{store_id}",
+              "DELETE /stores/{store_id}"
+            ]
+          },
+          {
+            "group": "Authorization Models",
+            "pages": [
+              "GET /stores/{store_id}/authorization-models",
+              "POST /stores/{store_id}/authorization-models",
+              "GET /stores/{store_id}/authorization-models/{id}"
+            ]
+          },
+          {
+            "group": "Relationship Tuples",
+            "pages": [
+              "GET /stores/{store_id}/changes",
+              "POST /stores/{store_id}/read",
+              "POST /stores/{store_id}/write"
+            ]
+          },
+          {
+            "group": "Relationship Queries",
+            "pages": [
+              "POST /stores/{store_id}/batch-check",
+              "POST /stores/{store_id}/check",
+              "POST /stores/{store_id}/expand",
+              "POST /stores/{store_id}/list-objects",
+              "POST /stores/{store_id}/list-users",
+              "POST /stores/{store_id}/streamed-list-objects"
+            ]
+          },
+          {
+            "group": "Assertions",
+            "pages": [
+              "GET /stores/{store_id}/assertions/{authorization_model_id}",
+              "PUT /stores/{store_id}/assertions/{authorization_model_id}"
+            ]
+          },
+          {
+            "group": "AuthZenService",
+            "tag": "Experimental",
+            "pages": [
+              "GET /.well-known/authzen-configuration/{store_id}",
+              "POST /stores/{store_id}/access/v1/evaluation",
+              "POST /stores/{store_id}/access/v1/evaluations",
+              "POST /stores/{store_id}/access/v1/search/action",
+              "POST /stores/{store_id}/access/v1/search/resource",
+              "POST /stores/{store_id}/access/v1/search/subject"
+            ]
+          }
+        ]
       },
       {
         "tab": "Blog",

--- a/mintlify-native/scripts/validate-api-navigation.mjs
+++ b/mintlify-native/scripts/validate-api-navigation.mjs
@@ -1,0 +1,103 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const mintlifyDirectory = join(dirname(fileURLToPath(import.meta.url)), "..");
+const docs = JSON.parse(readFileSync(join(mintlifyDirectory, "docs.json"), "utf8"));
+
+const apiTab = docs.navigation?.tabs?.find(({ tab }) => tab === "API");
+if (!apiTab) {
+  throw new Error('docs.json must contain an "API" navigation tab');
+}
+
+if (typeof apiTab.openapi !== "string") {
+  throw new Error('The "API" tab must define one OpenAPI specification');
+}
+
+const openapiPath = join(mintlifyDirectory, apiTab.openapi.replace(/^\/+/, ""));
+const openapi = JSON.parse(readFileSync(openapiPath, "utf8"));
+const httpMethods = new Set([
+  "get",
+  "post",
+  "put",
+  "patch",
+  "delete",
+  "options",
+  "head",
+  "trace",
+]);
+const expectedGroups = [
+  "Stores",
+  "Authorization Models",
+  "Relationship Tuples",
+  "Relationship Queries",
+  "Assertions",
+  "AuthZenService",
+];
+
+const groups = apiTab.groups ?? [];
+const groupNames = groups.map(({ group }) => group);
+if (JSON.stringify(groupNames) !== JSON.stringify(expectedGroups)) {
+  throw new Error(
+    `API groups must be ordered as: ${expectedGroups.join(", ")}; found: ${groupNames.join(", ")}`,
+  );
+}
+
+const authZenGroup = groups.at(-1);
+if (authZenGroup.tag !== "Experimental") {
+  throw new Error('The AuthZenService group must have the tag "Experimental"');
+}
+
+const operations = new Map();
+for (const [path, pathItem] of Object.entries(openapi.paths ?? {})) {
+  for (const [method, operation] of Object.entries(pathItem)) {
+    if (!httpMethods.has(method)) {
+      continue;
+    }
+
+    const reference = `${method.toUpperCase()} ${path}`;
+    if (!Array.isArray(operation.tags) || operation.tags.length !== 1) {
+      throw new Error(`${reference} must have exactly one canonical OpenAPI tag`);
+    }
+    operations.set(reference, operation.tags[0]);
+  }
+}
+
+const navigationReferences = [];
+for (const { group, pages = [] } of groups) {
+  for (const reference of pages) {
+    if (typeof reference !== "string" || !/^[A-Z]+ \//.test(reference)) {
+      throw new Error(`API group "${group}" contains an invalid operation reference`);
+    }
+    navigationReferences.push(reference);
+
+    const canonicalTag = operations.get(reference);
+    if (!canonicalTag) {
+      throw new Error(`${reference} does not match an OpenAPI operation`);
+    }
+    if (canonicalTag !== group) {
+      throw new Error(
+        `${reference} is in "${group}" but its canonical OpenAPI tag is "${canonicalTag}"`,
+      );
+    }
+  }
+}
+
+const duplicates = navigationReferences.filter(
+  (reference, index) => navigationReferences.indexOf(reference) !== index,
+);
+if (duplicates.length > 0) {
+  throw new Error(`Duplicate API operations in navigation: ${[...new Set(duplicates)].join(", ")}`);
+}
+
+const missing = [...operations.keys()].filter(
+  (reference) => !navigationReferences.includes(reference),
+);
+if (missing.length > 0) {
+  throw new Error(`OpenAPI operations missing from navigation: ${missing.join(", ")}`);
+}
+
+const counts = groups.map(
+  ({ group, pages = [] }) => `${group}: ${pages.length}`,
+);
+console.log(`Validated ${navigationReferences.length} API operations (${counts.join(", ")})`);

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "docusaurus start --port=${PORT:-3000}",
     "docusaurus": "docusaurus",
     "start": "npm run serve --port=${PORT:-3000}",
+    "prebuild": "npm run validate:mintlify-api-navigation",
     "build": "npm run build:config-page; npm run build:llms-txt; npm run build:docusaurus",
     "build:docusaurus": "docusaurus build",
     "build:config-page": "node scripts/update-config-page.mjs",
@@ -23,7 +24,8 @@
     "lint": "eslint . --ext .ts  --ext .tsx",
     "lint:fix": "npm run lint -- --fix",
     "format:check": "prettier --check src/**",
-    "format:fix": "prettier --write src/**"
+    "format:fix": "prettier --write src/**",
+    "validate:mintlify-api-navigation": "node mintlify-native/scripts/validate-api-navigation.mjs"
   },
   "dependencies": {
     "@docusaurus/core": "3.10.1",


### PR DESCRIPTION
## Summary
- Define six explicit API-reference navigation groups in the existing documentation preview.
- Preserve all 24 OpenAPI operations exactly once and order groups to match the current API documentation experience.
- Mark the AuthZen API group as experimental without changing canonical OpenAPI tags.

## Navigation order
1. Stores
2. Authorization Models
3. Relationship Tuples
4. Relationship Queries
5. Assertions
6. AuthZenService

## Validation
- Dependency-free navigation validator confirms group order, operation existence, canonical-tag alignment, and no missing or duplicate operations.
- Documentation build validation passes.
- Local rendered sidebar contains all 24 endpoints with counts `4 / 3 / 3 / 6 / 2 / 6` in the expected order.
- All generated endpoint pages return HTTP 200.

## Scope
This change configures documentation navigation only. It does not modify the canonical OpenAPI specification or API behavior.